### PR TITLE
add metadata to observe and allow multiple evaluations in CLI

### DIFF
--- a/src/lmnr/cli.py
+++ b/src/lmnr/cli.py
@@ -70,7 +70,7 @@ async def run_evaluation(args):
                 except Exception as e:
                     LOG.error(f"Error running evaluation: {e}")
                     if args.fail_on_error:
-                        raise
+                        raise e
     finally:
         PREPARE_ONLY.reset(prep_token)
 

--- a/src/lmnr/cli.py
+++ b/src/lmnr/cli.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from lmnr.sdk.evaluations import Evaluation
 
-from .sdk.eval_control import PREPARE_ONLY, EVALUATION_INSTANCE
+from .sdk.eval_control import PREPARE_ONLY, EVALUATION_INSTANCES
 from .sdk.log import get_default_logger
 
 LOG = get_default_logger(__name__)
@@ -38,10 +38,10 @@ async def run_evaluation(args):
     else:
         files = [args.file]
 
-    for file in files:
-        prep_token = PREPARE_ONLY.set(True)
-        LOG.info(f"Running evaluation from {file}")
-        try:
+    prep_token = PREPARE_ONLY.set(True)
+    try:
+        for file in files:
+            LOG.info(f"Running evaluation from {file}")
             file = os.path.abspath(file)
             name = "user_module" + file
 
@@ -55,16 +55,19 @@ async def run_evaluation(args):
             sys.modules[name] = mod
 
             spec.loader.exec_module(mod)
-            evaluation: Optional[Evaluation] = EVALUATION_INSTANCE.get()
-            if evaluation is None:
+            evaluations: Optional[list[Evaluation]] = EVALUATION_INSTANCES.get()
+            if evaluations is None:
                 LOG.warning("Evaluation instance not found")
                 if args.fail_on_error:
                     return
                 continue
 
-            await evaluation.run()
-        finally:
-            PREPARE_ONLY.reset(prep_token)
+            LOG.info(f"Loaded {len(evaluations)} evaluations from {file}")
+
+            for evaluation in evaluations:
+                await evaluation.run()
+    finally:
+        PREPARE_ONLY.reset(prep_token)
 
 
 def cli():

--- a/src/lmnr/cli.py
+++ b/src/lmnr/cli.py
@@ -65,7 +65,12 @@ async def run_evaluation(args):
             LOG.info(f"Loaded {len(evaluations)} evaluations from {file}")
 
             for evaluation in evaluations:
-                await evaluation.run()
+                try:
+                    await evaluation.run()
+                except Exception as e:
+                    LOG.error(f"Error running evaluation: {e}")
+                    if args.fail_on_error:
+                        raise
     finally:
         PREPARE_ONLY.reset(prep_token)
 

--- a/src/lmnr/cli.py
+++ b/src/lmnr/cli.py
@@ -70,7 +70,7 @@ async def run_evaluation(args):
                 except Exception as e:
                     LOG.error(f"Error running evaluation: {e}")
                     if args.fail_on_error:
-                        raise e
+                        raise
     finally:
         PREPARE_ONLY.reset(prep_token)
 

--- a/src/lmnr/sdk/eval_control.py
+++ b/src/lmnr/sdk/eval_control.py
@@ -2,4 +2,4 @@ from contextvars import ContextVar
 
 
 PREPARE_ONLY: ContextVar[bool] = ContextVar("__lmnr_prepare_only", default=False)
-EVALUATION_INSTANCE = ContextVar("__lmnr_evaluation_instance")
+EVALUATION_INSTANCES = ContextVar("__lmnr_evaluation_instances")

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -50,6 +50,7 @@ from .types import (
 class Laminar:
     __project_api_key: Optional[str] = None
     __initialized: bool = False
+    __base_http_url: Optional[str] = None
 
     @classmethod
     def initialize(
@@ -133,6 +134,7 @@ class Laminar:
                 cls.__logger.info(f"Using HTTP port passed as an argument: {http_port}")
 
         cls.__initialized = True
+        cls.__base_http_url = f"{url}:{http_port or 443}"
 
         if not os.getenv("OTEL_ATTRIBUTE_COUNT_LIMIT"):
             # each message is at least 2 attributes: role and content,
@@ -699,6 +701,14 @@ class Laminar:
         props.pop("session_id", None)
         props.pop("user_id", None)
         set_association_properties(props)
+
+    @classmethod
+    def get_base_http_url(cls):
+        return cls.__base_http_url
+
+    @classmethod
+    def get_project_api_key(cls):
+        return cls.__project_api_key
 
     @classmethod
     def _headers(cls):


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance evaluation handling to support multiple evaluations and add metadata support in CLI and decorators.
> 
>   - **Behavior**:
>     - `run_evaluation()` in `cli.py` now supports multiple evaluations by iterating over `EVALUATION_INSTANCES` instead of a single `EVALUATION_INSTANCE`.
>     - `evaluate()` in `evaluations.py` registers multiple evaluations in `EVALUATION_INSTANCES` when `PREPARE_ONLY` is set.
>     - `observe()` in `decorators.py` now supports `user_id` and `metadata` parameters for enhanced trace association.
>   - **Decorators**:
>     - `entity_method()` and `aentity_method()` in `decorators/__init__.py` updated to handle `association_properties` for metadata.
>   - **Context Management**:
>     - `EVALUATION_INSTANCE` renamed to `EVALUATION_INSTANCES` in `eval_control.py` to reflect support for multiple evaluations.
>   - **Tests**:
>     - Added tests in `test_observe.py` for `user_id` and `metadata` in `observe()` to ensure correct span attribute setting.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 4afe7bcd9d08f132ddb6efd3bdc33a3954fbb42e. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->