### PR TITLE
write output schema definition to the span attributes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "opentelemetry-exporter-otlp-proto-http (>=1.33.0)",
   "opentelemetry-exporter-otlp-proto-grpc (>=1.33.0)",
   "opentelemetry-semantic-conventions (>=0.54b0)",
-  "opentelemetry-semantic-conventions-ai (>=0.4.8)",
+  "opentelemetry-semantic-conventions-ai (>=0.4.9)",
   "tqdm (>=4.0)",
   "tenacity (>=8.0)",
   # Since 1.68.0, grpcio writes a warning message

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/__init__.py
@@ -134,6 +134,8 @@ def _set_request_attributes(span, args, kwargs):
         try:
             set_span_attribute(
                 span,
+                # TODO: change to SpanAttributes.LLM_REQUEST_STRUCTURED_OUTPUT_SCHEMA
+                # when we upgrade to opentelemetry-semantic-conventions-ai>=0.4.10
                 "gen_ai.request.structured_output_schema",
                 json.dumps(process_schema(schema), cls=SchemaJSONEncoder),
             )
@@ -143,6 +145,8 @@ def _set_request_attributes(span, args, kwargs):
         try:
             set_span_attribute(
                 span,
+                # TODO: change to SpanAttributes.LLM_REQUEST_STRUCTURED_OUTPUT_SCHEMA
+                # when we upgrade to opentelemetry-semantic-conventions-ai>=0.4.10
                 "gen_ai.request.structured_output_schema",
                 json.dumps(json_schema),
             )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/__init__.py
@@ -11,6 +11,7 @@ from google.genai import types
 from .config import (
     Config,
 )
+from .schema_utils import SchemaJSONEncoder, process_schema
 from .utils import (
     dont_throw,
     get_content,
@@ -24,8 +25,9 @@ from opentelemetry.trace import Tracer
 from wrapt import wrap_function_wrapper
 
 from opentelemetry import context as context_api
-from opentelemetry.trace import get_tracer, SpanKind, Span
+from opentelemetry.trace import get_tracer, SpanKind, Span, Status, StatusCode
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY, unwrap
@@ -78,7 +80,7 @@ WRAPPED_METHODS = [
 
 def should_send_prompts():
     return (
-        os.getenv("TRACELOOP_TRACE_CONTENT") or "true"
+        os.getenv("LAMINAR_TRACE_CONTENT") or "true"
     ).lower() == "true" or context_api.get_value("override_enable_content_tracing")
 
 
@@ -127,6 +129,25 @@ def _set_request_attributes(span, args, kwargs):
     set_span_attribute(
         span, gen_ai_attributes.GEN_AI_REQUEST_SEED, config_dict.get("seed")
     )
+
+    if schema := config_dict.get("response_schema"):
+        try:
+            set_span_attribute(
+                span,
+                "gen_ai.request.structured_output_schema",
+                json.dumps(process_schema(schema), cls=SchemaJSONEncoder),
+            )
+        except Exception:
+            pass
+    elif json_schema := config_dict.get("response_json_schema"):
+        try:
+            set_span_attribute(
+                span,
+                "gen_ai.request.structured_output_schema",
+                json.dumps(json_schema),
+            )
+        except Exception:
+            pass
 
     tools: list[types.FunctionDeclaration] = []
     arg_tools = config_dict.get("tools", kwargs.get("tools"))
@@ -454,16 +475,20 @@ def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
     if span.is_recording():
         _set_request_attributes(span, args, kwargs)
 
-    if to_wrap.get("is_streaming"):
-        return _build_from_streaming_response(span, wrapped(*args, **kwargs))
-    else:
+    try:
         response = wrapped(*args, **kwargs)
-
-    if span.is_recording():
-        _set_response_attributes(span, response)
-
-    span.end()
-    return response
+        if to_wrap.get("is_streaming"):
+            return _build_from_streaming_response(span, response)
+        if span.is_recording():
+            _set_response_attributes(span, response)
+        span.end()
+        return response
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise e
 
 
 @with_tracer_wrapper
@@ -485,16 +510,22 @@ async def _awrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
     if span.is_recording():
         _set_request_attributes(span, args, kwargs)
 
-    if to_wrap.get("is_streaming"):
-        return _abuild_from_streaming_response(span, await wrapped(*args, **kwargs))
-    else:
+    try:
         response = await wrapped(*args, **kwargs)
+        if to_wrap.get("is_streaming"):
+            return _abuild_from_streaming_response(span, response)
+        else:
+            if span.is_recording():
+                _set_response_attributes(span, response)
 
-    if span.is_recording():
-        _set_response_attributes(span, response)
-
-    span.end()
-    return response
+            span.end()
+            return response
+    except Exception as e:
+        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+        span.record_exception(e)
+        span.set_status(Status(StatusCode.ERROR, str(e)))
+        span.end()
+        raise e
 
 
 class GoogleGenAiSdkInstrumentor(BaseInstrumentor):

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/schema_utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/schema_utils.py
@@ -5,11 +5,12 @@ from google.genai.types import JSONSchemaType
 
 import json
 
+dummy_client = BaseApiClient(api_key="dummy")
+
 
 def process_schema(schema: Any) -> dict[str, Any]:
     # The only thing we need from the client is the t_schema function
-    client = BaseApiClient(api_key="dummy")
-    json_schema = t_schema(client, schema).json_schema.model_dump(
+    json_schema = t_schema(dummy_client, schema).json_schema.model_dump(
         exclude_unset=True, exclude_none=True
     )
     return json_schema

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/schema_utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/schema_utils.py
@@ -1,0 +1,22 @@
+from typing import Any
+from google.genai._api_client import BaseApiClient
+from google.genai._transformers import t_schema
+from google.genai.types import JSONSchemaType
+
+import json
+
+
+def process_schema(schema: Any) -> dict[str, Any]:
+    # The only thing we need from the client is the t_schema function
+    client = BaseApiClient(api_key="dummy")
+    json_schema = t_schema(client, schema).json_schema.model_dump(
+        exclude_unset=True, exclude_none=True
+    )
+    return json_schema
+
+
+class SchemaJSONEncoder(json.JSONEncoder):
+    def default(self, o: Any) -> Any:
+        if isinstance(o, JSONSchemaType):
+            return o.value
+        return super().default(o)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/schema_utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/schema_utils.py
@@ -5,12 +5,12 @@ from google.genai.types import JSONSchemaType
 
 import json
 
-dummy_client = BaseApiClient(api_key="dummy")
+DUMMY_CLIENT = BaseApiClient(api_key="dummy")
 
 
 def process_schema(schema: Any) -> dict[str, Any]:
     # The only thing we need from the client is the t_schema function
-    json_schema = t_schema(dummy_client, schema).json_schema.model_dump(
+    json_schema = t_schema(DUMMY_CLIENT, schema).json_schema.model_dump(
         exclude_unset=True, exclude_none=True
     )
     return json_schema

--- a/tests/cassettes/test_google_genai/test_google_genai_output_json_schema.yaml
+++ b/tests/cassettes/test_google_genai/test_google_genai_output_json_schema.yaml
@@ -1,0 +1,67 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Alice and Bob are going to a science
+      fair on Friday. Extract the event information."}], "role": "user"}], "generationConfig":
+      {"responseMimeType": "application/json", "responseJsonSchema": {"type": "object",
+      "title": "CalendarEvent", "properties": {"name": {"type": "string", "title":
+      "Name"}, "dayOfWeek": {"type": "string", "title": "Dayofweek"}, "participants":
+      {"type": "array", "title": "Participants", "items": {"type": "string"}}}, "required":
+      ["name", "dayOfWeek", "participants"]}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '526'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.24.0 gl-python/3.12.9
+      x-goog-api-client:
+      - google-genai-sdk/1.24.0 gl-python/3.12.9
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite-preview-06-17:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2VRy07DMBC85yusPSeoLSpU3HirB2iBCJDqHpZk01pN7Mh2oSXKv+MkTZoKH2xr
+        ZnZnPS48xiBCGYsYLRm4YguHMFbUe8UpaUlaR7SQA3PU9qhtVtG7O4mlXVUEBZeMcYhxP0s+iDbc
+        gRwetPPbc/AbVmJGDWEiQTIilqDQHV3ZiUjkKK2pZAsO16mIXInv2Bv1xWHJZQm9CcruvvSPc2uV
+        UjVUpmJKW3nZCiARUpj1K6FRspK9hbM5dKyQMe0cPPBag7o1bA2u6IksugSxywlyrbLchmpD8lZt
+        6wSHk6ZZL/AT/nx04K2ymJ5Q44H/r625c6Yi7X9E74/cGzEVdl89JLz/DKGXgz2dqg2iPpfeIZIm
+        pXfSRjRxrChzAQWjs3GQpGjWgWtPQa7pW9BPMLgIhpe1CWgyuZKGpnFVNn7LJc4fs+kk+N09T+Yr
+        pFH2sgGv9P4AFIc+RX4CAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Fri, 04 Jul 2025 01:14:13 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=262
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/test_google_genai/test_google_genai_output_schema.yaml
+++ b/tests/cassettes/test_google_genai/test_google_genai_output_schema.yaml
@@ -1,0 +1,68 @@
+interactions:
+- request:
+    body: '{"contents": [{"parts": [{"text": "Alice and Bob are going to a science
+      fair on Friday. Extract the event information."}], "role": "user"}], "generationConfig":
+      {"responseMimeType": "application/json", "responseSchema": {"properties": {"name":
+      {"title": "Name", "type": "STRING"}, "dayOfWeek": {"title": "Dayofweek", "type":
+      "STRING"}, "participants": {"items": {"type": "STRING"}, "title": "Participants",
+      "type": "ARRAY"}}, "propertyOrdering": ["name", "dayOfWeek", "participants"],
+      "required": ["name", "dayOfWeek", "participants"], "title": "CalendarEvent",
+      "type": "OBJECT"}}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '581'
+      content-type:
+      - application/json
+      host:
+      - generativelanguage.googleapis.com
+      user-agent:
+      - google-genai-sdk/1.24.0 gl-python/3.12.9
+      x-goog-api-client:
+      - google-genai-sdk/1.24.0 gl-python/3.12.9
+    method: POST
+    uri: https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash-lite-preview-06-17:generateContent
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/2WRUW+CMBSF3/kVTZ9hURen2dvcXLIsi26SbYn14Q4u2ggtaeuUEP77WhDEjAco
+        95yee/u19AihEYiYx2BQ03uythVCyvrtNCkMCmOFtmSLOShz8TZP2Vtbi8GT20RLJghhVECGzP4z
+        qiOOIkKSAFeM+o0cQ7FIvhD3jedZ2XGKTnXteMRzEEY7w5rRh5RHNtC36kz+MLphoqK9CapuvfEv
+        cyuZohsqkzGmrb1qDTThguvdB4KWwtlW4WJJO5WLGE+2PPDaBnU0PWjY4hsasASh40RzJbPchHKP
+        4lEeaoLDaRPWA36l347OupEG0itpPPD/xeon25Sn/Yvo3ZE9I6TcFO4g4fw7pD0O5nqqFkT93Xhn
+        JA2lT1SaNzi2mFlAwehmHCQp6F1g4zHIFf5yPAaDu2A4qZtQhTqXQuNL7La9Tk4ZLFejmS4KoefL
+        PYA8vk+pV3l/lsxVQX4CAAA=
+    headers:
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=UTF-8
+      Date:
+      - Thu, 03 Jul 2025 17:21:47 GMT
+      Server:
+      - scaffolding on HTTPServer2
+      Server-Timing:
+      - gfet4t7; dur=362
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      - X-Origin
+      - Referer
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_google_genai.py
+++ b/tests/test_google_genai.py
@@ -2,10 +2,13 @@ import base64
 import httpx
 import json
 import pytest
+import pydantic
 
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
 
 from google.genai import Client, types
+from google.genai.errors import ClientError
 
 
 image_url = "https://upload.wikimedia.org/wikipedia/commons/8/8e/MuseumOfFineArtsBoston_CopleySquare_19thc.jpg"
@@ -395,3 +398,178 @@ def test_google_genai_image_raw_bytes(exporter: InMemorySpanExporter):
         "text": response.text,
     }
     assert spans[0].attributes["gen_ai.completion.0.role"] == "model"
+
+
+class CalendarEvent(pydantic.BaseModel):
+    name: str
+    dayOfWeek: str
+    participants: list[str]
+
+
+EXPECTED_SCHEMA = {
+    "type": "object",
+    "title": "CalendarEvent",
+    "properties": {
+        "name": {"type": "string", "title": "Name"},
+        "dayOfWeek": {"type": "string", "title": "Dayofweek"},
+        "participants": {
+            "type": "array",
+            "title": "Participants",
+            "items": {"type": "string"},
+        },
+    },
+    "required": ["name", "dayOfWeek", "participants"],
+}
+
+
+@pytest.mark.vcr
+def test_google_genai_output_schema(exporter: InMemorySpanExporter):
+    # The actual key was used during recording and the request/response was saved
+    # to the VCR cassette.
+    client = Client(api_key="123")
+    prompt = "Alice and Bob are going to a science fair on Friday. Extract the event information."
+    response = client.models.generate_content(
+        model="gemini-2.5-flash-lite-preview-06-17",
+        contents=[
+            {
+                "role": "user",
+                "parts": [
+                    {"text": prompt},
+                ],
+            }
+        ],
+        config=types.GenerateContentConfig(
+            response_schema=CalendarEvent,
+            response_mime_type="application/json",
+        ),
+    )
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "gemini.generate_content"
+    assert (
+        spans[0].attributes["gen_ai.request.model"]
+        == "gemini-2.5-flash-lite-preview-06-17"
+    )
+    assert (
+        spans[0].attributes["gen_ai.response.model"]
+        == "gemini-2.5-flash-lite-preview-06-17"
+    )
+
+    user_content = json.loads(spans[0].attributes["gen_ai.prompt.0.content"])
+    assert user_content == [
+        {
+            "type": "text",
+            "text": prompt,
+        }
+    ]
+
+    assert spans[0].attributes["gen_ai.prompt.0.role"] == "user"
+    assert json.loads(spans[0].attributes["gen_ai.completion.0.content"])[0] == {
+        "type": "text",
+        "text": response.text,
+    }
+    assert spans[0].attributes["gen_ai.completion.0.role"] == "model"
+    assert (
+        json.loads(spans[0].attributes["gen_ai.request.structured_output_schema"])
+        == EXPECTED_SCHEMA
+    )
+
+
+@pytest.mark.vcr
+def test_google_genai_output_json_schema(exporter: InMemorySpanExporter):
+    # The actual key was used during recording and the request/response was saved
+    # to the VCR cassette.
+    client = Client(api_key="123")
+    prompt = "Alice and Bob are going to a science fair on Friday. Extract the event information."
+    response = client.models.generate_content(
+        model="gemini-2.5-flash-lite-preview-06-17",
+        contents=[
+            {
+                "role": "user",
+                "parts": [
+                    {"text": prompt},
+                ],
+            }
+        ],
+        config=types.GenerateContentConfig(
+            response_json_schema=EXPECTED_SCHEMA,
+            response_mime_type="application/json",
+        ),
+    )
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "gemini.generate_content"
+    assert (
+        spans[0].attributes["gen_ai.request.model"]
+        == "gemini-2.5-flash-lite-preview-06-17"
+    )
+    assert (
+        spans[0].attributes["gen_ai.response.model"]
+        == "gemini-2.5-flash-lite-preview-06-17"
+    )
+
+    user_content = json.loads(spans[0].attributes["gen_ai.prompt.0.content"])
+    assert user_content == [
+        {
+            "type": "text",
+            "text": prompt,
+        }
+    ]
+
+    assert spans[0].attributes["gen_ai.prompt.0.role"] == "user"
+    assert json.loads(spans[0].attributes["gen_ai.completion.0.content"])[0] == {
+        "type": "text",
+        "text": response.text,
+    }
+    assert spans[0].attributes["gen_ai.completion.0.role"] == "model"
+    assert (
+        json.loads(spans[0].attributes["gen_ai.request.structured_output_schema"])
+        == EXPECTED_SCHEMA
+    )
+
+
+def test_google_genai_error(exporter: InMemorySpanExporter):
+    # Invalid key on purpose
+    client = Client(api_key="123")
+    system_instruction = "Be concise and to the point. Use tools as much as possible."
+    with pytest.raises(ClientError):
+        client.models.generate_content(
+            model="gemini-2.5-flash-preview-05-20",
+            contents=[
+                {
+                    "role": "user",
+                    "parts": [
+                        {"text": "What is the capital of France?"},
+                    ],
+                }
+            ],
+            config=types.GenerateContentConfig(
+                system_instruction={"text": system_instruction},
+            ),
+        )
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "gemini.generate_content"
+    assert (
+        spans[0].attributes["gen_ai.request.model"] == "gemini-2.5-flash-preview-05-20"
+    )
+    assert spans[0].attributes["gen_ai.prompt.0.content"] == system_instruction
+    assert spans[0].attributes["gen_ai.prompt.0.role"] == "system"
+    user_content = json.loads(spans[0].attributes["gen_ai.prompt.1.content"])
+    assert user_content[0]["type"] == "text"
+    assert user_content[0]["text"] == "What is the capital of France?"
+    assert spans[0].attributes["gen_ai.prompt.1.role"] == "user"
+    assert spans[0].attributes["error.type"] == "ClientError"
+
+    assert spans[0].status.status_code == StatusCode.ERROR
+    events = spans[0].events
+    assert len(events) == 1
+    event = events[0]
+    assert event.name == "exception"
+    assert event.attributes["exception.type"] == "google.genai.errors.ClientError"
+    assert event.attributes["exception.message"].startswith("400")
+    assert (
+        "Traceback (most recent call last):" in event.attributes["exception.stacktrace"]
+    )
+    assert "google.genai.errors.ClientError" in event.attributes["exception.stacktrace"]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Add functionality to write output schema definitions to span attributes in Google GenAI instrumentation, with updated error handling and tests.
> 
>   - **Behavior**:
>     - Writes `response_schema` and `response_json_schema` to span attributes in `__init__.py`.
>     - Updates error handling in `_wrap()` and `_awrap()` to record exceptions and set error status.
>   - **Utilities**:
>     - Adds `process_schema()` and `SchemaJSONEncoder` in `schema_utils.py` for schema processing.
>   - **Tests**:
>     - Adds tests for schema handling in `test_google_genai.py`.
>     - Adds VCR cassettes `test_google_genai_output_json_schema.yaml` and `test_google_genai_output_schema.yaml` for schema tests.
>   - **Dependencies**:
>     - Updates `opentelemetry-semantic-conventions-ai` to `>=0.4.9` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 7ff2369ea4e42579efe2704db65b6069ef0a4560. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->