### PR TITLE
add input and output formatter to decorator for custom formats

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "grpcio>=1",
   "httpx>=0.25.0",
   "opentelemetry-instrumentation-threading>=0.54b0",
+  "orjson>=3.10.18",
 ]
 
 [project.scripts]

--- a/src/lmnr/opentelemetry_lib/decorators/__init__.py
+++ b/src/lmnr/opentelemetry_lib/decorators/__init__.py
@@ -155,7 +155,7 @@ def observe_base(
                 res = fn(*args, **kwargs)
             except Exception as e:
                 _process_exception(span, e)
-                span.end()
+                _cleanup_span(span, ctx_token)
                 raise e
 
             # span will be ended in the generator

--- a/src/lmnr/opentelemetry_lib/decorators/__init__.py
+++ b/src/lmnr/opentelemetry_lib/decorators/__init__.py
@@ -156,7 +156,13 @@ def _process_input(
         else:
             span.set_attribute(SPAN_INPUT, inp)
     except Exception:
-        logger.debug("Failed to process input, ignoring", exc_info=True)
+        msg = "Failed to process input, ignoring"
+        if input_formatter is not None:
+            # Only warn the user if they provided an input formatter
+            # because it's their responsibility to make sure it works.
+            logger.warning(msg, exc_info=True)
+        else:
+            logger.debug(msg, exc_info=True)
         pass
 
 
@@ -183,7 +189,13 @@ def _process_output(
         else:
             span.set_attribute(SPAN_OUTPUT, output)
     except Exception:
-        logger.debug("Failed to process output, ignoring", exc_info=True)
+        msg = "Failed to process output, ignoring"
+        if output_formatter is not None:
+            # Only warn the user if they provided an output formatter
+            # because it's their responsibility to make sure it works.
+            logger.warning(msg, exc_info=True)
+        else:
+            logger.debug(msg, exc_info=True)
         pass
 
 

--- a/src/lmnr/opentelemetry_lib/decorators/__init__.py
+++ b/src/lmnr/opentelemetry_lib/decorators/__init__.py
@@ -20,6 +20,9 @@ from lmnr.opentelemetry_lib.tracing.attributes import (
 )
 from lmnr.opentelemetry_lib.tracing import TracerWrapper
 from lmnr.opentelemetry_lib.utils.json_encoder import JSONEncoder
+from lmnr.sdk.log import get_default_logger
+
+logger = get_default_logger(__name__)
 
 
 class CustomJSONEncoder(JSONEncoder):
@@ -91,7 +94,8 @@ def _process_input(
             span.set_attribute(SPAN_INPUT, "Laminar: input too large to record")
         else:
             span.set_attribute(SPAN_INPUT, inp)
-    except TypeError:
+    except Exception:
+        logger.debug("Failed to process input, ignoring", exc_info=True)
         pass
 
 
@@ -117,7 +121,8 @@ def _process_output(
             span.set_attribute(SPAN_OUTPUT, "Laminar: output too large to record")
         else:
             span.set_attribute(SPAN_OUTPUT, output)
-    except TypeError:
+    except Exception:
+        logger.debug("Failed to process output, ignoring", exc_info=True)
         pass
 
 

--- a/src/lmnr/opentelemetry_lib/decorators/__init__.py
+++ b/src/lmnr/opentelemetry_lib/decorators/__init__.py
@@ -1,9 +1,9 @@
-import collections.abc
 from functools import wraps
-import dataclasses
-import json
 import logging
+import json
 import pydantic
+import dataclasses
+import collections.abc
 import types
 from typing import Any, AsyncGenerator, Callable, Generator, Literal
 
@@ -116,10 +116,7 @@ def _setup_span(
             for key, value in association_properties.items():
                 span.set_attribute(f"{ASSOCIATION_PROPERTIES}.{key}", value)
 
-        ctx = trace.set_span_in_context(span, context_api.get_current())
-        ctx_token = context_api.attach(ctx)
-
-        return span, ctx_token
+        return span
 
 
 def _process_input(
@@ -223,7 +220,9 @@ def observe_base(
 
             span_name = name or fn.__name__
 
-            span, ctx_token = _setup_span(span_name, span_type, association_properties)
+            span = _setup_span(span_name, span_type, association_properties)
+            ctx = trace.set_span_in_context(span, context_api.get_current())
+            ctx_token = context_api.attach(ctx)
 
             _process_input(
                 span, fn, args, kwargs, ignore_input, ignore_inputs, input_formatter
@@ -277,7 +276,9 @@ def async_observe_base(
 
             span_name = name or fn.__name__
 
-            span, ctx_token = _setup_span(span_name, span_type, association_properties)
+            span = _setup_span(span_name, span_type, association_properties)
+            ctx = trace.set_span_in_context(span, context_api.get_current())
+            ctx_token = context_api.attach(ctx)
 
             _process_input(
                 span, fn, args, kwargs, ignore_input, ignore_inputs, input_formatter

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -458,7 +458,7 @@ async def test_observe_skip_input_keys_with_kwargs_async(
     }
 
 
-def test_observe_input_formatter(exporter: InMemorySpanExporter):
+def test_observe_input_formatter(span_exporter: InMemorySpanExporter):
     def input_formatter(x):
         return {"x": x + 1}
 
@@ -467,13 +467,13 @@ def test_observe_input_formatter(exporter: InMemorySpanExporter):
         return x
 
     result = observed_foo(1)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert json.loads(spans[0].attributes["lmnr.span.input"]) == {"x": 2}
 
 
-def test_observe_input_formatter_exception(exporter: InMemorySpanExporter):
+def test_observe_input_formatter_exception(span_exporter: InMemorySpanExporter):
     def input_formatter(x):
         raise ValueError("test")
 
@@ -482,7 +482,7 @@ def test_observe_input_formatter_exception(exporter: InMemorySpanExporter):
         return x
 
     result = observed_foo(1)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert spans[0].name == "observed_foo"
@@ -491,7 +491,7 @@ def test_observe_input_formatter_exception(exporter: InMemorySpanExporter):
     assert "lmnr.span.input" not in spans[0].attributes
 
 
-def test_observe_input_formatter_with_kwargs(exporter: InMemorySpanExporter):
+def test_observe_input_formatter_with_kwargs(span_exporter: InMemorySpanExporter):
     def input_formatter(x, **kwargs):
         return {"x": x + 1, "custom-A": f"{kwargs.get('a')}--"}
 
@@ -500,7 +500,7 @@ def test_observe_input_formatter_with_kwargs(exporter: InMemorySpanExporter):
         return x
 
     result = observed_foo(1, a=1, b=2)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert json.loads(spans[0].attributes["lmnr.span.input"]) == {
@@ -568,7 +568,7 @@ def test_observe_sequential_spans(span_exporter: InMemorySpanExporter):
 
 
 @pytest.mark.asyncio
-async def test_observe_input_formatter_async(exporter: InMemorySpanExporter):
+async def test_observe_input_formatter_async(span_exporter: InMemorySpanExporter):
     def input_formatter(x):
         return {"x": x + 1}
 
@@ -577,7 +577,7 @@ async def test_observe_input_formatter_async(exporter: InMemorySpanExporter):
         return x
 
     result = await observed_foo(1)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert json.loads(spans[0].attributes["lmnr.span.input"]) == {"x": 2}
@@ -585,7 +585,7 @@ async def test_observe_input_formatter_async(exporter: InMemorySpanExporter):
 
 @pytest.mark.asyncio
 async def test_observe_input_formatter_with_kwargs_async(
-    exporter: InMemorySpanExporter,
+    span_exporter: InMemorySpanExporter,
 ):
     def input_formatter(x, **kwargs):
         return {"x": x + 1, "custom-A": f"{kwargs.get('a')}--"}
@@ -595,7 +595,7 @@ async def test_observe_input_formatter_with_kwargs_async(
         return x
 
     result = await observed_foo(1, a=1, b=2)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert json.loads(spans[0].attributes["lmnr.span.input"]) == {
@@ -604,7 +604,7 @@ async def test_observe_input_formatter_with_kwargs_async(
     }
 
 
-def test_observe_output_formatter(exporter: InMemorySpanExporter):
+def test_observe_output_formatter(span_exporter: InMemorySpanExporter):
     def output_formatter(x):
         return {"x": x + 1}
 
@@ -613,13 +613,13 @@ def test_observe_output_formatter(exporter: InMemorySpanExporter):
         return x
 
     result = observed_foo(1)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert json.loads(spans[0].attributes["lmnr.span.output"]) == {"x": 2}
 
 
-def test_observe_output_formatter_exception(exporter: InMemorySpanExporter):
+def test_observe_output_formatter_exception(span_exporter: InMemorySpanExporter):
     def output_formatter(x):
         raise ValueError("test")
 
@@ -628,14 +628,14 @@ def test_observe_output_formatter_exception(exporter: InMemorySpanExporter):
         return x
 
     result = observed_foo(1)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert "lmnr.span.output" not in spans[0].attributes
 
 
 @pytest.mark.asyncio
-async def test_observe_output_formatter_async(exporter: InMemorySpanExporter):
+async def test_observe_output_formatter_async(span_exporter: InMemorySpanExporter):
     def output_formatter(x):
         return {"x": x + 1}
 
@@ -644,13 +644,13 @@ async def test_observe_output_formatter_async(exporter: InMemorySpanExporter):
         return x
 
     result = await observed_foo(1)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
     assert result == 1
     assert len(spans) == 1
     assert json.loads(spans[0].attributes["lmnr.span.output"]) == {"x": 2}
 
 
-def test_observe_complex_nested_input(exporter: InMemorySpanExporter):
+def test_observe_complex_nested_input(span_exporter: InMemorySpanExporter):
     import dataclasses
     from typing import List
 
@@ -686,7 +686,7 @@ def test_observe_complex_nested_input(exporter: InMemorySpanExporter):
     }
 
     observed_foo(person, complex_data)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
 
     assert len(spans) == 1
     span = spans[0]
@@ -712,7 +712,7 @@ def test_observe_complex_nested_input(exporter: InMemorySpanExporter):
     assert span_output["data_count"] == 4
 
 
-def test_observe_complex_nested_output(exporter: InMemorySpanExporter):
+def test_observe_complex_nested_output(span_exporter: InMemorySpanExporter):
     import dataclasses
     from typing import List
 
@@ -748,7 +748,7 @@ def test_observe_complex_nested_output(exporter: InMemorySpanExporter):
 
     input_data = {"simple": "input"}
     observed_foo(input_data)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
 
     assert len(spans) == 1
     span = spans[0]
@@ -796,7 +796,7 @@ def test_observe_complex_nested_output(exporter: InMemorySpanExporter):
     assert span_output["simple_types"] == [1, "string", True, None, 3.14]
 
 
-def test_observe_non_serializable_fallback(exporter: InMemorySpanExporter):
+def test_observe_non_serializable_fallback(span_exporter: InMemorySpanExporter):
     class NonSerializable:
         def __init__(self, x: int):
             self.x = x
@@ -806,7 +806,7 @@ def test_observe_non_serializable_fallback(exporter: InMemorySpanExporter):
         return x
 
     observed_foo(NonSerializable(1), 2)
-    spans = exporter.get_finished_spans()
+    spans = span_exporter.get_finished_spans()
 
     assert len(spans) == 1
     span = spans[0]

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -475,7 +475,7 @@ def test_observe_input_formatter(exporter: InMemorySpanExporter):
 
 def test_observe_input_formatter_with_kwargs(exporter: InMemorySpanExporter):
     def input_formatter(x, **kwargs):
-        return {"x": x + 1, "custom-A": f"{kwargs.get("a")}--"}
+        return {"x": x + 1, "custom-A": f"{kwargs.get('a')}--"}
 
     @observe(input_formatter=input_formatter)
     def observed_foo(x, **kwargs):
@@ -570,7 +570,7 @@ async def test_observe_input_formatter_with_kwargs_async(
     exporter: InMemorySpanExporter,
 ):
     def input_formatter(x, **kwargs):
-        return {"x": x + 1, "custom-A": f"{kwargs.get("a")}--"}
+        return {"x": x + 1, "custom-A": f"{kwargs.get('a')}--"}
 
     @observe(input_formatter=input_formatter)
     async def observed_foo(x, **kwargs):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,97 @@
+import json
+import dataclasses
+from typing import List
+
+from lmnr.opentelemetry_lib.decorators import json_dumps, CustomJSONEncoder
 from lmnr.sdk.utils import is_otel_attribute_value_type
+
+
+# Test dataclasses
+@dataclasses.dataclass
+class SimpleDataClass:
+    name: str
+    value: int
+
+
+@dataclasses.dataclass
+class NestedDataClass:
+    simple: SimpleDataClass
+    items: List[str]
+
+
+class ObjectWithToJson:
+    def __init__(self, name: str):
+        self.name = name
+
+    def to_json(self):
+        return f'{{"to_json_name": "{self.name}"}}'
+
+
+class ObjectWithJson:
+    def __init__(self, name: str):
+        self.name = name
+
+    def json(self):
+        return f'{{"json_name": "{self.name}"}}'
+
+
+class CircularRef:
+    def __init__(self, name: str):
+        self.name = name
+        self.ref = None
+
+
+class FailingStr:
+    """Class that raises an exception in __str__ method"""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self):
+        raise RuntimeError("__str__ method failed")
+
+    def __repr__(self):
+        return f"FailingStr(name='{self.name}')"
+
+
+class FailingRepr:
+    """Class that raises an exception in __repr__ method"""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __repr__(self):
+        raise RuntimeError("__repr__ method failed")
+
+    def __str__(self):
+        return f"FailingRepr with name: {self.name}"
+
+
+class FailingBoth:
+    """Class that raises exceptions in both __str__ and __repr__ methods"""
+
+    def __init__(self, name: str):
+        self.name = name
+
+    def __str__(self):
+        raise RuntimeError("__str__ method failed")
+
+    def __repr__(self):
+        raise RuntimeError("__repr__ method failed")
+
+
+class ComplexFailingObject:
+    """Class that fails in str() but has other attributes"""
+
+    def __init__(self, value: int):
+        self.value = value
+        self.data = {"key": "value"}
+
+    def __str__(self):
+        raise ValueError("Cannot convert to string")
+
+    def __repr__(self):
+        raise ValueError("Cannot create repr")
 
 
 def test_is_otel_attribute_value_type():
@@ -33,3 +126,385 @@ def test_is_otel_attribute_value_type():
     assert not is_otel_attribute_value_type([1, "a", True])
     assert not is_otel_attribute_value_type((1, "a", True))
     assert not is_otel_attribute_value_type(("a", 1, True))
+
+
+def test_json_dumps_basic():
+    """Test basic serialization"""
+    assert json_dumps({"a": 1, "b": "test"}) == '{"a": 1, "b": "test"}'
+    assert (
+        json_dumps({"a": 1, "b": "test", "c": [1, 2, 3]})
+        == '{"a": 1, "b": "test", "c": [1, 2, 3]}'
+    )
+
+
+def test_json_dumps_sequence_types():
+    """Test different sequence types"""
+    # Lists
+    assert json_dumps([1, 2, 3]) == "[1, 2, 3]"
+
+    # Tuples
+    assert json_dumps((1, 2, 3)) == "[1, 2, 3]"
+
+    # Sets (order may vary, so check content)
+    result = json_dumps({1, 2, 3})
+    parsed = json.loads(result)
+    assert set(parsed) == {1, 2, 3}
+
+    # Nested sequences
+    assert (
+        json_dumps({"list": [1, 2], "tuple": (3, 4)})
+        == '{"list": [1, 2], "tuple": [3, 4]}'
+    )
+
+
+def test_json_dumps_dataclass():
+    """Test dataclass serialization"""
+    simple = SimpleDataClass(name="test", value=42)
+    expected = '{"name": "test", "value": 42}'
+    assert json_dumps(simple) == expected
+
+    # Nested dataclass
+    nested = NestedDataClass(simple=simple, items=["a", "b"])
+    result = json_dumps(nested)
+    parsed = json.loads(result)
+    assert parsed["simple"]["name"] == "test"
+    assert parsed["simple"]["value"] == 42
+    assert parsed["items"] == ["a", "b"]
+
+
+def test_json_dumps_object_with_to_json():
+    """Test object with to_json method - potential double serialization"""
+    obj = ObjectWithToJson("test")
+    result = json_dumps(obj)
+
+    # This should NOT result in double serialization
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+
+
+def test_json_dumps_object_with_json():
+    """Test object with json method - potential double serialization"""
+    obj = ObjectWithJson("test")
+    result = json_dumps(obj)
+
+    # This should NOT result in double serialization
+    parsed = json.loads(result)
+    assert isinstance(parsed, dict)
+
+
+def test_json_dumps_circular_reference():
+    """Test circular reference handling"""
+    obj1 = CircularRef("obj1")
+    obj2 = CircularRef("obj2")
+    obj1.ref = obj2
+    obj2.ref = obj1
+
+    # This should not cause infinite recursion
+    result = json_dumps(obj1)
+    assert isinstance(result, str)
+    # Should fallback to string representation or handle gracefully
+
+
+def test_json_dumps_mixed_nested_types():
+    """Test complex nested structures with different types"""
+    dataclass_obj = SimpleDataClass(name="dataclass", value=2)
+
+    complex_data = {
+        "list": [1, 2, 3],
+        "tuple": (4, 5, 6),
+        "set": {7, 8, 9},
+        "nested_dict": {"inner_list": [10, 11, 12], "inner_tuple": (13, 14, 15)},
+        "dataclass": dataclass_obj,
+    }
+
+    result = json_dumps(complex_data)
+    parsed = json.loads(result)
+
+    # Verify structure
+    assert parsed["list"] == [1, 2, 3]
+    assert parsed["tuple"] == [4, 5, 6]
+    assert set(parsed["set"]) == {7, 8, 9}
+    assert parsed["nested_dict"]["inner_list"] == [10, 11, 12]
+    assert parsed["nested_dict"]["inner_tuple"] == [13, 14, 15]
+    assert parsed["dataclass"]["name"] == "dataclass"
+    assert parsed["dataclass"]["value"] == 2
+
+
+def test_json_dumps_unsupported_types():
+    """Test handling of unsupported types"""
+
+    # Function object
+    def sample_func():
+        pass
+
+    result = json_dumps(sample_func)
+    parsed = json.loads(result)
+    assert isinstance(parsed, str)  # Should fallback to string representation
+
+    # Lambda
+    result = json_dumps(lambda x: x)
+    parsed = json.loads(result)
+    assert isinstance(parsed, str)
+
+
+def test_json_dumps_generators_and_iterators():
+    """Test that generators and iterators are handled properly"""
+
+    # Generator
+    def gen():
+        yield 1
+        yield 2
+        yield 3
+
+    result = json_dumps(gen())
+    parsed = json.loads(result)
+    assert isinstance(
+        parsed, str
+    )  # Should fallback to string, not consume the generator
+
+    # Iterator
+    iterator = iter([1, 2, 3])
+    result = json_dumps(iterator)
+    parsed = json.loads(result)
+    assert isinstance(
+        parsed, str
+    )  # Should fallback to string, not consume the iterator
+
+
+def test_json_dumps_deeply_nested():
+    """Test deeply nested structures"""
+    nested = {"level1": {"level2": {"level3": {"level4": {"value": "deep"}}}}}
+    result = json_dumps(nested)
+    parsed = json.loads(result)
+    assert parsed["level1"]["level2"]["level3"]["level4"]["value"] == "deep"
+
+
+def test_json_dumps_empty_containers():
+    """Test empty containers"""
+    assert json_dumps([]) == "[]"
+    assert json_dumps({}) == "{}"
+    assert json_dumps(()) == "[]"
+    assert json_dumps(set()) == "[]"
+
+
+def test_json_dumps_none_values():
+    """Test None values"""
+    assert json_dumps(None) == "null"
+    assert json_dumps({"key": None}) == '{"key": null}'
+
+
+def test_custom_json_encoder_direct():
+    """Test the CustomJSONEncoder directly"""
+    encoder = CustomJSONEncoder()
+
+    # Test default method with dataclass
+    simple_dc = SimpleDataClass(name="test", value=42)
+    serialized = encoder.default(simple_dc)
+    assert serialized == {"name": "test", "value": 42}
+
+    # Test with list containing dataclass
+    list_with_dc = [simple_dc, {"key": "value"}]
+    serialized = encoder.default(list_with_dc)
+    assert serialized == [{"name": "test", "value": 42}, {"key": "value"}]
+
+    # Test with primitive types (should pass through unchanged)
+    assert encoder.default(42) == 42
+    assert encoder.default("test") == "test"
+    assert encoder.default(True) is True
+    assert encoder.default(None) is None
+
+
+# Original test renamed to avoid conflict
+def test_original_json_dumps():
+    assert json_dumps({"a": 1, "b": "test"}) == '{"a": 1, "b": "test"}'
+    assert (
+        json_dumps({"a": 1, "b": "test", "c": [1, 2, 3]})
+        == '{"a": 1, "b": "test", "c": [1, 2, 3]}'
+    )
+    assert (
+        json_dumps({"a": 1, "b": "test", "c": [1, 2, 3]})
+        == '{"a": 1, "b": "test", "c": [1, 2, 3]}'
+    )
+
+
+def test_json_dumps_failing_str():
+    """Test object that fails in __str__ but works in __repr__"""
+    obj = FailingStr("test")
+    result = json_dumps(obj)
+
+    # When serialization completely fails, json_dumps returns "{}"
+    assert result == "{}"
+
+
+def test_json_dumps_failing_repr():
+    """Test object that fails in __repr__ but works in __str__"""
+    obj = FailingRepr("test")
+    result = json_dumps(obj)
+
+    # Should succeed using __str__ method as fallback
+    parsed = json.loads(result)
+    assert isinstance(parsed, str)
+    assert "FailingRepr with name: test" in parsed
+
+
+def test_json_dumps_failing_both():
+    """Test object that fails in both __str__ and __repr__"""
+    obj = FailingBoth("test")
+    result = json_dumps(obj)
+
+    # When serialization completely fails, json_dumps returns "{}"
+    assert result == "{}"
+
+
+def test_json_dumps_complex_failing_object():
+    """Test complex object that fails in string conversion"""
+    obj = ComplexFailingObject(42)
+    result = json_dumps(obj)
+
+    # When serialization completely fails, json_dumps returns "{}"
+    assert result == "{}"
+
+
+def test_json_dumps_failing_objects_in_nested_structures():
+    """Test failing objects within nested data structures"""
+    failing_str = FailingStr("nested")
+    failing_both = FailingBoth("deeply_nested")
+
+    complex_data = {
+        "normal": "value",
+        "failing_str": failing_str,
+        "list_with_failing": [1, 2, failing_both, 4],
+        "nested_dict": {"inner": failing_str, "normal": "still_works"},
+    }
+
+    result = json_dumps(complex_data)
+
+    # When any object in the structure fails to serialize, the entire thing fails
+    assert result == "{}"
+
+
+def test_json_dumps_fallback_hierarchy():
+    """Test the complete fallback hierarchy"""
+    # Test with different types of objects to verify fallback behavior
+
+    # These should fail completely and return "{}"
+    failing_cases = [
+        FailingStr(
+            "test1"
+        ),  # __str__ fails, __repr__ works but encoder might not use it
+        FailingBoth("test3"),  # Both __str__ and __repr__ fail
+        ComplexFailingObject(99),  # Both __str__ and __repr__ fail
+    ]
+
+    for obj in failing_cases:
+        result = json_dumps(obj)
+        # Should produce the fallback empty JSON object
+        assert result == "{}"
+
+    # This should succeed using __str__ method
+    succeeding_case = FailingRepr("test2")  # __repr__ fails but __str__ works
+    result = json_dumps(succeeding_case)
+    parsed = json.loads(result)
+    assert isinstance(parsed, str)
+    assert "FailingRepr with name: test2" in parsed
+
+
+def test_custom_json_encoder_fallback_direct():
+    """Test the CustomJSONEncoder fallback behavior directly"""
+    encoder = CustomJSONEncoder()
+
+    # Test with failing __str__ - should use super().default() which may work
+    failing_str = FailingStr("direct_test")
+    result = encoder.default(failing_str)
+    # The result depends on what super().default() returns
+    assert result is not None
+
+    # Test with failing __repr__ - should use super().default() which may work
+    failing_repr = FailingRepr("direct_test")
+    result = encoder.default(failing_repr)
+    # The result depends on what super().default() returns
+    assert result is not None
+
+    # Test with both failing - should use the final fallback
+    failing_both = FailingBoth("direct_test")
+    result = encoder.default(failing_both)
+    # Should return the object itself as final fallback
+    assert result is not None
+
+
+def test_json_dumps_working_objects_with_embedded_failing():
+    """Test that working objects serialize correctly even when some fail"""
+    # Create a structure with mostly working objects
+    simple_dc = SimpleDataClass(name="working", value=100)
+
+    # Test with only working objects first
+    working_data = {"dataclass": simple_dc, "normal_list": [1, 2, 3], "string": "test"}
+
+    result = json_dumps(working_data)
+    parsed = json.loads(result)
+
+    # Should work normally
+    assert parsed["dataclass"]["name"] == "working"
+    assert parsed["dataclass"]["value"] == 100
+    assert parsed["normal_list"] == [1, 2, 3]
+    assert parsed["string"] == "test"
+
+
+def test_json_dumps_mixed_failing_and_working():
+    """Test mix of working and failing objects"""
+    simple_dc = SimpleDataClass(name="working", value=100)
+    failing_obj = FailingBoth("mixed_test")
+
+    # Any failing object in the structure causes the entire serialization to fail
+    mixed_data = {
+        "dataclass": simple_dc,
+        "failing": failing_obj,
+        "normal_list": [1, 2, 3],
+    }
+
+    result = json_dumps(mixed_data)
+    # Should return the fallback empty object
+    assert result == "{}"
+
+
+def test_custom_json_encoder_fallback_order():
+    """Test that the fallback order works correctly in the encoder"""
+    encoder = CustomJSONEncoder()
+
+    # Test with a simple non-serializable object that doesn't fail in str()
+    class SimpleNonSerializable:
+        def __init__(self, value):
+            self.value = value
+
+    obj = SimpleNonSerializable(42)
+    result = encoder.default(obj)
+
+    # Should return a string representation
+    assert isinstance(result, str)
+    assert "SimpleNonSerializable" in result
+
+    # Test that this works when used with json_dumps
+    result_json = json_dumps(obj)
+    parsed = json.loads(result_json)
+    assert isinstance(parsed, str)
+    assert "SimpleNonSerializable" in parsed
+
+
+def test_json_dumps_encoder_fallback_success():
+    """Test cases where the encoder fallback succeeds"""
+
+    # Test with a custom object that has a good __str__ method
+    class GoodCustomObject:
+        def __init__(self, name):
+            self.name = name
+
+        def __str__(self):
+            return f"GoodCustomObject({self.name})"
+
+    obj = GoodCustomObject("test")
+    result = json_dumps(obj)
+    parsed = json.loads(result)
+
+    # Should successfully serialize to a string
+    assert isinstance(parsed, str)
+    assert "GoodCustomObject(test)" == parsed

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -258,7 +258,7 @@ def test_json_dumps_mixed_nested_types():
     }
 
     result = json_dumps(complex_data)
-    parsed = json.loads(str(result))
+    parsed = json.loads(result)
 
     # Verify structure
     assert parsed["list"] == [1, 2, 3]


### PR DESCRIPTION
Creating a draft to try and run tests here. For some reason they don't run for me on local
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add input and output formatters to `observe` decorator for custom serialization, using `orjson` for improved performance and handling.
> 
>   - **Behavior**:
>     - Add `input_formatter` and `output_formatter` to `observe` and `async_observe_base` in `decorators.py` for custom input/output serialization.
>     - Use `orjson` for JSON serialization in `json_dumps()` in `decorators/__init__.py`.
>     - Handle serialization errors by logging and using placeholders.
>   - **Functions**:
>     - Add `_process_input()` and `_process_output()` in `decorators/__init__.py` to handle input/output processing with formatters.
>     - Add `_setup_span()` and `_cleanup_span()` for span management in `decorators/__init__.py`.
>   - **Tests**:
>     - Add tests for input/output formatters in `test_observe.py`.
>     - Add tests for `json_dumps()` handling of various data types in `test_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for ea5f1d830b4318fd929794479779e4f7e11e4e0c. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->