### PR TITLE
only lock write path, remove lock from read path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.9"
+version = "0.7.10"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.7.9"
+__version__ = "0.7.10"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
Tested manually with BU's repro script. ThreadPool unit tests (written at original Amplitude issue report) also pass
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Removed lock from `verify_initialized()` in `TracerWrapper` to prevent deadlocks, and updated version to `0.7.10`.
> 
>   - **Behavior**:
>     - Removed lock from `verify_initialized()` in `TracerWrapper` in `__init__.py` to prevent deadlocks during initialization.
>     - Updated logic to return `False` if initialization is ongoing, allowing re-evaluation of decorators at runtime.
>   - **Versioning**:
>     - Bumped version from `0.7.9` to `0.7.10` in `pyproject.toml` and `version.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 7bd2d992df620f432cb17a78e7177cfcd47a4676. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->