### PR TITLE
Propagate span

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.4.62"
+version = "0.4.63b0"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.4.63b0"
+version = "0.4.63"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.4.63"
+version = "0.4.64"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/__init__.py
+++ b/src/lmnr/__init__.py
@@ -10,6 +10,7 @@ from .sdk.types import (
     TracingLevel,
 )
 from .sdk.decorators import observe
+from .sdk.types import LaminarSpanContext
 from .openllmetry_sdk import Instruments
 from .openllmetry_sdk.tracing.attributes import Attributes
 from opentelemetry.trace import use_span

--- a/src/lmnr/openllmetry_sdk/__init__.py
+++ b/src/lmnr/openllmetry_sdk/__init__.py
@@ -76,3 +76,7 @@ class Traceloop:
             project_api_key=project_api_key,
             max_export_batch_size=max_export_batch_size,
         )
+
+    @staticmethod
+    def flush():
+        Traceloop.__tracer_wrapper.flush()

--- a/src/lmnr/openllmetry_sdk/__init__.py
+++ b/src/lmnr/openllmetry_sdk/__init__.py
@@ -79,4 +79,5 @@ class Traceloop:
 
     @staticmethod
     def flush():
-        Traceloop.__tracer_wrapper.flush()
+        if Traceloop.__tracer_wrapper:
+            Traceloop.__tracer_wrapper.flush()

--- a/src/lmnr/openllmetry_sdk/tracing/tracing.py
+++ b/src/lmnr/openllmetry_sdk/tracing/tracing.py
@@ -38,7 +38,7 @@ from opentelemetry.sdk.trace.export import (
     SimpleSpanProcessor,
     BatchSpanProcessor,
 )
-from opentelemetry.trace import get_tracer_provider, ProxyTracerProvider
+from opentelemetry.sdk.trace import SpanLimits
 
 from typing import Dict, Optional, Set
 
@@ -68,6 +68,8 @@ EXCLUDED_URLS = """
     googleapis.com,
     githubusercontent.com,
     openaipublic.blob.core.windows.net"""
+
+MAX_EVENTS_OR_ATTRIBUTES_PER_SPAN = 5000
 
 
 class TracerWrapper(object):
@@ -291,22 +293,21 @@ def init_spans_exporter(api_endpoint: str, headers: Dict[str, str]) -> SpanExpor
         )
 
 
+# TODO: check if it's safer to use the default tracer provider obtained from
+# get_tracer_provider()
 def init_tracer_provider(resource: Resource) -> TracerProvider:
-    provider: TracerProvider = None
-    default_provider: TracerProvider = get_tracer_provider()
+    tracer_provider = TracerProvider(
+        resource=resource,
+        span_limits=SpanLimits(
+            # this defaults to 128, which causes us to drop messages
+            max_attributes=MAX_EVENTS_OR_ATTRIBUTES_PER_SPAN,
+            max_span_attributes=MAX_EVENTS_OR_ATTRIBUTES_PER_SPAN,
+            max_event_attributes=MAX_EVENTS_OR_ATTRIBUTES_PER_SPAN,
+            max_events=MAX_EVENTS_OR_ATTRIBUTES_PER_SPAN,
+        ),
+    )
 
-    if isinstance(default_provider, ProxyTracerProvider):
-        provider = TracerProvider(resource=resource)
-        trace.set_tracer_provider(provider)
-    elif not hasattr(default_provider, "add_span_processor"):
-        module_logger.error(
-            "Cannot add span processor to the default provider since it doesn't support it"
-        )
-        return
-    else:
-        provider = default_provider
-
-    return provider
+    return tracer_provider
 
 
 def init_instrumentations(

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -13,7 +13,6 @@ from lmnr.openllmetry_sdk.config import MAX_MANUAL_SPAN_PAYLOAD_SIZE
 from lmnr.openllmetry_sdk.decorators.base import json_dumps
 from opentelemetry import context as context_api, trace
 from opentelemetry.context import attach, detach
-from lmnr.version import SDK_VERSION, get_latest_pypi_version, is_latest_version
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
     OTLPSpanExporter,
     Compression,
@@ -55,6 +54,7 @@ from .types import (
     InitEvaluationResponse,
     EvaluationResultDatapoint,
     GetDatapointsResponse,
+    LaminarSpanContext,
     PipelineRunError,
     PipelineRunResponse,
     NodeInput,
@@ -347,8 +347,10 @@ class Laminar:
             Literal["DEFAULT"], Literal["LLM"], Literal["TOOL"]
         ] = "DEFAULT",
         context: Optional[Context] = None,
-        trace_id: Optional[uuid.UUID] = None,
         labels: Optional[dict[str, str]] = None,
+        parent_span_context: Optional[LaminarSpanContext] = None,
+        # deprecated, use parent_span_context instead
+        trace_id: Optional[uuid.UUID] = None,
     ):
         """Start a new span as the current span. Useful for manual
         instrumentation. If `span_type` is set to `"LLM"`, you should report
@@ -371,11 +373,13 @@ class Laminar:
                 and response attributes manually. Defaults to "DEFAULT".
             context (Optional[Context], optional): raw OpenTelemetry context\
                 to attach the span to. Defaults to None.
-            trace_id (Optional[uuid.UUID], optional): [EXPERIMENTAL] override\
-                the trace id for the span. If not provided, use the current\
-                trace id. Defaults to None.
+            parent_span_context (Optional[LaminarSpanContext], optional): parent\
+                span context to use for the span. Defaults to None.
             labels (Optional[dict[str, str]], optional): labels to set for the\
                 span. Defaults to None.
+            trace_id (Optional[uuid.UUID], optional): [Deprecated] override\
+                the trace id for the span. If not provided, use the current\
+                trace id. Defaults to None.
         """
 
         if not cls.is_initialized():
@@ -385,21 +389,30 @@ class Laminar:
         with get_tracer() as tracer:
             ctx = context or context_api.get_current()
             if trace_id is not None:
-                if isinstance(trace_id, uuid.UUID):
-                    span_context = trace.SpanContext(
-                        trace_id=int(trace_id),
-                        span_id=random.getrandbits(64),
-                        is_remote=False,
-                        trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
-                    )
-                    ctx = trace.set_span_in_context(
-                        trace.NonRecordingSpan(span_context), ctx
-                    )
-                else:
-                    cls.__logger.warning(
-                        "trace_id provided to `Laminar.start_as_current_span`"
-                        " is not a valid UUID"
-                    )
+                cls.__logger.warning(
+                    "trace_id provided to `Laminar.start_as_current_span`"
+                    " is deprecated, use parent_span_context instead"
+                )
+            if parent_span_context is not None:
+                span_context = trace.SpanContext(
+                    trace_id=parent_span_context.trace_id.int,
+                    span_id=parent_span_context.span_id.int,
+                    is_remote=parent_span_context.is_remote,
+                    trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+                )
+                ctx = trace.set_span_in_context(
+                    trace.NonRecordingSpan(span_context), ctx
+                )
+            elif trace_id is not None and isinstance(trace_id, uuid.UUID):
+                span_context = trace.SpanContext(
+                    trace_id=int(trace_id),
+                    span_id=random.getrandbits(64),
+                    is_remote=False,
+                    trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+                )
+                ctx = trace.set_span_in_context(
+                    trace.NonRecordingSpan(span_context), ctx
+                )
             ctx_token = attach(ctx)
             label_props = {}
             try:
@@ -487,8 +500,10 @@ class Laminar:
             Literal["DEFAULT"], Literal["LLM"], Literal["TOOL"]
         ] = "DEFAULT",
         context: Optional[Context] = None,
-        trace_id: Optional[uuid.UUID] = None,
+        parent_span_context: Optional[LaminarSpanContext] = None,
         labels: Optional[dict[str, str]] = None,
+        # deprecated, use parent_span_context instead
+        trace_id: Optional[uuid.UUID] = None,
     ):
         """Start a new span. Useful for manual instrumentation.
         If `span_type` is set to `"LLM"`, you should report usage and response
@@ -530,30 +545,41 @@ class Laminar:
                 and response attributes manually. Defaults to "DEFAULT".
             context (Optional[Context], optional): raw OpenTelemetry context\
                 to attach the span to. Defaults to None.
-            trace_id (Optional[uuid.UUID], optional): [EXPERIMENTAL] override\
-                the trace id for the span. If not provided, use the current\
-                trace id. Defaults to None.
+            parent_span_context (Optional[LaminarSpanContext], optional): parent\
+                span context to use for the span. Defaults to None.
             labels (Optional[dict[str, str]], optional): labels to set for the\
                 span. Defaults to None.
+            trace_id (Optional[uuid.UUID], optional): Deprecated, use\
+                `parent_span_context` instead. If provided, it will be used to\
+                set the trace id for the span.
         """
         with get_tracer() as tracer:
             ctx = context or context_api.get_current()
             if trace_id is not None:
-                if isinstance(trace_id, uuid.UUID):
-                    span_context = trace.SpanContext(
-                        trace_id=int(trace_id),
-                        span_id=random.getrandbits(64),
-                        is_remote=False,
-                        trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
-                    )
-                    ctx = trace.set_span_in_context(
-                        trace.NonRecordingSpan(span_context), ctx
-                    )
-                else:
-                    cls.__logger.warning(
-                        "trace_id provided to `Laminar.start_span`"
-                        " is not a valid UUID"
-                    )
+                cls.__logger.warning(
+                    "trace_id provided to `Laminar.start_span`"
+                    " is deprecated, use parent_span_context instead"
+                )
+            if parent_span_context is not None:
+                span_context = trace.SpanContext(
+                    trace_id=parent_span_context.trace_id.int,
+                    span_id=parent_span_context.span_id.int,
+                    is_remote=parent_span_context.is_remote,
+                    trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+                )
+                ctx = trace.set_span_in_context(
+                    trace.NonRecordingSpan(span_context), ctx
+                )
+            elif trace_id is not None and isinstance(trace_id, uuid.UUID):
+                span_context = trace.SpanContext(
+                    trace_id=int(trace_id),
+                    span_id=random.getrandbits(64),
+                    is_remote=False,
+                    trace_flags=trace.TraceFlags(trace.TraceFlags.SAMPLED),
+                )
+                ctx = trace.set_span_in_context(
+                    trace.NonRecordingSpan(span_context), ctx
+                )
             label_props = {}
             try:
                 if labels:
@@ -687,6 +713,51 @@ class Laminar:
                 span.set_attribute(key.value, json_dumps(value))
             else:
                 span.set_attribute(key.value, value)
+
+    @classmethod
+    def get_laminar_span_context(
+        cls, span: Optional[trace.Span] = None
+    ) -> Optional[LaminarSpanContext]:
+        """Get the laminar span context for a given span.
+        If no span is provided, the current active span will be used.
+        """
+        span = span or trace.get_current_span()
+        if span == trace.INVALID_SPAN:
+            return None
+        return LaminarSpanContext(
+            trace_id=uuid.UUID(int=span.get_span_context().trace_id),
+            span_id=uuid.UUID(int=span.get_span_context().span_id),
+            is_remote=span.get_span_context().is_remote,
+        )
+
+    @classmethod
+    def get_laminar_span_context_dict(
+        cls, span: Optional[trace.Span] = None
+    ) -> Optional[dict]:
+        span_context = cls.get_laminar_span_context(span)
+        if span_context is None:
+            return None
+        return span_context.to_dict()
+
+    @classmethod
+    def get_laminar_span_context_str(
+        cls, span: Optional[trace.Span] = None
+    ) -> Optional[str]:
+        span_context = cls.get_laminar_span_context(span)
+        if span_context is None:
+            return None
+        return json.dumps(span_context.to_dict())
+
+    @classmethod
+    def deserialize_laminar_span_context(
+        cls, span_context: Union[dict, str]
+    ) -> LaminarSpanContext:
+        if isinstance(span_context, dict):
+            return LaminarSpanContext.from_dict(span_context)
+        elif isinstance(span_context, str):
+            return LaminarSpanContext.from_dict(json.loads(span_context))
+        else:
+            raise ValueError("Invalid span context")
 
     @classmethod
     def set_session(

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -797,6 +797,10 @@ class Laminar:
         return LaminarSpanContext.deserialize(span_context)
 
     @classmethod
+    def shutdown(cls):
+        Traceloop.flush()
+
+    @classmethod
     def set_session(
         cls,
         session_id: Optional[str] = None,

--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -213,6 +213,18 @@ class TracingLevel(Enum):
 
 
 class LaminarSpanContext(pydantic.BaseModel):
+    """
+    A span context that can be used to continue a trace across services. This
+    is a slightly modified version of the OpenTelemetry span context. For
+    usage examples, see `Laminar.get_laminar_span_context_dict`,
+    `Laminar.get_laminar_span_context_str`, `Laminar.get_span_context`, and
+    `Laminar.deserialize_laminar_span_context`.
+
+    The difference between this and the OpenTelemetry span context is that
+    the `trace_id` and `span_id` are stored as UUIDs instead of integers for
+    easier debugging, and the separate trace flags are not currently stored.
+    """
+
     trace_id: uuid.UUID
     span_id: uuid.UUID
     is_remote: bool = pydantic.Field(default=False)

--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -284,11 +284,9 @@ class LaminarSpanContext(pydantic.BaseModel):
                     trace_flags=TraceFlags(TraceFlags.SAMPLED),
                 )
             except Exception:
-                raise ValueError(
-                    "Invalid span_context provided to `Laminar.start_span`"
-                )
+                raise ValueError("Invalid span_context provided")
         else:
-            raise ValueError("Invalid span_context provided to `Laminar.start_span`")
+            raise ValueError("Invalid span_context provided")
 
     @classmethod
     def deserialize(cls, data: Union[dict[str, Any], str]) -> "LaminarSpanContext":
@@ -297,4 +295,4 @@ class LaminarSpanContext(pydantic.BaseModel):
         elif isinstance(data, str):
             return cls.from_dict(json.loads(data))
         else:
-            raise ValueError("Invalid span_context provided to `Laminar.start_span`")
+            raise ValueError("Invalid span_context provided")

--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -210,3 +210,25 @@ class TracingLevel(Enum):
     OFF = 0
     META_ONLY = 1
     ALL = 2
+
+
+class LaminarSpanContext(pydantic.BaseModel):
+    trace_id: uuid.UUID
+    span_id: uuid.UUID
+    is_remote: bool = pydantic.Field(default=False)
+
+    # uuid is not serializable by default, so we need to convert it to a string
+    def to_dict(self):
+        return {
+            "traceId": str(self.trace_id),
+            "spanId": str(self.span_id),
+            "isRemote": self.is_remote,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "LaminarSpanContext":
+        return cls(
+            trace_id=uuid.UUID(data["traceId"]),
+            span_id=uuid.UUID(data["spanId"]),
+            is_remote=data["isRemote"],
+        )

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import requests
 from packaging import version
 
 
-SDK_VERSION = "0.4.62"
+SDK_VERSION = "0.4.63b0"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import requests
 from packaging import version
 
 
-SDK_VERSION = "0.4.63b0"
+SDK_VERSION = "0.4.63"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import requests
 from packaging import version
 
 
-SDK_VERSION = "0.4.63"
+SDK_VERSION = "0.4.64"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -391,18 +391,15 @@ def test_1k_attributes_fails_with_default_tracer_provider(
     from unittest.mock import patch
     import os
 
-    # reset to default just in case this test is run with env var set
-    if os.environ.get("OTEL_ATTRIBUTE_COUNT_LIMIT"):
-        os.environ["OTEL_ATTRIBUTE_COUNT_LIMIT"] = "128"
-
-    default_tracer_provider = get_tracer_provider()
-    with patch(
-        "lmnr.openllmetry_sdk.tracing.tracing.init_tracer_provider",
-        return_value=default_tracer_provider,
-    ):
-        with Laminar.start_as_current_span("test") as span:
-            for i in range(1000):
-                span.set_attribute(f"foo_{i}", f"bar{i}")
+    with patch.dict(os.environ, {"OTEL_ATTRIBUTE_COUNT_LIMIT": "128"}, clear=True):
+        default_tracer_provider = get_tracer_provider()
+        with patch(
+            "lmnr.openllmetry_sdk.tracing.tracing.init_tracer_provider",
+            return_value=default_tracer_provider,
+        ):
+            with Laminar.start_as_current_span("test") as span:
+                for i in range(1000):
+                    span.set_attribute(f"foo_{i}", f"bar{i}")
 
     spans = exporter.get_finished_spans()
     assert len(spans) == 1


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhances Laminar SDK tracing by introducing `LaminarSpanContext`, deprecating `trace_id`, and adding tests for improved span context management.
> 
>   - **Behavior**:
>     - Introduces `LaminarSpanContext` in `types.py` for span context management, replacing `trace_id` with `parent_span_context` in `start_as_current_span()` and `start_span()` in `laminar.py`.
>     - Adds `flush()` method to `Traceloop` in `openllmetry_sdk/__init__.py` to flush tracer data.
>     - Sets `MAX_EVENTS_OR_ATTRIBUTES_PER_SPAN` to 5000 in `tracing.py` to handle more attributes per span.
>   - **Deprecations**:
>     - Deprecates `trace_id` in favor of `parent_span_context` in `start_as_current_span()` and `start_span()` in `laminar.py`.
>   - **Tests**:
>     - Adds tests in `test_tracing.py` for `LaminarSpanContext` and its integration with spans.
>     - Tests for handling 1000 attributes per span and fallback mechanisms for span context.
>   - **Misc**:
>     - Updates version to `0.4.64` in `pyproject.toml` and `version.py`.
>     - Minor import adjustments in `__init__.py` files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for e6b289bcf4fa41e77114fbcf089f3644007e740f. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->