### PR TITLE
remove deprecated google-generativeai instrumentation

### DIFF
--- a/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
+++ b/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
@@ -102,22 +102,6 @@ class CrewAIInstrumentorInitializer(InstrumentorInitializer):
         return CrewAiInstrumentor()
 
 
-class GoogleGenerativeAIInstrumentorInitializer(InstrumentorInitializer):
-    def init_instrumentor(self, *args, **kwargs) -> BaseInstrumentor | None:
-        if not is_package_installed("google-generativeai"):
-            return None
-        if not is_package_installed(
-            "opentelemetry-instrumentation-google-generativeai"
-        ):
-            return None
-
-        from opentelemetry.instrumentation.google_generativeai import (
-            GoogleGenerativeAiInstrumentor,
-        )
-
-        return GoogleGenerativeAiInstrumentor()
-
-
 class GoogleGenAIInstrumentorInitializer(InstrumentorInitializer):
     def init_instrumentor(self, *args, **kwargs) -> BaseInstrumentor | None:
         if not is_package_installed("google-genai"):

--- a/src/lmnr/opentelemetry_lib/tracing/instruments.py
+++ b/src/lmnr/opentelemetry_lib/tracing/instruments.py
@@ -20,7 +20,6 @@ class Instruments(Enum):
     CHROMA = "chroma"
     COHERE = "cohere"
     CREWAI = "crewai"
-    GOOGLE_GENERATIVEAI = "google_generativeai"
     GOOGLE_GENAI = "google_genai"
     GROQ = "groq"
     HAYSTACK = "haystack"
@@ -63,7 +62,6 @@ INSTRUMENTATION_INITIALIZERS: dict[
     Instruments.CHROMA: initializers.ChromaInstrumentorInitializer(),
     Instruments.COHERE: initializers.CohereInstrumentorInitializer(),
     Instruments.CREWAI: initializers.CrewAIInstrumentorInitializer(),
-    Instruments.GOOGLE_GENERATIVEAI: initializers.GoogleGenerativeAIInstrumentorInitializer(),
     Instruments.GOOGLE_GENAI: initializers.GoogleGenAIInstrumentorInitializer(),
     Instruments.GROQ: initializers.GroqInstrumentorInitializer(),
     Instruments.HAYSTACK: initializers.HaystackInstrumentorInitializer(),


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Remove deprecated Google Generative AI instrumentation from `_instrument_initializers.py` and `instruments.py`.
> 
>   - **Removal**:
>     - Remove `GoogleGenerativeAIInstrumentorInitializer` class from `_instrument_initializers.py`.
>     - Remove `GOOGLE_GENERATIVEAI` from `Instruments` enum in `instruments.py`.
>     - Remove `GOOGLE_GENERATIVEAI` entry from `INSTRUMENTATION_INITIALIZERS` in `instruments.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 6b5554317118dfc9a8cee455a0e04343166921c9. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->