### PR TITLE
fix: evaluate function return awaitable handle with AsyncIO

### DIFF
--- a/src/lmnr/sdk/evaluations.py
+++ b/src/lmnr/sdk/evaluations.py
@@ -482,6 +482,6 @@ def evaluate(
     else:
         loop = asyncio.get_event_loop()
         if loop.is_running():
-            return loop.run_until_complete(evaluation.run())
+            return evaluation.run()
         else:
             return asyncio.run(evaluation.run())


### PR DESCRIPTION
Refactor evaluate function to return an awaitable handle using asyncio. This change addresses the issue where the event loop was already running, preventing proper execution of the evaluation function.
#101 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `evaluate()` in `evaluations.py` to return an awaitable handle when the event loop is already running, addressing issue #101.
> 
>   - **Behavior**:
>     - Refactor `evaluate()` in `evaluations.py` to return an awaitable handle when the event loop is already running.
>     - Addresses issue #101 where the event loop was already running, preventing proper execution.
>   - **Misc**:
>     - No changes to function signatures or parameters.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for a1d180edc821c1b937d7fbf1fd094b008cb61268. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->