### PR TITLE
wrap get_span_context() to fix datadog trace flags

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/opentelemetry/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/opentelemetry/__init__.py
@@ -1,0 +1,69 @@
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.trace import TraceFlags, SpanContext
+from typing import Collection
+from wrapt import wrap_function_wrapper
+import logging
+
+
+def _wrap_span_context(fn, instance, args, kwargs):
+    """
+    DataDog does something to the OpenTelemetry Contexts, so that when any code
+    tries to access the current active span, it returns a non-recording span.
+
+    There is nothing wrong about that per se, but they create their
+    NonRecordingSpan from an invalid SpanContext, because they don't
+    wrap the trace flags int/bitmap into a TraceFlags object.
+
+    It is an easy to miss bug, because `TraceFlags.SAMPLED` looks like an
+    instance of `TraceFlags`, but is actually just an integer 1, and  the
+    proper way to create it is actually
+    `TraceFlags(TraceFlags.SAMPLED)` or `TraceFlags(0x1)`.
+
+    This is a problem because the trace flags are used to determine if a span
+    is sampled or not. If the trace flags are not wrapped, then the check
+    for sampling will fail, causing any span creation to fail, and sometimes
+    breaking the entire application.
+
+    Issue: https://github.com/DataDog/dd-trace-py/issues/12585
+    PR: https://github.com/DataDog/dd-trace-py/pull/12596
+    The PR only fixed the issue in one place, but it is still there in other places.
+    https://github.com/DataDog/dd-trace-py/pull/12596#issuecomment-2718239507
+
+    https://github.com/DataDog/dd-trace-py/blob/a8419a40fe9e73e0a84c4cab53094c384480a5a6/ddtrace/internal/opentelemetry/context.py#L83
+
+    We patch the `get_span_context` method to return a valid SpanContext.
+    """
+    res = fn(*args, **kwargs)
+
+    new_span_context = SpanContext(
+        trace_id=res.trace_id,
+        span_id=res.span_id,
+        is_remote=res.is_remote,
+        trace_state=res.trace_state,
+        trace_flags=TraceFlags(res.trace_flags),
+    )
+
+    return new_span_context
+
+
+class OpentelemetryInstrumentor(BaseInstrumentor):
+    def __init__(self):
+        super().__init__()
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return ("opentelemetry-api>=1.0.0",)
+
+    def _instrument(self, **kwargs):
+        try:
+            wrap_function_wrapper(
+                "opentelemetry.trace.span",
+                "NonRecordingSpan.get_span_context",
+                _wrap_span_context,
+            )
+
+        except Exception as e:
+            logging.debug(f"Error wrapping SpanContext: {e}")
+
+    def _uninstrument(self, **kwargs):
+        unwrap("opentelemetry.trace.span", "NonRecordingSpan.get_span_context")

--- a/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
+++ b/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
@@ -274,6 +274,15 @@ class OpenAIInstrumentorInitializer(InstrumentorInitializer):
         )
 
 
+class OpenTelemetryInstrumentorInitializer(InstrumentorInitializer):
+    def init_instrumentor(self, *args, **kwargs) -> BaseInstrumentor | None:
+        from ..opentelemetry.instrumentation.opentelemetry import (
+            OpentelemetryInstrumentor,
+        )
+
+        return OpentelemetryInstrumentor()
+
+
 class PatchrightInstrumentorInitializer(InstrumentorInitializer):
     def init_instrumentor(
         self, client, async_client, *args, **kwargs
@@ -345,6 +354,7 @@ class SageMakerInstrumentorInitializer(InstrumentorInitializer):
 
         return SageMakerInstrumentor()
 
+
 class SkyvernInstrumentorInitializer(InstrumentorInitializer):
     def init_instrumentor(self, *args, **kwargs) -> BaseInstrumentor | None:
         if not is_package_installed("skyvern"):
@@ -353,6 +363,7 @@ class SkyvernInstrumentorInitializer(InstrumentorInitializer):
         from ..opentelemetry.instrumentation.skyvern import SkyvernInstrumentor
 
         return SkyvernInstrumentor()
+
 
 class TogetherInstrumentorInitializer(InstrumentorInitializer):
     def init_instrumentor(self, *args, **kwargs) -> BaseInstrumentor | None:

--- a/src/lmnr/opentelemetry_lib/tracing/instruments.py
+++ b/src/lmnr/opentelemetry_lib/tracing/instruments.py
@@ -34,6 +34,11 @@ class Instruments(Enum):
     MISTRAL = "mistral"
     OLLAMA = "ollama"
     OPENAI = "openai"
+    # Patch OpenTelemetry to fix DataDog's broken Span context
+    # See lmnr.opentelemetry_lib.opentelemetry.instrumentation.opentelemetry
+    # for more details.
+    OPENTELEMETRY = "opentelemetry"
+    ###
     PATCHRIGHT = "patchright"
     PINECONE = "pinecone"
     PLAYWRIGHT = "playwright"
@@ -46,6 +51,7 @@ class Instruments(Enum):
     VERTEXAI = "vertexai"
     WATSONX = "watsonx"
     WEAVIATE = "weaviate"
+
 
 INSTRUMENTATION_INITIALIZERS: dict[
     Instruments, initializers.InstrumentorInitializer
@@ -71,6 +77,7 @@ INSTRUMENTATION_INITIALIZERS: dict[
     Instruments.MISTRAL: initializers.MistralInstrumentorInitializer(),
     Instruments.OLLAMA: initializers.OllamaInstrumentorInitializer(),
     Instruments.OPENAI: initializers.OpenAIInstrumentorInitializer(),
+    Instruments.OPENTELEMETRY: initializers.OpenTelemetryInstrumentorInitializer(),
     Instruments.PATCHRIGHT: initializers.PatchrightInstrumentorInitializer(),
     Instruments.PINECONE: initializers.PineconeInstrumentorInitializer(),
     Instruments.PLAYWRIGHT: initializers.PlaywrightInstrumentorInitializer(),

--- a/tests/cassettes/test_openai/test_openai_completion_in_observe.yaml
+++ b/tests/cassettes/test_openai/test_openai_completion_in_observe.yaml
@@ -1,0 +1,108 @@
+interactions:
+- request:
+    body: '{"messages":[{"role":"user","content":"What is the capital of France?"}],"model":"gpt-4.1-nano"}'
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate, zstd
+      connection:
+      - keep-alive
+      content-length:
+      - '96'
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      traceparent:
+      - 00-34160bc869a6c4624285a201dab3f738-9e49c95ecdd2acc1-01
+      user-agent:
+      - OpenAI/Python 1.86.0
+      x-stainless-arch:
+      - arm64
+      x-stainless-async:
+      - 'false'
+      x-stainless-lang:
+      - python
+      x-stainless-os:
+      - MacOS
+      x-stainless-package-version:
+      - 1.86.0
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
+      x-stainless-runtime:
+      - CPython
+      x-stainless-runtime-version:
+      - 3.12.9
+    method: POST
+    uri: https://api.openai.com/v1/chat/completions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAwAAAP//jJJBb9swDIXv/hWCznEQO04T5LgCxbZDVgzdaSgMRqZtbbKoSvTWosh/
+        H2Snsbt1QC8+8OOj36P4nAghdSX3QqoWWHXOpB8ePj0dPn/svvymu5tvV4/6gIdjfn1oHm7NV7mI
+        Cjr+QMUvqqWizhlkTXbEyiMwxqnZdpPtVpur3XYAHVVooqxxnBbLLLVgKc1X+SZdFWlWnOUtaYVB
+        7sX3RAghnodvNGorfJR7sVq8VDoMARqU+0uTENKTiRUJIejAYFkuJqjIMtrB+12LQoHTDEZQLW48
+        WIVCB3ELXoflXOWx7gNE67Y3ZgbAWmKI0Qe/92dyujg01DhPx/CXVNba6tCWHiGQjW4Ck5MDPSVC
+        3A+b6F+Fk85T57hk+onD77JiHCenB5jg9syYGMxUzrPFG8PKChm0CbNFSgWqxWpSTluHvtI0A8ks
+        8r9e3po9xta2ec/4CSiFjrEqncdKq9d5pzaP8Tr/13ZZ8WBYBvS/tMKSNfr4DBXW0JvxZGR4Coxd
+        WWvboHdej3dTu3K9WxdryOtdLZNT8gcAAP//AwBYzAvhRgMAAA==
+    headers:
+      CF-RAY:
+      - 95af2d271cef6377-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json
+      Date:
+      - Sun, 06 Jul 2025 12:41:27 GMT
+      Server:
+      - cloudflare
+      Set-Cookie:
+      - __cf_bm=Rps4D0_CxY9ZfQLaafs180xOC.Qi90Tm0CA83sm_R.A-1751805687-1.0.1.1-sN3.KvnW7qppduuWyqPuCjwVSRRbN8pxTDpNh5e3AN9sdHFcxJfD79n5Nvwbo7BOIKB1Oox_ucmb0qdCtcc3SDHx.Eu.H8HmOBxr1ktogHw;
+        path=/; expires=Sun, 06-Jul-25 13:11:27 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=yhuush7cCpNKZk7WfhWPLtlSc.CJemtYN9324.Qj7A8-1751805687528-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      access-control-expose-headers:
+      - X-Request-ID
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - user-xzaeeoqlanzncr8pomspsknu
+      openai-processing-ms:
+      - '197'
+      openai-version:
+      - '2020-10-01'
+      strict-transport-security:
+      - max-age=31536000; includeSubDomains; preload
+      x-envoy-upstream-service-time:
+      - '203'
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999990'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_692be25f493f883ca64ff42da365aa4a
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_non_standard_span.py
+++ b/tests/test_non_standard_span.py
@@ -1,0 +1,147 @@
+"""
+This test primarily tests our patching of the OpenTelemetry context to fix
+DataDog's broken Span context.
+
+See lmnr.opentelemetry_lib.opentelemetry.instrumentation.opentelemetry
+for more details.
+"""
+
+import asyncio
+import pytest
+import time
+import uuid
+
+from opentelemetry import trace, context
+from opentelemetry.trace import SpanContext, NonRecordingSpan
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from lmnr import Laminar, observe
+
+
+SPAN_ID = 369
+
+
+class MyBrokenSpanContext(SpanContext):
+    @property
+    def trace_flags(self) -> int:
+        return 1
+
+
+def test_broken_span(exporter: InMemorySpanExporter):
+    with Laminar.start_as_current_span("outer"):
+        trace_id = trace.get_current_span().get_span_context().trace_id
+        span = NonRecordingSpan(MyBrokenSpanContext(trace_id, SPAN_ID, False))
+        ctx = trace.set_span_in_context(span, context.get_current())
+        ctx_token = context.attach(ctx)
+
+        with Laminar.start_as_current_span("inner"):
+            pass
+        pass
+
+    span.end()
+    time.sleep(0.5)
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+    inner_span = [span for span in spans if span.name == "inner"][0]
+    outer_span = [span for span in spans if span.name == "outer"][0]
+    assert outer_span.name == "outer"
+    assert outer_span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert outer_span.attributes["lmnr.span.path"] == ("outer",)
+    assert outer_span.attributes["lmnr.span.ids_path"] == (
+        str(uuid.UUID(int=outer_span.get_span_context().span_id)),
+    )
+
+    assert (
+        inner_span.get_span_context().trace_id == outer_span.get_span_context().trace_id
+    )
+
+    context.detach(ctx_token)
+
+
+def test_broken_span_observe(exporter: InMemorySpanExporter):
+    @observe()
+    def test():
+        return 1
+
+    @observe()
+    def outer():
+        trace_id = trace.get_current_span().get_span_context().trace_id
+        span = NonRecordingSpan(MyBrokenSpanContext(trace_id, SPAN_ID, False))
+        ctx = trace.set_span_in_context(span, context.get_current())
+        context.attach(ctx)
+
+        result = test()
+        return result
+
+    result = outer()
+    time.sleep(0.5)
+    assert result == 1
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+    inner_span = [span for span in spans if span.name == "test"][0]
+    outer_span = [span for span in spans if span.name == "outer"][0]
+    assert inner_span.name == "test"
+    assert inner_span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert inner_span.attributes["lmnr.span.path"] == ("test",)
+    assert inner_span.attributes["lmnr.span.ids_path"] == (
+        str(uuid.UUID(int=inner_span.get_span_context().span_id)),
+    )
+    assert inner_span.parent.span_id == SPAN_ID
+    assert inner_span.parent.trace_flags.sampled
+
+    assert outer_span.name == "outer"
+    assert outer_span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert outer_span.attributes["lmnr.span.path"] == ("outer",)
+    assert outer_span.attributes["lmnr.span.ids_path"] == (
+        str(uuid.UUID(int=outer_span.get_span_context().span_id)),
+    )
+
+    assert (
+        inner_span.get_span_context().trace_id == outer_span.get_span_context().trace_id
+    )
+
+
+@pytest.mark.asyncio
+async def test_broken_span_observe_async(exporter: InMemorySpanExporter):
+    @observe()
+    async def test():
+        return 1
+
+    @observe()
+    async def outer():
+        trace_id = trace.get_current_span().get_span_context().trace_id
+        span = NonRecordingSpan(MyBrokenSpanContext(trace_id, SPAN_ID, False))
+        ctx = trace.set_span_in_context(span, context.get_current())
+        context.attach(ctx)
+
+        result = await test()
+        return result
+
+    result = await outer()
+    await asyncio.sleep(0.5)
+    assert result == 1
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+    inner_span = [span for span in spans if span.name == "test"][0]
+    outer_span = [span for span in spans if span.name == "outer"][0]
+    assert inner_span.name == "test"
+    assert inner_span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert inner_span.attributes["lmnr.span.path"] == ("test",)
+    assert inner_span.attributes["lmnr.span.ids_path"] == (
+        str(uuid.UUID(int=inner_span.get_span_context().span_id)),
+    )
+    assert inner_span.parent.span_id == SPAN_ID
+    assert inner_span.parent.trace_flags.sampled
+
+    assert outer_span.name == "outer"
+    assert outer_span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert outer_span.attributes["lmnr.span.path"] == ("outer",)
+    assert outer_span.attributes["lmnr.span.ids_path"] == (
+        str(uuid.UUID(int=outer_span.get_span_context().span_id)),
+    )
+
+    assert (
+        inner_span.get_span_context().trace_id == outer_span.get_span_context().trace_id
+    )

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -282,3 +282,233 @@ def test_observe_tags_invalid_type(exporter: InMemorySpanExporter):
     assert span.attributes.get("lmnr.association.properties.tags") is None
     assert span.attributes["lmnr.span.instrumentation_source"] == "python"
     assert span.attributes["lmnr.span.path"] == ("observed_foo",)
+
+
+@pytest.mark.asyncio
+async def test_observe_sequential_spans_async(exporter: InMemorySpanExporter):
+    @observe()
+    async def observed_foo():
+        return "foo"
+
+    @observe()
+    async def observed_bar():
+        return "bar"
+
+    await observed_foo()
+    await observed_bar()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+
+    foo_span = [span for span in spans if span.name == "observed_foo"][0]
+    bar_span = [span for span in spans if span.name == "observed_bar"][0]
+
+    assert foo_span.parent is None or foo_span.parent.span_id == 0
+    assert bar_span.parent is None or bar_span.parent.span_id == 0
+
+    assert foo_span.get_span_context().trace_id != bar_span.get_span_context().trace_id
+
+
+@pytest.mark.asyncio
+async def test_observe_name_async(exporter: InMemorySpanExporter):
+    @observe(name="custom_name")
+    async def observed_foo(x, y, z, **kwargs):
+        return "foo"
+
+    result = await observed_foo("arg", "arg2", "arg3", a=1, b=2, c=3)
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].name == "custom_name"
+    assert result == "foo"
+    assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
+    assert spans[0].attributes["lmnr.span.path"] == ("custom_name",)
+
+
+@pytest.mark.asyncio
+async def test_observe_session_id_async(exporter: InMemorySpanExporter):
+    @observe(session_id="123")
+    async def observed_foo(x, y, z, **kwargs):
+        return "foo"
+
+    result = await observed_foo("arg", "arg2", "arg3", a=1, b=2, c=3)
+    spans = exporter.get_finished_spans()
+    assert result == "foo"
+    assert len(spans) == 1
+    assert spans[0].attributes["lmnr.association.properties.session_id"] == "123"
+    assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
+    assert spans[0].attributes["lmnr.span.path"] == ("observed_foo",)
+
+
+@pytest.mark.asyncio
+async def test_observe_user_id_async(exporter: InMemorySpanExporter):
+    @observe(user_id="123")
+    async def observed_foo(x, y, z, **kwargs):
+        return "foo"
+
+    result = await observed_foo("arg", "arg2", "arg3", a=1, b=2, c=3)
+    spans = exporter.get_finished_spans()
+    assert result == "foo"
+    assert len(spans) == 1
+    assert spans[0].attributes["lmnr.association.properties.user_id"] == "123"
+    assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
+    assert spans[0].attributes["lmnr.span.path"] == ("observed_foo",)
+
+
+@pytest.mark.asyncio
+async def test_observe_metadata_async(exporter: InMemorySpanExporter):
+    @observe(metadata={"key": "value", "nested": {"key2": "value2"}})
+    async def observed_foo(x, y, z, **kwargs):
+        return "foo"
+
+    result = await observed_foo("arg", "arg2", "arg3", a=1, b=2, c=3)
+    spans = exporter.get_finished_spans()
+    assert result == "foo"
+    assert len(spans) == 1
+    assert spans[0].attributes["lmnr.association.properties.metadata.key"] == "value"
+    assert json.loads(
+        spans[0].attributes["lmnr.association.properties.metadata.nested"]
+    ) == {"key2": "value2"}
+    assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
+    assert spans[0].attributes["lmnr.span.path"] == ("observed_foo",)
+
+
+@pytest.mark.asyncio
+async def test_observe_exception_with_session_id_and_name_async(
+    exporter: InMemorySpanExporter,
+):
+    @observe(session_id="123", name="custom_name")
+    async def observed_foo():
+        raise ValueError("test")
+
+    with pytest.raises(ValueError):
+        await observed_foo()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert spans[0].attributes["lmnr.association.properties.session_id"] == "123"
+    assert spans[0].name == "custom_name"
+    assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
+    assert spans[0].attributes["lmnr.span.path"] == ("custom_name",)
+
+    events = spans[0].events
+    assert len(events) == 1
+    assert events[0].name == "exception"
+    assert events[0].attributes["exception.type"] == "ValueError"
+    assert events[0].attributes["exception.message"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_observe_nested_async(exporter: InMemorySpanExporter):
+    @observe()
+    async def observed_bar():
+        return "bar"
+
+    @observe(session_id="123")
+    async def observed_foo():
+        return await observed_bar()
+
+    result = await observed_foo()
+    spans = exporter.get_finished_spans()
+
+    assert result == "bar"
+    assert len(spans) == 2
+
+    foo_span = [span for span in spans if span.name == "observed_foo"][0]
+    bar_span = [span for span in spans if span.name == "observed_bar"][0]
+    assert foo_span.parent is None or foo_span.parent.span_id == 0
+    assert bar_span.parent.span_id == foo_span.context.span_id
+    assert foo_span.context.trace_id == bar_span.context.trace_id
+
+    assert foo_span.attributes["lmnr.association.properties.session_id"] == "123"
+
+    assert foo_span.attributes["lmnr.span.input"] == json.dumps({})
+    assert foo_span.attributes["lmnr.span.path"] == ("observed_foo",)
+    assert bar_span.attributes["lmnr.span.input"] == json.dumps({})
+    assert bar_span.attributes["lmnr.span.path"] == ("observed_foo", "observed_bar")
+
+    assert foo_span.attributes["lmnr.span.output"] == json.dumps("bar")
+    assert bar_span.attributes["lmnr.span.output"] == json.dumps("bar")
+
+    assert foo_span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert bar_span.attributes["lmnr.span.instrumentation_source"] == "python"
+
+
+@pytest.mark.asyncio
+async def test_observe_skip_input_keys_with_kwargs_async(
+    exporter: InMemorySpanExporter,
+):
+    @observe(ignore_inputs=["a", "d"])
+    async def observed_foo(a, b, c, **kwargs):
+        return "foo"
+
+    result = await observed_foo(1, 2, 3, d=4, e=5, f=6)
+    spans = exporter.get_finished_spans()
+    assert result == "foo"
+    assert len(spans) == 1
+    assert spans[0].name == "observed_foo"
+    assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
+    assert spans[0].attributes["lmnr.span.path"] == ("observed_foo",)
+    assert json.loads(spans[0].attributes["lmnr.span.input"]) == {
+        "b": 2,
+        "c": 3,
+        "e": 5,
+        "f": 6,
+    }
+
+
+@pytest.mark.asyncio
+async def test_observe_tags_async(exporter: InMemorySpanExporter):
+    @observe(tags=["foo", "bar"])
+    async def observed_foo(x, y, z, **kwargs):
+        return "foo"
+
+    result = await observed_foo("arg", "arg2", "arg3", a=1, b=2, c=3)
+    spans = exporter.get_finished_spans()
+    assert result == "foo"
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.attributes["lmnr.association.properties.tags"] == ("foo", "bar")
+    assert span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert span.attributes["lmnr.span.path"] == ("observed_foo",)
+
+
+@pytest.mark.asyncio
+async def test_observe_tags_invalid_type_async(exporter: InMemorySpanExporter):
+    @observe(tags=["foo", "bar", 1])
+    async def observed_foo(x, y, z, **kwargs):
+        return "foo"
+
+    result = await observed_foo("arg", "arg2", "arg3", a=1, b=2, c=3)
+    spans = exporter.get_finished_spans()
+    assert result == "foo"
+    assert len(spans) == 1
+    span = spans[0]
+
+    assert span.attributes.get("lmnr.association.properties.tags") is None
+    assert span.attributes["lmnr.span.instrumentation_source"] == "python"
+    assert span.attributes["lmnr.span.path"] == ("observed_foo",)
+
+
+def test_observe_sequential_spans(exporter: InMemorySpanExporter):
+    @observe()
+    def observed_foo():
+        return "foo"
+
+    @observe()
+    def observed_bar():
+        return "bar"
+
+    observed_foo()
+    observed_bar()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+
+    foo_span = [span for span in spans if span.name == "observed_foo"][0]
+    bar_span = [span for span in spans if span.name == "observed_bar"][0]
+
+    assert foo_span.parent is None or foo_span.parent.span_id == 0
+    assert bar_span.parent is None or bar_span.parent.span_id == 0
+
+    assert foo_span.get_span_context().trace_id != bar_span.get_span_context().trace_id

--- a/tests/test_observe_concurrency.py
+++ b/tests/test_observe_concurrency.py
@@ -1,0 +1,488 @@
+import asyncio
+import concurrent.futures
+import pytest
+import threading
+import time
+
+from lmnr import observe
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+# =============================================================================
+# ASYNCIO CONCURRENCY TESTS
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_asyncio_parallel_spans_separate_traces(exporter: InMemorySpanExporter):
+    """Test multiple parallel async spans live in separate traces."""
+
+    @observe()
+    async def task_a():
+        await asyncio.sleep(0.01)
+        return "task_a"
+
+    @observe()
+    async def task_b():
+        await asyncio.sleep(0.01)
+        return "task_b"
+
+    @observe()
+    async def task_c():
+        await asyncio.sleep(0.01)
+        return "task_c"
+
+    # Run tasks concurrently
+    results = await asyncio.gather(task_a(), task_b(), task_c())
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+    assert set(results) == {"task_a", "task_b", "task_c"}
+
+    # Check all spans have different trace IDs (separate traces)
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # Check no span has a parent (all are root spans)
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+
+@pytest.mark.asyncio
+async def test_asyncio_parallel_spans_same_parent(exporter: InMemorySpanExporter):
+    """Test multiple parallel async spans within one parent share the same trace."""
+
+    @observe()
+    async def child_task(task_id: str):
+        await asyncio.sleep(0.01)
+        return f"child_{task_id}"
+
+    @observe(session_id="parent_session")
+    async def parent_task():
+        # Run child tasks concurrently within the parent context
+        results = await asyncio.gather(
+            child_task("a"), child_task("b"), child_task("c")
+        )
+        return results
+
+    result = await parent_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 4  # 1 parent + 3 children
+    assert result == ["child_a", "child_b", "child_c"]
+
+    # Find parent and child spans
+    parent_span = [s for s in spans if s.name == "parent_task"][0]
+    child_spans = [s for s in spans if s.name == "child_task"]
+
+    assert len(child_spans) == 3
+    assert (
+        parent_span.attributes["lmnr.association.properties.session_id"]
+        == "parent_session"
+    )
+
+    # Check all spans share the same trace ID
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1, "All spans should share the same trace ID"
+
+    # Check all child spans have the parent as their parent
+    for child_span in child_spans:
+        assert child_span.parent.span_id == parent_span.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_asyncio_deeply_nested_with_parallelism(exporter: InMemorySpanExporter):
+    """Test deeply nested async spans with some parallelism."""
+
+    @observe()
+    async def leaf_task(task_id: str):
+        await asyncio.sleep(0.01)
+        return f"leaf_{task_id}"
+
+    @observe()
+    async def branch_task(branch_id: str):
+        # Each branch runs some leaf tasks in parallel
+        results = await asyncio.gather(
+            leaf_task(f"{branch_id}_1"), leaf_task(f"{branch_id}_2")
+        )
+        return results
+
+    @observe(session_id="root_session")
+    async def root_task():
+        # Run multiple branches in parallel
+        results = await asyncio.gather(branch_task("branch_a"), branch_task("branch_b"))
+        return results
+
+    await root_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 7  # 1 root + 2 branches + 4 leaves
+
+    # Find spans by name
+    root_span = [s for s in spans if s.name == "root_task"][0]
+    branch_spans = [s for s in spans if s.name == "branch_task"]
+    leaf_spans = [s for s in spans if s.name == "leaf_task"]
+
+    assert len(branch_spans) == 2
+    assert len(leaf_spans) == 4
+
+    # All spans should be in the same trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1
+
+    # Check hierarchy
+    for branch_span in branch_spans:
+        assert branch_span.parent.span_id == root_span.context.span_id
+
+    # Each leaf should have a branch as parent
+    for leaf_span in leaf_spans:
+        assert leaf_span.parent.span_id in [b.context.span_id for b in branch_spans]
+
+
+# =============================================================================
+# THREADING.THREAD CONCURRENCY TESTS
+# =============================================================================
+
+
+def test_threading_parallel_spans_separate_traces(exporter: InMemorySpanExporter):
+    """Test multiple parallel thread spans live in separate traces."""
+
+    results = []
+
+    @observe()
+    def task_worker(task_id: str):
+        time.sleep(0.01)
+        result = f"task_{task_id}"
+        results.append(result)
+        return result
+
+    # Create and start threads
+    threads = []
+    for i in range(3):
+        thread = threading.Thread(target=task_worker, args=(str(i),))
+        threads.append(thread)
+        thread.start()
+
+    # Wait for all threads to complete
+    for thread in threads:
+        thread.join()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+    assert len(results) == 3
+
+    # Check all spans have different trace IDs (separate traces)
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # Check no span has a parent (all are root spans)
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+
+def test_threading_parallel_spans_same_parent(exporter: InMemorySpanExporter):
+    """Test multiple parallel thread spans within one parent share the same trace."""
+
+    child_results = []
+
+    @observe()
+    def child_worker(task_id: str):
+        time.sleep(0.01)
+        result = f"child_{task_id}"
+        child_results.append(result)
+        return result
+
+    @observe(session_id="parent_session")
+    def parent_task():
+        # Create child threads within parent context
+        threads = []
+        for i in range(3):
+            thread = threading.Thread(target=child_worker, args=(str(i),))
+            threads.append(thread)
+            thread.start()
+
+        # Wait for all threads
+        for thread in threads:
+            thread.join()
+
+        return child_results
+
+    parent_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 4  # 1 parent + 3 children
+    assert len(child_results) == 3
+
+    # Find parent and child spans
+    parent_span = [s for s in spans if s.name == "parent_task"][0]
+    child_spans = [s for s in spans if s.name == "child_worker"]
+
+    assert len(child_spans) == 3
+    assert (
+        parent_span.attributes["lmnr.association.properties.session_id"]
+        == "parent_session"
+    )
+
+    # Check all spans share the same trace ID
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1, "All spans should share the same trace ID"
+
+    # Check all child spans have the parent as their parent
+    for child_span in child_spans:
+        assert child_span.parent.span_id == parent_span.context.span_id
+
+
+def test_threading_deeply_nested_with_parallelism(exporter: InMemorySpanExporter):
+    """Test deeply nested thread spans with some parallelism."""
+
+    leaf_results = []
+
+    @observe()
+    def leaf_worker(task_id: str):
+        time.sleep(0.01)
+        result = f"leaf_{task_id}"
+        leaf_results.append(result)
+        return result
+
+    @observe()
+    def branch_worker(branch_id: str):
+        # Each branch creates leaf threads
+        threads = []
+        for i in range(2):
+            thread = threading.Thread(target=leaf_worker, args=(f"{branch_id}_{i}",))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        return f"branch_{branch_id}"
+
+    @observe(session_id="root_session")
+    def root_task():
+        # Create branch threads
+        threads = []
+        for i in range(2):
+            thread = threading.Thread(target=branch_worker, args=(str(i),))
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        return "root_done"
+
+    root_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 7  # 1 root + 2 branches + 4 leaves
+
+    # Find spans by name
+    root_span = [s for s in spans if s.name == "root_task"][0]
+    branch_spans = [s for s in spans if s.name == "branch_worker"]
+    leaf_spans = [s for s in spans if s.name == "leaf_worker"]
+
+    assert len(branch_spans) == 2
+    assert len(leaf_spans) == 4
+
+    # All spans should be in the same trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1
+
+    # Check hierarchy
+    for branch_span in branch_spans:
+        assert branch_span.parent.span_id == root_span.context.span_id
+
+    # Each leaf should have a branch as parent
+    for leaf_span in leaf_spans:
+        assert leaf_span.parent.span_id in [b.context.span_id for b in branch_spans]
+
+
+# =============================================================================
+# THREADPOOLEXECUTOR CONCURRENCY TESTS
+# =============================================================================
+
+
+def test_threadpool_parallel_spans_separate_traces(exporter: InMemorySpanExporter):
+    """Test multiple parallel ThreadPoolExecutor spans live in separate traces."""
+
+    @observe()
+    def task_worker(task_id: str):
+        time.sleep(0.01)
+        return f"task_{task_id}"
+
+    # Use ThreadPoolExecutor to run tasks
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [executor.submit(task_worker, str(i)) for i in range(3)]
+        results = [
+            future.result() for future in concurrent.futures.as_completed(futures)
+        ]
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+    assert len(results) == 3
+
+    # Check all spans have different trace IDs (separate traces)
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # Check no span has a parent (all are root spans)
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+
+def test_threadpool_parallel_spans_same_parent(exporter: InMemorySpanExporter):
+    """Test multiple parallel ThreadPoolExecutor spans within one parent share the same trace."""
+
+    @observe()
+    def child_worker(task_id: str):
+        time.sleep(0.01)
+        return f"child_{task_id}"
+
+    @observe(session_id="parent_session")
+    def parent_task():
+        # Use ThreadPoolExecutor within parent context
+        with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+            futures = [executor.submit(child_worker, str(i)) for i in range(3)]
+            results = [
+                future.result() for future in concurrent.futures.as_completed(futures)
+            ]
+        return results
+
+    result = parent_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 4  # 1 parent + 3 children
+    assert len(result) == 3
+
+    # Find parent and child spans
+    parent_span = [s for s in spans if s.name == "parent_task"][0]
+    child_spans = [s for s in spans if s.name == "child_worker"]
+
+    assert len(child_spans) == 3
+    assert (
+        parent_span.attributes["lmnr.association.properties.session_id"]
+        == "parent_session"
+    )
+
+    # Check all spans share the same trace ID
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1, "All spans should share the same trace ID"
+
+    # Check all child spans have the parent as their parent
+    for child_span in child_spans:
+        assert child_span.parent.span_id == parent_span.context.span_id
+
+
+def test_threadpool_deeply_nested_with_parallelism(exporter: InMemorySpanExporter):
+    """Test deeply nested ThreadPoolExecutor spans with some parallelism."""
+
+    @observe()
+    def leaf_worker(task_id: str):
+        time.sleep(0.01)
+        return f"leaf_{task_id}"
+
+    @observe()
+    def branch_worker(branch_id: str):
+        # Each branch uses ThreadPoolExecutor for leaf tasks
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [
+                executor.submit(leaf_worker, f"{branch_id}_{i}") for i in range(2)
+            ]
+            results = [
+                future.result() for future in concurrent.futures.as_completed(futures)
+            ]
+        return results
+
+    @observe(session_id="root_session")
+    def root_task():
+        # Use ThreadPoolExecutor for branch tasks
+        with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+            futures = [executor.submit(branch_worker, str(i)) for i in range(2)]
+            results = [
+                future.result() for future in concurrent.futures.as_completed(futures)
+            ]
+        return results
+
+    root_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 7  # 1 root + 2 branches + 4 leaves
+
+    # Find spans by name
+    root_span = [s for s in spans if s.name == "root_task"][0]
+    branch_spans = [s for s in spans if s.name == "branch_worker"]
+    leaf_spans = [s for s in spans if s.name == "leaf_worker"]
+
+    assert len(branch_spans) == 2
+    assert len(leaf_spans) == 4
+
+    # All spans should be in the same trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1
+
+    # Check hierarchy
+    for branch_span in branch_spans:
+        assert branch_span.parent.span_id == root_span.context.span_id
+
+    # Each leaf should have a branch as parent
+    for leaf_span in leaf_spans:
+        assert leaf_span.parent.span_id in [b.context.span_id for b in branch_spans]
+
+
+# =============================================================================
+# MIXED CONCURRENCY TESTS
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_mixed_concurrency_isolation(exporter: InMemorySpanExporter):
+    """Test that different concurrency models don't interfere with each other."""
+
+    async_result = []
+    thread_result = []
+
+    @observe()
+    async def async_task():
+        await asyncio.sleep(0.01)
+        async_result.append("async_done")
+        return "async_task"
+
+    @observe()
+    def thread_task():
+        time.sleep(0.01)
+        thread_result.append("thread_done")
+        return "thread_task"
+
+    @observe()
+    def threadpool_task():
+        time.sleep(0.01)
+        return "threadpool_task"
+
+    # Run different concurrency models simultaneously
+    async_future = asyncio.create_task(async_task())
+
+    thread = threading.Thread(target=thread_task)
+    thread.start()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        threadpool_future = executor.submit(threadpool_task)
+        threadpool_future.result()
+
+    await async_future
+    thread.join()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+
+    # Each should be in a separate trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # All should be root spans
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+    # Check span names
+    span_names = {span.name for span in spans}
+    assert span_names == {"async_task", "thread_task", "threadpool_task"}

--- a/tests/test_openai.py
+++ b/tests/test_openai.py
@@ -1,5 +1,6 @@
 import pytest
 
+from lmnr import observe
 from openai import OpenAI
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 
@@ -20,3 +21,35 @@ def test_openai_completion(exporter: InMemorySpanExporter):
     assert spans[0].attributes["gen_ai.request.model"] == "gpt-4.1-nano"
     assert spans[0].name == "openai.chat"
     assert spans[0].attributes["lmnr.span.path"] == ("openai.chat",)
+
+
+@pytest.mark.vcr
+def test_openai_completion_in_observe(exporter: InMemorySpanExporter):
+    # The actual key was used during recording and the request/response was saved
+    # to the VCR cassette.
+    client = OpenAI(api_key="test-123")
+
+    @observe()
+    def foo():
+        return client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[{"role": "user", "content": "What is the capital of France?"}],
+        )
+
+    foo()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 2
+    openai_span = [span for span in spans if span.name == "openai.chat"][0]
+    outer_span = [span for span in spans if span.name == "foo"][0]
+    assert openai_span.name == "openai.chat"
+    assert openai_span.attributes["gen_ai.request.model"] == "gpt-4.1-nano"
+    assert openai_span.name == "openai.chat"
+    assert openai_span.attributes["lmnr.span.path"] == (
+        "foo",
+        "openai.chat",
+    )
+
+    assert outer_span.parent is None or outer_span.parent.span_id == 0
+    assert openai_span.parent.span_id == outer_span.get_span_context().span_id
+    assert openai_span.parent.trace_id == outer_span.get_span_context().trace_id

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -301,6 +301,12 @@ def test_metadata_does_not_leak(exporter: InMemorySpanExporter):
     assert with_metadata_span.attributes["lmnr.span.instrumentation_source"] == "python"
     assert no_metadata_span.attributes["lmnr.span.instrumentation_source"] == "python"
     assert no_metadata_span.attributes["lmnr.span.path"] == ("no_metadata",)
+    assert with_metadata_span.parent is None or with_metadata_span.parent.span_id == 0
+    assert no_metadata_span.parent is None or no_metadata_span.parent.span_id == 0
+    assert (
+        with_metadata_span.get_span_context().trace_id
+        != no_metadata_span.get_span_context().trace_id
+    )
 
 
 def test_tags(exporter: InMemorySpanExporter):

--- a/tests/test_tracing_concurrency.py
+++ b/tests/test_tracing_concurrency.py
@@ -1,0 +1,531 @@
+import asyncio
+import concurrent.futures
+import pytest
+import threading
+import time
+
+from lmnr import Laminar
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+
+# =============================================================================
+# ASYNCIO CONCURRENCY TESTS
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_asyncio_parallel_spans_separate_traces(exporter: InMemorySpanExporter):
+    """Test multiple parallel async spans live in separate traces."""
+
+    async def task_a():
+        with Laminar.start_as_current_span("task_a"):
+            await asyncio.sleep(0.01)
+            Laminar.set_span_output("task_a")
+            return "task_a"
+
+    async def task_b():
+        with Laminar.start_as_current_span("task_b"):
+            await asyncio.sleep(0.01)
+            Laminar.set_span_output("task_b")
+            return "task_b"
+
+    async def task_c():
+        with Laminar.start_as_current_span("task_c"):
+            await asyncio.sleep(0.01)
+            Laminar.set_span_output("task_c")
+            return "task_c"
+
+    # Run tasks concurrently
+    results = await asyncio.gather(task_a(), task_b(), task_c())
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+    assert set(results) == {"task_a", "task_b", "task_c"}
+
+    # Check all spans have different trace IDs (separate traces)
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # Check no span has a parent (all are root spans)
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+
+@pytest.mark.asyncio
+async def test_asyncio_parallel_spans_same_parent(exporter: InMemorySpanExporter):
+    """Test multiple parallel async spans within one parent share the same trace."""
+
+    async def child_task(task_id: str):
+        with Laminar.start_as_current_span("child_task"):
+            await asyncio.sleep(0.01)
+            result = f"child_{task_id}"
+            Laminar.set_span_output(result)
+            return result
+
+    async def parent_task():
+        with Laminar.start_as_current_span("parent_task"):
+            Laminar.set_trace_session_id("parent_session")
+            # Run child tasks concurrently within the parent context
+            results = await asyncio.gather(
+                child_task("a"), child_task("b"), child_task("c")
+            )
+            Laminar.set_span_output(results)
+            return results
+
+    result = await parent_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 4  # 1 parent + 3 children
+    assert result == ["child_a", "child_b", "child_c"]
+
+    # Find parent and child spans
+    parent_span = [s for s in spans if s.name == "parent_task"][0]
+    child_spans = [s for s in spans if s.name == "child_task"]
+
+    assert len(child_spans) == 3
+    assert (
+        parent_span.attributes["lmnr.association.properties.session_id"]
+        == "parent_session"
+    )
+
+    # Check all spans share the same trace ID
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1, "All spans should share the same trace ID"
+
+    # Check all child spans have the parent as their parent
+    for child_span in child_spans:
+        assert child_span.parent.span_id == parent_span.context.span_id
+
+
+@pytest.mark.asyncio
+async def test_asyncio_deeply_nested_with_parallelism(exporter: InMemorySpanExporter):
+    """Test deeply nested async spans with some parallelism."""
+
+    async def leaf_task(task_id: str):
+        with Laminar.start_as_current_span("leaf_task"):
+            await asyncio.sleep(0.01)
+            result = f"leaf_{task_id}"
+            Laminar.set_span_output(result)
+            return result
+
+    async def branch_task(branch_id: str):
+        with Laminar.start_as_current_span("branch_task"):
+            # Each branch runs some leaf tasks in parallel
+            results = await asyncio.gather(
+                leaf_task(f"{branch_id}_1"), leaf_task(f"{branch_id}_2")
+            )
+            Laminar.set_span_output(results)
+            return results
+
+    async def root_task():
+        with Laminar.start_as_current_span("root_task"):
+            Laminar.set_trace_session_id("root_session")
+            # Run multiple branches in parallel
+            results = await asyncio.gather(
+                branch_task("branch_a"), branch_task("branch_b")
+            )
+            Laminar.set_span_output(results)
+            return results
+
+    await root_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 7  # 1 root + 2 branches + 4 leaves
+
+    # Find spans by name
+    root_span = [s for s in spans if s.name == "root_task"][0]
+    branch_spans = [s for s in spans if s.name == "branch_task"]
+    leaf_spans = [s for s in spans if s.name == "leaf_task"]
+
+    assert len(branch_spans) == 2
+    assert len(leaf_spans) == 4
+
+    # All spans should be in the same trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1
+
+    # Check hierarchy
+    for branch_span in branch_spans:
+        assert branch_span.parent.span_id == root_span.context.span_id
+
+    # Each leaf should have a branch as parent
+    for leaf_span in leaf_spans:
+        assert leaf_span.parent.span_id in [b.context.span_id for b in branch_spans]
+
+
+# =============================================================================
+# THREADING.THREAD CONCURRENCY TESTS
+# =============================================================================
+
+
+def test_threading_parallel_spans_separate_traces(exporter: InMemorySpanExporter):
+    """Test multiple parallel thread spans live in separate traces."""
+
+    results = []
+
+    def task_worker(task_id: str):
+        with Laminar.start_as_current_span("task_worker"):
+            time.sleep(0.01)
+            result = f"task_{task_id}"
+            results.append(result)
+            Laminar.set_span_output(result)
+            return result
+
+    # Create and start threads
+    threads = []
+    for i in range(3):
+        thread = threading.Thread(target=task_worker, args=(str(i),))
+        threads.append(thread)
+        thread.start()
+
+    # Wait for all threads to complete
+    for thread in threads:
+        thread.join()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+    assert len(results) == 3
+
+    # Check all spans have different trace IDs (separate traces)
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # Check no span has a parent (all are root spans)
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+
+def test_threading_parallel_spans_same_parent(exporter: InMemorySpanExporter):
+    """Test multiple parallel thread spans within one parent share the same trace."""
+
+    child_results = []
+
+    def child_worker(task_id: str):
+        with Laminar.start_as_current_span("child_worker"):
+            time.sleep(0.01)
+            result = f"child_{task_id}"
+            child_results.append(result)
+            Laminar.set_span_output(result)
+            return result
+
+    def parent_task():
+        with Laminar.start_as_current_span("parent_task"):
+            Laminar.set_trace_session_id("parent_session")
+            # Create child threads within parent context
+            threads = []
+            for i in range(3):
+                thread = threading.Thread(target=child_worker, args=(str(i),))
+                threads.append(thread)
+                thread.start()
+
+            # Wait for all threads
+            for thread in threads:
+                thread.join()
+
+            Laminar.set_span_output(child_results)
+            return child_results
+
+    parent_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 4  # 1 parent + 3 children
+    assert len(child_results) == 3
+
+    # Find parent and child spans
+    parent_span = [s for s in spans if s.name == "parent_task"][0]
+    child_spans = [s for s in spans if s.name == "child_worker"]
+
+    assert len(child_spans) == 3
+    assert (
+        parent_span.attributes["lmnr.association.properties.session_id"]
+        == "parent_session"
+    )
+
+    # Check all spans share the same trace ID
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1, "All spans should share the same trace ID"
+
+    # Check all child spans have the parent as their parent
+    for child_span in child_spans:
+        assert child_span.parent.span_id == parent_span.context.span_id
+
+
+def test_threading_deeply_nested_with_parallelism(exporter: InMemorySpanExporter):
+    """Test deeply nested thread spans with some parallelism."""
+
+    leaf_results = []
+
+    def leaf_worker(task_id: str):
+        with Laminar.start_as_current_span("leaf_worker"):
+            time.sleep(0.01)
+            result = f"leaf_{task_id}"
+            leaf_results.append(result)
+            Laminar.set_span_output(result)
+            return result
+
+    def branch_worker(branch_id: str):
+        with Laminar.start_as_current_span("branch_worker"):
+            # Each branch creates leaf threads
+            threads = []
+            for i in range(2):
+                thread = threading.Thread(
+                    target=leaf_worker, args=(f"{branch_id}_{i}",)
+                )
+                threads.append(thread)
+                thread.start()
+
+            for thread in threads:
+                thread.join()
+
+            result = f"branch_{branch_id}"
+            Laminar.set_span_output(result)
+            return result
+
+    def root_task():
+        with Laminar.start_as_current_span("root_task"):
+            Laminar.set_trace_session_id("root_session")
+            # Create branch threads
+            threads = []
+            for i in range(2):
+                thread = threading.Thread(target=branch_worker, args=(str(i),))
+                threads.append(thread)
+                thread.start()
+
+            for thread in threads:
+                thread.join()
+
+            result = "root_done"
+            Laminar.set_span_output(result)
+            return result
+
+    root_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 7  # 1 root + 2 branches + 4 leaves
+
+    # Find spans by name
+    root_span = [s for s in spans if s.name == "root_task"][0]
+    branch_spans = [s for s in spans if s.name == "branch_worker"]
+    leaf_spans = [s for s in spans if s.name == "leaf_worker"]
+
+    assert len(branch_spans) == 2
+    assert len(leaf_spans) == 4
+
+    # All spans should be in the same trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1
+
+    # Check hierarchy
+    for branch_span in branch_spans:
+        assert branch_span.parent.span_id == root_span.context.span_id
+
+    # Each leaf should have a branch as parent
+    for leaf_span in leaf_spans:
+        assert leaf_span.parent.span_id in [b.context.span_id for b in branch_spans]
+
+
+# =============================================================================
+# THREADPOOLEXECUTOR CONCURRENCY TESTS
+# =============================================================================
+
+
+def test_threadpool_parallel_spans_separate_traces(exporter: InMemorySpanExporter):
+    """Test multiple parallel ThreadPoolExecutor spans live in separate traces."""
+
+    def task_worker(task_id: str):
+        with Laminar.start_as_current_span("task_worker"):
+            time.sleep(0.01)
+            result = f"task_{task_id}"
+            Laminar.set_span_output(result)
+            return result
+
+    # Use ThreadPoolExecutor to run tasks
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        futures = [executor.submit(task_worker, str(i)) for i in range(3)]
+        results = [
+            future.result() for future in concurrent.futures.as_completed(futures)
+        ]
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+    assert len(results) == 3
+
+    # Check all spans have different trace IDs (separate traces)
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # Check no span has a parent (all are root spans)
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+
+def test_threadpool_parallel_spans_same_parent(exporter: InMemorySpanExporter):
+    """Test multiple parallel ThreadPoolExecutor spans within one parent share the same trace."""
+
+    def child_worker(task_id: str):
+        with Laminar.start_as_current_span("child_worker"):
+            time.sleep(0.01)
+            result = f"child_{task_id}"
+            Laminar.set_span_output(result)
+            return result
+
+    def parent_task():
+        with Laminar.start_as_current_span("parent_task"):
+            Laminar.set_trace_session_id("parent_session")
+            # Use ThreadPoolExecutor within parent context
+            with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+                futures = [executor.submit(child_worker, str(i)) for i in range(3)]
+                results = [
+                    future.result()
+                    for future in concurrent.futures.as_completed(futures)
+                ]
+            Laminar.set_span_output(results)
+            return results
+
+    result = parent_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 4  # 1 parent + 3 children
+    assert len(result) == 3
+
+    # Find parent and child spans
+    parent_span = [s for s in spans if s.name == "parent_task"][0]
+    child_spans = [s for s in spans if s.name == "child_worker"]
+
+    assert len(child_spans) == 3
+    assert (
+        parent_span.attributes["lmnr.association.properties.session_id"]
+        == "parent_session"
+    )
+
+    # Check all spans share the same trace ID
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1, "All spans should share the same trace ID"
+
+    # Check all child spans have the parent as their parent
+    for child_span in child_spans:
+        assert child_span.parent.span_id == parent_span.context.span_id
+
+
+def test_threadpool_deeply_nested_with_parallelism(exporter: InMemorySpanExporter):
+    """Test deeply nested ThreadPoolExecutor spans with some parallelism."""
+
+    def leaf_worker(task_id: str):
+        with Laminar.start_as_current_span("leaf_worker"):
+            time.sleep(0.01)
+            result = f"leaf_{task_id}"
+            Laminar.set_span_output(result)
+            return result
+
+    def branch_worker(branch_id: str):
+        with Laminar.start_as_current_span("branch_worker"):
+            # Each branch uses ThreadPoolExecutor for leaf tasks
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [
+                    executor.submit(leaf_worker, f"{branch_id}_{i}") for i in range(2)
+                ]
+                results = [
+                    future.result()
+                    for future in concurrent.futures.as_completed(futures)
+                ]
+            Laminar.set_span_output(results)
+            return results
+
+    def root_task():
+        with Laminar.start_as_current_span("root_task"):
+            Laminar.set_trace_session_id("root_session")
+            # Use ThreadPoolExecutor for branch tasks
+            with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+                futures = [executor.submit(branch_worker, str(i)) for i in range(2)]
+                results = [
+                    future.result()
+                    for future in concurrent.futures.as_completed(futures)
+                ]
+            Laminar.set_span_output(results)
+            return results
+
+    root_task()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 7  # 1 root + 2 branches + 4 leaves
+
+    # Find spans by name
+    root_span = [s for s in spans if s.name == "root_task"][0]
+    branch_spans = [s for s in spans if s.name == "branch_worker"]
+    leaf_spans = [s for s in spans if s.name == "leaf_worker"]
+
+    assert len(branch_spans) == 2
+    assert len(leaf_spans) == 4
+
+    # All spans should be in the same trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 1
+
+    # Check hierarchy
+    for branch_span in branch_spans:
+        assert branch_span.parent.span_id == root_span.context.span_id
+
+    # Each leaf should have a branch as parent
+    for leaf_span in leaf_spans:
+        assert leaf_span.parent.span_id in [b.context.span_id for b in branch_spans]
+
+
+# =============================================================================
+# MIXED CONCURRENCY TESTS
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_mixed_concurrency_isolation(exporter: InMemorySpanExporter):
+    """Test that different concurrency models don't interfere with each other."""
+
+    async_result = []
+    thread_result = []
+
+    async def async_task():
+        with Laminar.start_as_current_span("async_task"):
+            await asyncio.sleep(0.01)
+            async_result.append("async_done")
+            Laminar.set_span_output("async_task")
+            return "async_task"
+
+    def thread_task():
+        with Laminar.start_as_current_span("thread_task"):
+            time.sleep(0.01)
+            thread_result.append("thread_done")
+            Laminar.set_span_output("thread_task")
+            return "thread_task"
+
+    def threadpool_task():
+        with Laminar.start_as_current_span("threadpool_task"):
+            time.sleep(0.01)
+            Laminar.set_span_output("threadpool_task")
+            return "threadpool_task"
+
+    # Run different concurrency models simultaneously
+    async_future = asyncio.create_task(async_task())
+
+    thread = threading.Thread(target=thread_task)
+    thread.start()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        threadpool_future = executor.submit(threadpool_task)
+        threadpool_future.result()
+
+    await async_future
+    thread.join()
+
+    spans = exporter.get_finished_spans()
+    assert len(spans) == 3
+
+    # Each should be in a separate trace
+    trace_ids = [span.get_span_context().trace_id for span in spans]
+    assert len(set(trace_ids)) == 3, "All spans should have different trace IDs"
+
+    # All should be root spans
+    for span in spans:
+        assert span.parent is None or span.parent.span_id == 0
+
+    # Check span names
+    span_names = {span.name for span in spans}
+    assert span_names == {"async_task", "thread_task", "threadpool_task"}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Wraps `get_span_context` to fix DataDog trace flags handling, adds `OpentelemetryInstrumentor`, and includes extensive tests for validation.
> 
>   - **Behavior**:
>     - Wraps `get_span_context` in `opentelemetry/instrumentation/opentelemetry/__init__.py` to fix DataDog's handling of trace flags.
>     - Ensures `TraceFlags` are correctly wrapped to prevent sampling errors.
>   - **Instrumentation**:
>     - Adds `OpentelemetryInstrumentor` class in `opentelemetry/instrumentation/opentelemetry/__init__.py`.
>     - Updates `OpenTelemetryInstrumentorInitializer` in `_instrument_initializers.py` to use the new instrumentor.
>     - Adds `OPENTELEMETRY` to `Instruments` enum in `instruments.py`.
>   - **Testing**:
>     - Adds tests in `test_non_standard_span.py` to verify correct span context handling.
>     - Includes concurrency tests in `test_observe_concurrency.py` and `test_tracing_concurrency.py`.
>     - Adds VCR tests for OpenAI integration in `test_openai.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for e8e4741c9808cc31a0c72dd7e5bd8a2b8353efb9. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->