### PR TITLE
v0.5.1 add listener on 'page' in context, add screenshots, fix Laminar.flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,6 @@ async for chunk in client.agent.run(
 ):
     if chunk.chunkType == 'step':
         print(chunk.summary)
-    else if chunk.chunkType == 'finalOutput':
+    elif chunk.chunkType == 'finalOutput':
         print(chunk.content.result.content)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/openllmetry_sdk/__init__.py
+++ b/src/lmnr/openllmetry_sdk/__init__.py
@@ -67,6 +67,5 @@ class TracerManager:
         )
 
     @staticmethod
-    def flush():
-        if getattr(TracerManager, "__tracer_wrapper", None):
-            TracerManager.__tracer_wrapper.flush()
+    def flush() -> bool:
+        return TracerManager.__tracer_wrapper.flush()

--- a/src/lmnr/openllmetry_sdk/tracing/tracing.py
+++ b/src/lmnr/openllmetry_sdk/tracing/tracing.py
@@ -236,8 +236,13 @@ class TracerWrapper(object):
         cls.__span_id_to_path = {}
         cls.__span_id_lists = {}
 
-    def flush(self):
+    def shutdown(self):
         self.__spans_processor.force_flush()
+        self.__spans_processor.shutdown()
+        self.__tracer_provider.shutdown()
+
+    def flush(self):
+        return self.__spans_processor.force_flush()
 
     def get_tracer(self):
         return self.__tracer_provider.get_tracer(TRACER_NAME)

--- a/src/lmnr/sdk/browser/pw_utils.py
+++ b/src/lmnr/sdk/browser/pw_utils.py
@@ -36,7 +36,7 @@ INJECT_PLACEHOLDER = """
 () => {
     const BATCH_SIZE = 1000;  // Maximum events to store in memory
     
-    window.lmnrRrwebEventsBatch = [];
+    window.lmnrRrwebEventsBatch = new Set();
     
     // Utility function to compress individual event data
     async function compressEventData(data) {
@@ -50,8 +50,8 @@ INJECT_PLACEHOLDER = """
     
     window.lmnrGetAndClearEvents = () => {
         const events = window.lmnrRrwebEventsBatch;
-        window.lmnrRrwebEventsBatch = [];
-        return events;
+        window.lmnrRrwebEventsBatch = new Set();
+        return Array.from(events);
     };
 
     // Add heartbeat events
@@ -62,11 +62,11 @@ INJECT_PLACEHOLDER = """
             timestamp: Date.now()
         };
         
-        window.lmnrRrwebEventsBatch.push(heartbeat);
+        window.lmnrRrwebEventsBatch.add(heartbeat);
         
         // Prevent memory issues by limiting batch size
-        if (window.lmnrRrwebEventsBatch.length > BATCH_SIZE) {
-            window.lmnrRrwebEventsBatch = window.lmnrRrwebEventsBatch.slice(-BATCH_SIZE);
+        if (window.lmnrRrwebEventsBatch.size > BATCH_SIZE) {
+            window.lmnrRrwebEventsBatch = new Set(Array.from(window.lmnrRrwebEventsBatch).slice(-BATCH_SIZE));
         }
     }, 1000);
 
@@ -81,7 +81,7 @@ INJECT_PLACEHOLDER = """
                 ...event,
                 data: await compressEventData(event.data)
             };
-            window.lmnrRrwebEventsBatch.push(compressedEvent);
+            window.lmnrRrwebEventsBatch.add(compressedEvent);
         }
     });
 }

--- a/src/lmnr/sdk/client/asynchronous/resources/agent.py
+++ b/src/lmnr/sdk/client/asynchronous/resources/agent.py
@@ -186,7 +186,6 @@ class AsyncAgent(BaseAsyncResource):
                 line = line[6:]
                 if line:
                     chunk = RunAgentResponseChunk.model_validate_json(line)
-                    print(line)
                     yield chunk.root
 
     async def __run_non_streaming(self, request: RunAgentRequest) -> AgentOutput:

--- a/src/lmnr/sdk/client/asynchronous/resources/agent.py
+++ b/src/lmnr/sdk/client/asynchronous/resources/agent.py
@@ -35,6 +35,7 @@ class AsyncAgent(BaseAsyncResource):
         model_provider: Optional[ModelProvider] = None,
         model: Optional[str] = None,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> AsyncIterator[RunAgentResponseChunk]:
         """Run Laminar index agent in streaming mode.
 
@@ -45,7 +46,7 @@ class AsyncAgent(BaseAsyncResource):
             model_provider (Optional[ModelProvider], optional): LLM model provider
             model (Optional[str], optional): LLM model name
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
-
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
         Returns:
             AsyncIterator[RunAgentResponseChunk]: a generator of response chunks
         """
@@ -59,6 +60,7 @@ class AsyncAgent(BaseAsyncResource):
         model_provider: Optional[ModelProvider] = None,
         model: Optional[str] = None,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> AgentOutput:
         """Run Laminar index agent.
 
@@ -68,7 +70,7 @@ class AsyncAgent(BaseAsyncResource):
             model_provider (Optional[ModelProvider], optional): LLM model provider
             model (Optional[str], optional): LLM model name
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
-
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
         Returns:
             AgentOutput: agent output
         """
@@ -83,6 +85,7 @@ class AsyncAgent(BaseAsyncResource):
         model: Optional[str] = None,
         stream: Literal[False] = False,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> AgentOutput:
         """Run Laminar index agent.
 
@@ -93,7 +96,7 @@ class AsyncAgent(BaseAsyncResource):
             model (Optional[str], optional): LLM model name
             stream (Literal[False], optional): whether to stream the agent's response
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
-
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
         Returns:
             AgentOutput: agent output
         """
@@ -107,6 +110,7 @@ class AsyncAgent(BaseAsyncResource):
         model: Optional[str] = None,
         stream: bool = False,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> Union[AgentOutput, Awaitable[AsyncIterator[RunAgentResponseChunk]]]:
         """Run Laminar index agent.
 
@@ -117,7 +121,7 @@ class AsyncAgent(BaseAsyncResource):
             model (Optional[str], optional): LLM model name
             stream (bool, optional): whether to stream the agent's response
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
-
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
         Returns:
             Union[AgentOutput, AsyncIterator[RunAgentResponseChunk]]: agent output or a generator of response chunks
         """
@@ -146,6 +150,7 @@ class AsyncAgent(BaseAsyncResource):
             # https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-nlb-tcp-configurable-idle-timeout/
             stream=True,
             enable_thinking=enable_thinking,
+            return_screenshots=return_screenshots,
         )
 
         # For streaming case, use a generator function
@@ -181,6 +186,7 @@ class AsyncAgent(BaseAsyncResource):
                 line = line[6:]
                 if line:
                     chunk = RunAgentResponseChunk.model_validate_json(line)
+                    print(line)
                     yield chunk.root
 
     async def __run_non_streaming(self, request: RunAgentRequest) -> AgentOutput:

--- a/src/lmnr/sdk/client/synchronous/resources/agent.py
+++ b/src/lmnr/sdk/client/synchronous/resources/agent.py
@@ -27,6 +27,7 @@ class Agent(BaseResource):
         model_provider: Optional[ModelProvider] = None,
         model: Optional[str] = None,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> Generator[RunAgentResponseChunk, None, None]:
         """Run Laminar index agent in streaming mode.
 
@@ -37,7 +38,7 @@ class Agent(BaseResource):
             model_provider (Optional[ModelProvider], optional): LLM model provider
             model (Optional[str], optional): LLM model name
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
-
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
         Returns:
             Generator[RunAgentResponseChunk, None, None]: a generator of response chunks
         """
@@ -51,6 +52,7 @@ class Agent(BaseResource):
         model_provider: Optional[ModelProvider] = None,
         model: Optional[str] = None,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> AgentOutput:
         """Run Laminar index agent.
 
@@ -60,6 +62,7 @@ class Agent(BaseResource):
             model_provider (Optional[ModelProvider], optional): LLM model provider
             model (Optional[str], optional): LLM model name
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
 
         Returns:
             AgentOutput: agent output
@@ -75,6 +78,7 @@ class Agent(BaseResource):
         model: Optional[str] = None,
         stream: Literal[False] = False,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> AgentOutput:
         """Run Laminar index agent.
 
@@ -85,7 +89,7 @@ class Agent(BaseResource):
             model (Optional[str], optional): LLM model name
             stream (Literal[False], optional): whether to stream the agent's response
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
-            cdp_url (Optional[str], optional): CDP URL to connect to an existing browser session.
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
 
         Returns:
             AgentOutput: agent output
@@ -100,6 +104,7 @@ class Agent(BaseResource):
         model: Optional[str] = None,
         stream: bool = False,
         enable_thinking: bool = True,
+        return_screenshots: bool = False,
     ) -> Union[AgentOutput, Generator[RunAgentResponseChunk, None, None]]:
         """Run Laminar index agent.
 
@@ -110,7 +115,7 @@ class Agent(BaseResource):
             model (Optional[str], optional): LLM model name
             stream (bool, optional): whether to stream the agent's response
             enable_thinking (bool, optional): whether to enable thinking on the underlying LLM. Default to True.
-            cdp_url (Optional[str], optional): CDP URL to connect to an existing browser session.
+            return_screenshots (bool, optional): whether to return screenshots of the agent's states at every step. Default to False.
 
         Returns:
             Union[AgentOutput, Generator[RunAgentResponseChunk, None, None]]: agent output or a generator of response chunks
@@ -140,6 +145,7 @@ class Agent(BaseResource):
             # https://aws.amazon.com/blogs/networking-and-content-delivery/introducing-nlb-tcp-configurable-idle-timeout/
             stream=True,
             enable_thinking=enable_thinking,
+            return_screenshots=return_screenshots,
         )
 
         # For streaming case, use a generator function

--- a/src/lmnr/sdk/evaluations.py
+++ b/src/lmnr/sdk/evaluations.py
@@ -406,8 +406,8 @@ def evaluate(
 
     If there is no event loop, creates it and runs the evaluation until
     completion.
-    If there is an event loop, schedules the evaluation as a task in the
-    event loop and returns an awaitable handle.
+    If there is an event loop, returns an awaitable handle immediately. IMPORTANT:
+    You must await the call to `evaluate`.
 
     Parameters:
         data (Union[list[EvaluationDatapoint|dict]], EvaluationDataset]):\

--- a/src/lmnr/sdk/evaluations.py
+++ b/src/lmnr/sdk/evaluations.py
@@ -35,15 +35,13 @@ MAX_EXPORT_BATCH_SIZE = 64
 def get_evaluation_url(
     project_id: str, evaluation_id: str, base_url: Optional[str] = None
 ):
-    if not base_url:
+    if not base_url or base_url == "https://api.lmnr.ai":
         base_url = "https://www.lmnr.ai"
 
     url = base_url
-    if url.endswith("/"):
-        url = url[:-1]
+    url = re.sub(r"\/$", "", url)
     if url.endswith("localhost") or url.endswith("127.0.0.1"):
-        # We best effort assume that the frontend is running on port 3000
-        # TODO: expose the frontend port?
+        # We best effort assume that the frontend is running on port 5667
         url = url + ":5667"
     return f"{url}/project/{project_id}/evaluations/{evaluation_id}"
 

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -639,8 +639,16 @@ class Laminar:
         return LaminarSpanContext.deserialize(span_context)
 
     @classmethod
-    def flush(cls):
-        TracerManager.flush()
+    def flush(cls) -> bool:
+        """Flush the internal tracer.
+
+        Returns:
+            bool: True if the tracer was flushed, False otherwise
+            (e.g. no tracer or timeout).
+        """
+        if not cls.is_initialized():
+            return False
+        return TracerManager.flush()
 
     @classmethod
     def shutdown(cls):

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -639,8 +639,13 @@ class Laminar:
         return LaminarSpanContext.deserialize(span_context)
 
     @classmethod
-    def shutdown(cls):
+    def flush(cls):
         TracerManager.flush()
+
+    @classmethod
+    def shutdown(cls):
+        # other shutdown logic could be added here
+        cls.flush()
 
     @classmethod
     def set_session(

--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -367,19 +367,21 @@ class ModelProvider(str, Enum):
 
 class RunAgentRequest(pydantic.BaseModel):
     prompt: str
-    state: Optional[str] = None
-    parent_span_context: Optional[str] = None
-    model_provider: Optional[ModelProvider] = None
-    model: Optional[str] = None
-    stream: bool = False
-    enable_thinking: bool = True
-    cdp_url: Optional[str] = None
+    state: Optional[str] = pydantic.Field(default=None)
+    parent_span_context: Optional[str] = pydantic.Field(default=None)
+    model_provider: Optional[ModelProvider] = pydantic.Field(default=None)
+    model: Optional[str] = pydantic.Field(default=None)
+    stream: bool = pydantic.Field(default=False)
+    enable_thinking: bool = pydantic.Field(default=True)
+    cdp_url: Optional[str] = pydantic.Field(default=None)
+    return_screenshots: bool = pydantic.Field(default=False)
 
     def to_dict(self):
         result = {
             "prompt": self.prompt,
             "stream": self.stream,
             "enableThinking": self.enable_thinking,
+            "returnScreenshots": self.return_screenshots,
         }
         if self.state:
             result["state"] = self.state
@@ -409,6 +411,7 @@ class StepChunkContent(pydantic.BaseModel):
     messageId: uuid.UUID
     actionResult: ActionResult
     summary: str
+    screenshot: Optional[str] = pydantic.Field(default=None)
 
 
 class FinalOutputChunkContent(pydantic.BaseModel):

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add 'page' event listener in Playwright context, enhance agent functionality with screenshot support, and update version to 0.5.1.
> 
>   - **Playwright Integration**:
>     - Add listener for 'page' events in `playwright_otel.py` to handle navigation in both sync and async contexts.
>     - Introduce `_wrap_new_context_sync` and `_wrap_new_context_async` to wrap new context creation.
>   - **Agent Enhancements**:
>     - Add `return_screenshots` parameter to `run()` methods in `agent.py` for both async and sync clients.
>     - Update `RunAgentRequest` in `types.py` to include `return_screenshots`.
>   - **Miscellaneous**:
>     - Change `lmnrRrwebEventsBatch` from list to set in `pw_utils.py` to prevent duplicate events.
>     - Fix typo in `README.md` (`else if` to `elif`).
>     - Update version to `0.5.1` in `pyproject.toml` and `version.py`.
>     - Add `flush()` method to `TracerManager` in `__init__.py` and `tracing.py` to return a boolean.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 404ad3ca5bb9c7992f8fed7b0c24eab4ecc6f395. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->