### PR TITLE
fix(browser-use): no longer cast return type

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.6.1"
+version = "0.6.2"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/sdk/browser/browser_use_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_otel.py
@@ -83,12 +83,13 @@ async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         span.set_attributes(attributes)
         result = await wrapped(*args, **kwargs)
         if not to_wrap.get("ignore_output"):
+            to_serialize = result
             if isinstance(result, AgentHistoryList):
-                result = result.final_result()
+                to_serialize = result.final_result()
             serialized = (
-                result.model_dump_json()
-                if isinstance(result, pydantic.BaseModel)
-                else json_dumps(result)
+                to_serialize.model_dump_json()
+                if isinstance(to_serialize, pydantic.BaseModel)
+                else json_dumps(to_serialize)
             )
             span.set_attribute("lmnr.span.output", serialized)
         return result

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
**Problem:**
`lmnr` instrumentation of `browser_use.agent.run` was altering its return type from `AgentHistoryList` to `str` by calling `.final_result()`.

**Changes:**
The `_wrap` function in `lmnr/sdk/browser/browser_use_otel.py` is updated to:
1.  Return the original `AgentHistoryList` object from `agent.run` to the caller.
2.  Continue to use `result.final_result()` for the `lmnr.span.output` attribute in traces.


**Impact:**
*   Calling code now receives the expected `AgentHistoryList` from `agent.run`.
*   Trace data for `lmnr.span.output` remains consistent (string representation).

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix `_wrap` in `browser_use_otel.py` to return `AgentHistoryList` from `agent.run` while maintaining string output for traces.
> 
>   - **Behavior**:
>     - `_wrap` function in `browser_use_otel.py` now returns `AgentHistoryList` from `agent.run` instead of `str`.
>     - `lmnr.span.output` in traces still uses `result.final_result()` for string representation.
>   - **Impact**:
>     - Calling code receives `AgentHistoryList` as expected.
>     - Trace data remains consistent with string output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 4504eb9786003238cd89c1e300532dc657f6aa3c. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->