### PR TITLE
v0.4.66: fix the naming bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.4.65"
+version = "0.4.66"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/sdk/browser/browser_use_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_otel.py
@@ -35,7 +35,7 @@ WRAPPED_METHODS = [
         "object": "Controller",
         "method": "act",
         "span_name": "controller.act",
-        "ignore_input": False,
+        "ignore_input": True,
         "ignore_output": False,
         "span_type": "DEFAULT",
     },
@@ -58,13 +58,12 @@ async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
     }
     if to_wrap.get("method") == "execute_action":
         span_name = args[0] if len(args) > 0 else kwargs.get("action_name", "action")
-    elif to_wrap.get("method") == "execute_action":
-        attributes["lmnr.span.input"] = {
-            "action": span_name,
-            "params": json_dumps(
-                args[1] if len(args) > 1 else kwargs.get("params", {})
-            ),
-        }
+        attributes["lmnr.span.input"] = json_dumps(
+            {
+                "action": span_name,
+                "params": args[1] if len(args) > 1 else kwargs.get("params", {}),
+            }
+        )
     else:
         if not to_wrap.get("ignore_input"):
             attributes["lmnr.span.input"] = json_dumps(

--- a/src/lmnr/sdk/browser/playwright_otel.py
+++ b/src/lmnr/sdk/browser/playwright_otel.py
@@ -259,7 +259,7 @@ async def _wrap_async(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         return page
 
 
-class BrowserUseInstrumentor(BaseInstrumentor):
+class PlaywrightInstrumentor(BaseInstrumentor):
     def __init__(self):
         super().__init__()
 

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import requests
 from packaging import version
 
 
-SDK_VERSION = "0.4.65"
+SDK_VERSION = "0.4.66"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fix naming bug, update version to 0.4.66, and rename `BrowserUseInstrumentor` to `PlaywrightInstrumentor`.
> 
>   - **Version Update**:
>     - Update version to `0.4.66` in `pyproject.toml` and `version.py`.
>   - **Behavior**:
>     - Change `ignore_input` to `True` for `Controller.act` in `browser_use_otel.py`.
>   - **Renames**:
>     - Rename `BrowserUseInstrumentor` to `PlaywrightInstrumentor` in `playwright_otel.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 00956bc9e75ee7e950d04b31841566eb886f3561. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->