### PR TITLE
deduplicate span tags

### DIFF
--- a/src/lmnr/sdk/decorators.py
+++ b/src/lmnr/sdk/decorators.py
@@ -102,7 +102,8 @@ def observe(
             ):
                 logger.warning("Tags must be a list of strings. Tags will be ignored.")
             else:
-                association_properties["tags"] = tags
+                # list(set(tags)) to deduplicate tags
+                association_properties["tags"] = list(set(tags))
         if input_formatter is not None and ignore_input:
             logger.warning(
                 f"observe, function {func.__name__}: Input formatter"

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -741,7 +741,8 @@ class Laminar:
                 "Tags must be a list of strings. Tags will be ignored."
             )
             return
-        span.set_attribute(f"{ASSOCIATION_PROPERTIES}.tags", tags)
+        # list(set(tags)) to deduplicate tags
+        span.set_attribute(f"{ASSOCIATION_PROPERTIES}.tags", list(set(tags)))
 
     @classmethod
     def set_trace_session_id(cls, session_id: str | None = None):

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -59,10 +59,10 @@ def test_start_as_current_span_tags(span_exporter: InMemorySpanExporter):
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].attributes["lmnr.association.properties.tags"] == (
-        "foo",
+    assert sorted(spans[0].attributes["lmnr.association.properties.tags"]) == [
         "bar",
-    )
+        "foo",
+    ]
     assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
     assert spans[0].attributes["lmnr.span.path"] == ("test",)
 
@@ -386,7 +386,10 @@ def test_tags(span_exporter: InMemorySpanExporter):
 
     spans = span_exporter.get_finished_spans()
     assert len(spans) == 1
-    assert spans[0].attributes["lmnr.association.properties.tags"] == ("foo", "bar")
+    assert sorted(spans[0].attributes["lmnr.association.properties.tags"]) == [
+        "bar",
+        "foo",
+    ]
     assert spans[0].name == "test"
     assert spans[0].attributes["lmnr.span.instrumentation_source"] == "python"
     assert spans[0].attributes["lmnr.span.path"] == ("test",)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -560,3 +560,16 @@ def test_span_context_dict_fallback(span_exporter: InMemorySpanExporter):
     assert (
         inner_span.get_span_context().trace_id == outer_span.get_span_context().trace_id
     )
+
+
+def test_tags_deduplication(span_exporter: InMemorySpanExporter):
+    with Laminar.start_as_current_span("test"):
+        Laminar.set_span_tags(["foo", "bar", "foo"])
+        pass
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert sorted(spans[0].attributes["lmnr.association.properties.tags"]) == [
+        "bar",
+        "foo",
+    ]


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Deduplicate span tags by converting to a set in `decorators.py` and `laminar.py`, with updated tests to verify behavior.
> 
>   - **Behavior**:
>     - Deduplicate tags in spans by converting `tags` list to a set and back to a list in `decorators.py` and `laminar.py`.
>     - Handle invalid tag types by logging a warning and ignoring them.
>   - **Tests**:
>     - Update tests in `test_observe.py` and `test_tracing.py` to check for tag deduplication.
>     - Add `test_observe_tags_deduplication()` and `test_tags_deduplication()` to verify deduplication logic.
>     - Ensure tests handle both valid and invalid tag inputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 7ec9e5a59dc6c12311ce91d1c5a81bbd06599379. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->