### PR TITLE
Silence litellm warn + bump to 0.6.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.6.12"
+version = "0.6.13"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/opentelemetry_lib/litellm/__init__.py
+++ b/src/lmnr/opentelemetry_lib/litellm/__init__.py
@@ -347,7 +347,7 @@ try:
                 self._process_response_choices(span, response_dict.get("choices"))
 
 except ImportError as e:
-    logger.warning(f"LiteLLM callback unavailable: {e}")
+    logger.debug(f"LiteLLM callback unavailable: {e}")
 
     # Create a no-op logger when LiteLLM is not available
     class LaminarLiteLLMCallback:

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.6.12"
+__version__ = "0.6.13"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Change LiteLLM callback unavailability log level to debug and update version to 0.6.13.
> 
>   - **Logging**:
>     - Change logging level from `warning` to `debug` for LiteLLM callback unavailability in `litellm/__init__.py`.
>   - **Versioning**:
>     - Update version from `0.6.12` to `0.6.13` in `pyproject.toml` and `version.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 10f3970f7e8578a8dca0e901d4aca03a9c1dd324. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->