### PR TITLE
Fix/playwright

### DIFF
--- a/src/lmnr/sdk/browser/browser_use_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_otel.py
@@ -19,7 +19,7 @@ except ImportError as e:
         "to install Browser Use or remove this import."
     ) from e
 
-_instruments = ("browser-use >= 0.1.0",)
+_instruments = ("browser-use < 0.5.0",)
 
 WRAPPED_METHODS = [
     {

--- a/src/lmnr/sdk/browser/patchright_otel.py
+++ b/src/lmnr/sdk/browser/patchright_otel.py
@@ -5,8 +5,6 @@ from lmnr.sdk.browser.playwright_otel import (
     _wrap_new_browser_async,
     _wrap_new_context_sync,
     _wrap_new_context_async,
-    _wrap_close_browser_sync,
-    _wrap_close_browser_async,
 )
 from lmnr.sdk.client.synchronous.sync_client import LaminarClient
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
@@ -53,12 +51,6 @@ WRAPPED_METHODS = [
     {
         "package": "patchright.sync_api",
         "object": "Browser",
-        "method": "close",
-        "wrapper": _wrap_close_browser_sync,
-    },
-    {
-        "package": "patchright.sync_api",
-        "object": "Browser",
         "method": "new_context",
         "wrapper": _wrap_new_context_sync,
     },
@@ -100,12 +92,6 @@ WRAPPED_METHODS_ASYNC = [
         "object": "BrowserType",
         "method": "connect_over_cdp",
         "wrapper": _wrap_new_browser_async,
-    },
-    {
-        "package": "patchright.async_api",
-        "object": "Browser",
-        "method": "close",
-        "wrapper": _wrap_close_browser_async,
     },
     {
         "package": "patchright.async_api",

--- a/src/lmnr/sdk/browser/pw_utils.py
+++ b/src/lmnr/sdk/browser/pw_utils.py
@@ -109,9 +109,6 @@ async def send_events_async(
         await client._browser_events.send(session_id, trace_id, events)
     except Exception as e:
         if str(e).startswith("Page.evaluate: Execution context was destroyed"):
-            logger.info(
-                "Execution context was destroyed, injecting session recorder again"
-            )
             await inject_session_recorder_async(page)
             await send_events_async(page, session_id, trace_id, client)
         else:
@@ -120,7 +117,7 @@ async def send_events_async(
                 "Page.evaluate: Target page, context or browser has been closed"
                 not in str(e)
             ):
-                logger.warn(f"Could not send events: {e}")
+                logger.warning(f"Could not send events: {e}")
 
 
 def send_events_sync(
@@ -145,9 +142,6 @@ def send_events_sync(
 
     except Exception as e:
         if str(e).startswith("Page.evaluate: Execution context was destroyed"):
-            logger.info(
-                "Execution context was destroyed, injecting session recorder again"
-            )
             inject_session_recorder_sync(page)
             send_events_sync(page, session_id, trace_id, client)
         else:
@@ -156,7 +150,7 @@ def send_events_sync(
                 "Page.evaluate: Target page, context or browser has been closed"
                 not in str(e)
             ):
-                logger.warn(f"Could not send events: {e}")
+                logger.warning(f"Could not send events: {e}")
 
 
 def inject_session_recorder_sync(page: SyncPage):

--- a/src/lmnr/sdk/browser/pw_utils.py
+++ b/src/lmnr/sdk/browser/pw_utils.py
@@ -11,7 +11,6 @@ from lmnr.sdk.decorators import observe
 from lmnr.sdk.browser.utils import retry_sync, retry_async
 from lmnr.sdk.client.synchronous.sync_client import LaminarClient
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-from lmnr.opentelemetry_lib.tracing import _get_current_context
 
 try:
     if is_package_installed("playwright"):
@@ -222,8 +221,7 @@ async def inject_rrweb_async(page: Page):
 
 @observe(name="playwright.page", ignore_input=True, ignore_output=True)
 def handle_navigation_sync(page: SyncPage, session_id: str, client: LaminarClient):
-    ctx = _get_current_context()
-    span = trace.get_current_span(ctx)
+    span = trace.get_current_span()
     trace_id = format(span.get_span_context().trace_id, "032x")
     span.set_attribute("lmnr.internal.has_browser_session", True)
     original_bring_to_front = page.bring_to_front
@@ -275,8 +273,7 @@ async def handle_navigation_async(
     page: Page, session_id: str, client: AsyncLaminarClient
 ):
 
-    ctx = _get_current_context()
-    span = trace.get_current_span(ctx)
+    span = trace.get_current_span()
     trace_id = format(span.get_span_context().trace_id, "032x")
     span.set_attribute("lmnr.internal.has_browser_session", True)
 

--- a/src/lmnr/sdk/browser/pw_utils.py
+++ b/src/lmnr/sdk/browser/pw_utils.py
@@ -109,11 +109,18 @@ async def send_events_async(
         await client._browser_events.send(session_id, trace_id, events)
     except Exception as e:
         if str(e).startswith("Page.evaluate: Execution context was destroyed"):
-            logger.info("Execution context was destroyed, injecting rrweb again")
-            await inject_rrweb_async(page)
+            logger.info(
+                "Execution context was destroyed, injecting session recorder again"
+            )
+            await inject_session_recorder_async(page)
             await send_events_async(page, session_id, trace_id, client)
         else:
-            logger.debug(f"Could not send events: {e}")
+            # silence the error if the page has been closed, not an issue
+            if (
+                "Page.evaluate: Target page, context or browser has been closed"
+                not in str(e)
+            ):
+                logger.warn(f"Could not send events: {e}")
 
 
 def send_events_sync(
@@ -138,14 +145,21 @@ def send_events_sync(
 
     except Exception as e:
         if str(e).startswith("Page.evaluate: Execution context was destroyed"):
-            logger.info("Execution context was destroyed, injecting rrweb again")
-            inject_rrweb_sync(page)
+            logger.info(
+                "Execution context was destroyed, injecting session recorder again"
+            )
+            inject_session_recorder_sync(page)
             send_events_sync(page, session_id, trace_id, client)
         else:
-            logger.debug(f"Could not send events: {e}")
+            # silence the error if the page has been closed, not an issue
+            if (
+                "Page.evaluate: Target page, context or browser has been closed"
+                not in str(e)
+            ):
+                logger.warn(f"Could not send events: {e}")
 
 
-def inject_rrweb_sync(page: SyncPage):
+def inject_session_recorder_sync(page: SyncPage):
     try:
         page.wait_for_load_state("domcontentloaded")
 
@@ -155,34 +169,36 @@ def inject_rrweb_sync(page: SyncPage):
                 """() => typeof window.lmnrRrweb !== 'undefined'"""
             )
         except Exception as e:
-            logger.debug(f"Failed to check if rrweb is loaded: {e}")
+            logger.debug(f"Failed to check if session recorder is loaded: {e}")
             is_loaded = False
 
         if not is_loaded:
 
-            def load_rrweb():
+            def load_session_recorder():
                 try:
                     page.evaluate(RRWEB_CONTENT)
                     return True
                 except Exception as e:
-                    logger.debug(f"Failed to load rrweb: {e}")
+                    logger.debug(f"Failed to load session recorder: {e}")
                     return False
 
             if not retry_sync(
-                load_rrweb, delay=1, error_message="Failed to load rrweb"
+                load_session_recorder,
+                delay=1,
+                error_message="Failed to load session recorder",
             ):
                 return
 
         try:
             page.evaluate(INJECT_PLACEHOLDER)
         except Exception as e:
-            logger.debug(f"Failed to inject rrweb placeholder: {e}")
+            logger.debug(f"Failed to inject session recorder: {e}")
 
     except Exception as e:
-        logger.error(f"Error during rrweb injection: {e}")
+        logger.error(f"Error during session recorder injection: {e}")
 
 
-async def inject_rrweb_async(page: Page):
+async def inject_session_recorder_async(page: Page):
     try:
         await page.wait_for_load_state("domcontentloaded")
 
@@ -192,31 +208,33 @@ async def inject_rrweb_async(page: Page):
                 """() => typeof window.lmnrRrweb !== 'undefined'"""
             )
         except Exception as e:
-            logger.debug(f"Failed to check if rrweb is loaded: {e}")
+            logger.debug(f"Failed to check if session recorder is loaded: {e}")
             is_loaded = False
 
         if not is_loaded:
 
-            async def load_rrweb():
+            async def load_session_recorder():
                 try:
                     await page.evaluate(RRWEB_CONTENT)
                     return True
                 except Exception as e:
-                    logger.debug(f"Failed to load rrweb: {e}")
+                    logger.debug(f"Failed to load session recorder: {e}")
                     return False
 
             if not await retry_async(
-                load_rrweb, delay=1, error_message="Failed to load rrweb"
+                load_session_recorder,
+                delay=1,
+                error_message="Failed to load session recorder",
             ):
                 return
 
         try:
             await page.evaluate(INJECT_PLACEHOLDER)
         except Exception as e:
-            logger.debug(f"Failed to inject rrweb placeholder: {e}")
+            logger.debug(f"Failed to inject session recorder placeholder: {e}")
 
     except Exception as e:
-        logger.error(f"Error during rrweb injection: {e}")
+        logger.error(f"Error during session recorder injection: {e}")
 
 
 @observe(name="playwright.page", ignore_input=True, ignore_output=True)
@@ -244,7 +262,7 @@ def handle_navigation_sync(page: SyncPage, session_id: str, client: LaminarClien
 
     def on_load():
         try:
-            inject_rrweb_sync(page)
+            inject_session_recorder_sync(page)
         except Exception as e:
             logger.error(f"Error in on_load handler: {e}")
 
@@ -265,7 +283,7 @@ def handle_navigation_sync(page: SyncPage, session_id: str, client: LaminarClien
 
     page.on("load", on_load)
     page.on("close", on_close)
-    inject_rrweb_sync(page)
+    inject_session_recorder_sync(page)
 
 
 @observe(name="playwright.page", ignore_input=True, ignore_output=True)
@@ -291,7 +309,7 @@ async def handle_navigation_async(
 
     async def on_load():
         try:
-            await inject_rrweb_async(page)
+            await inject_session_recorder_async(page)
         except Exception as e:
             logger.error(f"Error in on_load handler: {e}")
 
@@ -323,4 +341,4 @@ async def handle_navigation_async(
         )
 
     page.bring_to_front = bring_to_front
-    await inject_rrweb_async(page)
+    await inject_session_recorder_async(page)

--- a/tests/test_browser_events.py
+++ b/tests/test_browser_events.py
@@ -185,7 +185,6 @@ class TestBrowserEvents:
             "new_page",
             "launch",
             "new_context",
-            "close",
             "connect",
             "connect_over_cdp",
             "launch_persistent_context",


### PR DESCRIPTION
- Remove parent pw spans
- Restrict bu instrumentor to <0.5.0, because since 0.5 laminar instrumetation is shipped with browser-use
- silence the "page.closed" log messages
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Remove parent spans, restrict `browser-use` version, and silence specific log messages in Playwright integration.
> 
>   - **Behavior**:
>     - Removed parent spans in `playwright_otel.py` and `patchright_otel.py`.
>     - Restricted `browser-use` instrumentor to versions `<0.5.0` in `browser_use_otel.py`.
>     - Silenced "page.closed" log messages in `pw_utils.py`.
>   - **Functions**:
>     - Removed `_wrap_close_browser_sync` and `_wrap_close_browser_async` from `playwright_otel.py`.
>     - Updated `send_events_sync` and `send_events_async` in `pw_utils.py` to handle closed page errors silently.
>   - **Tests**:
>     - Updated `test_browser_events.py` to reflect changes in event handling and logging.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 8b5e7e9ba70f1ac94858e582620e9d0de27e2f07. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->