### PR TITLE
v0.6.5 fix mcp instrumentor import

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.6.4"
+version = "0.6.5"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
+++ b/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
@@ -204,9 +204,9 @@ class MCPInstrumentorInitializer(InstrumentorInitializer):
         if not is_package_installed("opentelemetry-instrumentation-mcp"):
             return None
 
-        from opentelemetry.instrumentation.mcp import MCPInstrumentor
+        from opentelemetry.instrumentation.mcp import McpInstrumentor
 
-        return MCPInstrumentor()
+        return McpInstrumentor()
 
 
 class MilvusInstrumentorInitializer(InstrumentorInitializer):

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes import statement for `McpInstrumentor` and updates version to `0.6.5`.
> 
>   - **Bug Fix**:
>     - Corrects import statement for `McpInstrumentor` in `_instrument_initializers.py`.
>   - **Version Update**:
>     - Updates version to `0.6.5` in `pyproject.toml` and `version.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 1f54a5b37b290b2f9502e15fc7a6a6fb5d8dc556. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->