### PR TITLE
fix browser use version 1 to 0.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.5"
+version = "0.7.6"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
+++ b/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
@@ -65,7 +65,7 @@ class BrowserUseInstrumentorInitializer(InstrumentorInitializer):
 
             return BrowserUseLegacyInstrumentor()
 
-        if version and parse(version) >= parse("1.0.0rc1"):
+        if version and parse(version) >= parse("0.6.0rc1"):
             from lmnr.sdk.browser.browser_use_cdp_otel import BrowserUseInstrumentor
 
             return BrowserUseInstrumentor(async_client)

--- a/src/lmnr/sdk/browser/browser_use_cdp_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_cdp_otel.py
@@ -14,8 +14,8 @@ from typing import Collection
 from wrapt import wrap_function_wrapper
 import uuid
 
-# Stable versions, e.g. 1.0.0, satisfy this condition too
-_instruments = ("browser-use >= 1.0.0rc1",)
+# Stable versions, e.g. 0.6.0, satisfy this condition too
+_instruments = ("browser-use >= 0.6.0rc1",)
 
 WRAPPED_METHODS = [
     {

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
browser-use decided to release their new package as `0.6.0` not `1.0.0`, so updating our instrumentation requirements
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `browser-use` version requirement to `0.6.0` and increment `lmnr` version to `0.7.6`.
> 
>   - **Behavior**:
>     - Update `browser-use` version requirement from `1.0.0` to `0.6.0` in `_instrument_initializers.py` and `browser_use_cdp_otel.py`.
>     - Adjust logic in `init_instrumentor()` in `_instrument_initializers.py` to use `BrowserUseInstrumentor` for versions `>= 0.6.0rc1`.
>   - **Versioning**:
>     - Increment `lmnr` package version from `0.7.5` to `0.7.6` in `pyproject.toml` and `version.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 476376a4b300a347276feb4dc2c3a37746082876. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->