### PR TITLE
fix some response types for some versions of openai in 1.99.*

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
@@ -56,7 +56,6 @@ from opentelemetry.trace import SpanKind, Tracer
 from opentelemetry.trace.status import Status, StatusCode
 from wrapt import ObjectProxy
 
-from openai.types.chat.chat_completion_message import FunctionCall
 import pydantic
 
 SPAN_NAME = "openai.chat"
@@ -1014,7 +1013,7 @@ def _parse_tool_calls(
             tool_call_data = copy.deepcopy(tool_call)
         elif _is_tool_call_model(tool_call):
             tool_call_data = tool_call.model_dump()
-        elif isinstance(tool_call, FunctionCall):
+        elif _is_function_call(tool_call):
             function_call = tool_call.model_dump()
             tool_call_data = ToolCall(
                 id="",
@@ -1036,6 +1035,15 @@ def _is_tool_call_model(tool_call):
         )
 
         return isinstance(tool_call, ChatCompletionMessageFunctionToolCall)
+    except Exception:
+        return False
+
+
+def _is_function_call(model: Union[dict, pydantic.BaseModel]) -> bool:
+    try:
+        from openai.types.chat.chat_completion_message import FunctionCall
+
+        return isinstance(model, FunctionCall)
     except Exception:
         return False
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -455,6 +455,14 @@ def responses_get_or_create_wrapper(tracer: Tracer, wrapped, instance, args, kwa
     merged_tools = existing_data.get("tools", []) + request_tools
 
     try:
+        parsed_response_output_text = None
+        if hasattr(parsed_response, "output_text"):
+            parsed_response_output_text = parsed_response.output_text
+        else:
+            try:
+                parsed_response_output_text = parsed_response.output[0].content[0].text
+            except Exception:
+                pass
         traced_data = TracedData(
             start_time=existing_data.get("start_time", start_time),
             response_id=parsed_response.id,
@@ -464,7 +472,7 @@ def responses_get_or_create_wrapper(tracer: Tracer, wrapped, instance, args, kwa
             output_blocks={block.id: block for block in parsed_response.output}
             | existing_data.get("output_blocks", {}),
             usage=existing_data.get("usage", parsed_response.usage),
-            output_text=existing_data.get("output_text", parsed_response.output_text),
+            output_text=existing_data.get("output_text", parsed_response_output_text),
             request_model=existing_data.get("request_model", kwargs.get("model")),
             response_model=existing_data.get("response_model", parsed_response.model),
         )
@@ -551,6 +559,15 @@ async def async_responses_get_or_create_wrapper(
     merged_tools = existing_data.get("tools", []) + request_tools
 
     try:
+        parsed_response_output_text = None
+        if hasattr(parsed_response, "output_text"):
+            parsed_response_output_text = parsed_response.output_text
+        else:
+            try:
+                parsed_response_output_text = parsed_response.output[0].content[0].text
+            except Exception:
+                pass
+
         traced_data = TracedData(
             start_time=existing_data.get("start_time", start_time),
             response_id=parsed_response.id,
@@ -560,7 +577,7 @@ async def async_responses_get_or_create_wrapper(
             output_blocks={block.id: block for block in parsed_response.output}
             | existing_data.get("output_blocks", {}),
             usage=existing_data.get("usage", parsed_response.usage),
-            output_text=existing_data.get("output_text", parsed_response.output_text),
+            output_text=existing_data.get("output_text", parsed_response_output_text),
             request_model=existing_data.get("request_model", kwargs.get("model")),
             response_model=existing_data.get("response_model", parsed_response.model),
         )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -643,7 +643,7 @@ async def async_responses_cancel_wrapper(
     return response
 
 
-def _get_output_text(parsed_response: Response) -> str:
+def _get_output_text(parsed_response: Response) -> Optional[str]:
     output_text = None
     if hasattr(parsed_response, "output_text"):
         output_text = parsed_response.output_text


### PR DESCRIPTION
Ports some of work in openllmetry pr 3244
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes response type handling for OpenAI 1.99.* by updating function call identification and output text extraction.
> 
>   - **Behavior**:
>     - Replaces `FunctionCall` import with `_is_function_call()` in `chat_wrappers.py` to handle function call identification.
>     - Updates `_parse_tool_calls()` to use `_is_function_call()` for processing tool calls.
>     - Modifies `responses_get_or_create_wrapper()` and `async_responses_get_or_create_wrapper()` in `responses_wrappers.py` to use `_get_output_text()` for extracting output text.
>   - **Functions**:
>     - Adds `_is_function_call()` to `chat_wrappers.py` to check if a model is a `FunctionCall`.
>     - Adds `_get_output_text()` to `responses_wrappers.py` to safely extract output text from `Response` objects.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for b1978301a8d3967c7f25bcf4dd9a4a230ab5577f. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->