### PR TITLE
v0.6.3 bump and update action to publish on release

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,8 @@
 name: Upload Python Package
 
 on:
-  push:
-    branches: ["main"]
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.6.2"
+version = "0.6.3"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.6.2"
+__version__ = "0.6.3"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Update GitHub Actions to publish on release and bump version to 0.6.3.
> 
>   - **GitHub Actions**:
>     - Update `python-publish.yml` to trigger on release publication instead of push to `main`.
>   - **Version Bump**:
>     - Update version to `0.6.3` in `pyproject.toml` and `version.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 5ae965035caed221d7036a79a9761283c5682c68. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->