### PR TITLE
Cdp use fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.10"
+version = "0.7.11"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/opentelemetry_lib/tracing/__init__.py
+++ b/src/lmnr/opentelemetry_lib/tracing/__init__.py
@@ -201,6 +201,20 @@ class TracerWrapper(object):
 
         return new_context
 
+    def push_raw_span_context(self, span_context: trace.SpanContext) -> Context:
+        current_ctx = get_current_context()
+        new_context = trace.set_span_in_context(
+            trace.NonRecordingSpan(span_context), current_ctx
+        )
+        token = attach_context(new_context)
+
+        # Store the token for later detachment - tokens are much lighter than contexts
+        current_stack = get_token_stack().copy()
+        current_stack.append(token)
+        set_token_stack(current_stack)
+
+        return new_context
+
     def pop_span_context(self) -> None:
         """Pop the current span context from the stack."""
         current_stack = get_token_stack().copy()

--- a/src/lmnr/opentelemetry_lib/tracing/__init__.py
+++ b/src/lmnr/opentelemetry_lib/tracing/__init__.py
@@ -201,20 +201,6 @@ class TracerWrapper(object):
 
         return new_context
 
-    def push_raw_span_context(self, span_context: trace.SpanContext) -> Context:
-        current_ctx = get_current_context()
-        new_context = trace.set_span_in_context(
-            trace.NonRecordingSpan(span_context), current_ctx
-        )
-        token = attach_context(new_context)
-
-        # Store the token for later detachment - tokens are much lighter than contexts
-        current_stack = get_token_stack().copy()
-        current_stack.append(token)
-        set_token_stack(current_stack)
-
-        return new_context
-
     def pop_span_context(self) -> None:
         """Pop the current span context from the stack."""
         current_stack = get_token_stack().copy()

--- a/src/lmnr/opentelemetry_lib/tracing/instruments.py
+++ b/src/lmnr/opentelemetry_lib/tracing/instruments.py
@@ -17,6 +17,8 @@ class Instruments(Enum):
     ANTHROPIC = "anthropic"
     BEDROCK = "bedrock"
     BROWSER_USE = "browser_use"
+    BROWSER_USE_SESSION = "browser_use_session"
+    BUBUS = "bubus"
     CHROMA = "chroma"
     COHERE = "cohere"
     CREWAI = "crewai"
@@ -60,6 +62,8 @@ INSTRUMENTATION_INITIALIZERS: dict[
     Instruments.ANTHROPIC: initializers.AnthropicInstrumentorInitializer(),
     Instruments.BEDROCK: initializers.BedrockInstrumentorInitializer(),
     Instruments.BROWSER_USE: initializers.BrowserUseInstrumentorInitializer(),
+    Instruments.BROWSER_USE_SESSION: initializers.BrowserUseSessionInstrumentorInitializer(),
+    Instruments.BUBUS: initializers.BubusInstrumentorInitializer(),
     Instruments.CHROMA: initializers.ChromaInstrumentorInitializer(),
     Instruments.COHERE: initializers.CohereInstrumentorInitializer(),
     Instruments.CREWAI: initializers.CrewAIInstrumentorInitializer(),

--- a/src/lmnr/sdk/browser/browser_use_cdp_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_cdp_otel.py
@@ -42,10 +42,8 @@ async def process_wrapped_result(result, instance, client, to_wrap):
             await start_recording_events(result, str(uuid.uuid4()), client)
 
     if to_wrap.get("action") == "take_full_snapshot":
-        print("wrapped on switch tab event")
         target_id = result
         if target_id:
-            print(f"target id: {target_id}")
             cdp_session = await instance.get_or_create_cdp_session(target_id)
             await take_full_snapshot(cdp_session)
 
@@ -62,7 +60,6 @@ async def _wrap(
 
 class BrowserUseInstrumentor(BaseInstrumentor):
     def __init__(self, async_client: AsyncLaminarClient):
-        print("BrowserUseInstrumentor with full snapshot logs")
         super().__init__()
         self.async_client = async_client
 

--- a/src/lmnr/sdk/browser/browser_use_cdp_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_cdp_otel.py
@@ -1,3 +1,6 @@
+import asyncio
+import uuid
+
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 from lmnr.sdk.browser.utils import with_tracer_and_client_wrapper
 from lmnr.version import __version__
@@ -12,7 +15,6 @@ from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.trace import get_tracer, Tracer
 from typing import Collection
 from wrapt import wrap_function_wrapper
-import uuid
 
 # Stable versions, e.g. 0.6.0, satisfy this condition too
 _instruments = ("browser-use >= 0.6.0rc1",)
@@ -33,11 +35,9 @@ WRAPPED_METHODS = [
 ]
 
 
-@with_tracer_and_client_wrapper
-async def _wrap(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
-):
-    result = await wrapped(*args, **kwargs)
+async def process_wrapped_result(result, instance, client, to_wrap):
+    if not instance._cached_browser_state_summary:
+        return
 
     if to_wrap.get("action") == "inject_session_recorder":
         is_registered = await is_recorder_present(result)
@@ -49,6 +49,14 @@ async def _wrap(
         if target_id:
             cdp_session = await instance.get_or_create_cdp_session(target_id)
             await take_full_snapshot(cdp_session)
+
+
+@with_tracer_and_client_wrapper
+async def _wrap(
+    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+):
+    result = await wrapped(*args, **kwargs)
+    asyncio.create_task(process_wrapped_result(result, instance, client, to_wrap))
 
     return result
 

--- a/src/lmnr/sdk/browser/browser_use_cdp_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_cdp_otel.py
@@ -36,17 +36,16 @@ WRAPPED_METHODS = [
 
 
 async def process_wrapped_result(result, instance, client, to_wrap):
-    if not instance._cached_browser_state_summary:
-        return
-
     if to_wrap.get("action") == "inject_session_recorder":
         is_registered = await is_recorder_present(result)
         if not is_registered:
             await start_recording_events(result, str(uuid.uuid4()), client)
 
     if to_wrap.get("action") == "take_full_snapshot":
+        print("wrapped on switch tab event")
         target_id = result
         if target_id:
+            print(f"target id: {target_id}")
             cdp_session = await instance.get_or_create_cdp_session(target_id)
             await take_full_snapshot(cdp_session)
 
@@ -63,6 +62,7 @@ async def _wrap(
 
 class BrowserUseInstrumentor(BaseInstrumentor):
     def __init__(self, async_client: AsyncLaminarClient):
+        print("BrowserUseInstrumentor with full snapshot logs")
         super().__init__()
         self.async_client = async_client
 

--- a/src/lmnr/sdk/browser/bubus_otel.py
+++ b/src/lmnr/sdk/browser/bubus_otel.py
@@ -1,0 +1,90 @@
+from typing import Collection
+
+from lmnr.opentelemetry_lib.tracing import TracerWrapper
+from lmnr.opentelemetry_lib.tracing.context import get_current_context
+
+from opentelemetry import context as context_api
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from opentelemetry.trace import get_current_span
+from wrapt import wrap_function_wrapper
+
+from lmnr.sdk.log import get_default_logger
+
+_instruments = ("bubus >= 1.3.0",)
+event_id_to_span_context = {}
+logger = get_default_logger(__name__)
+
+
+def wrap_dispatch(wrapped, instance, args, kwargs):
+    event = args[0] if args and len(args) > 0 else kwargs.get("event", None)
+    if event and hasattr(event, "event_id"):
+        event_id = event.event_id
+        if event_id:
+            span = get_current_span(get_current_context())
+            event_id_to_span_context[event_id] = span.get_span_context()
+    return wrapped(*args, **kwargs)
+
+
+async def wrap_process_event(wrapped, instance, args, kwargs):
+    event = args[0] if args and len(args) > 0 else kwargs.get("event", None)
+    span_context = None
+    if event and hasattr(event, "event_id"):
+        event_id = event.event_id
+        if event_id:
+            span_context = event_id_to_span_context.get(event_id)
+    if not span_context:
+        return await wrapped(*args, **kwargs)
+    if not TracerWrapper.verify_initialized():
+        return await wrapped(*args, **kwargs)
+    wrapper = None
+    context = None
+    context_token = None
+    try:
+        wrapper = TracerWrapper()
+        context = wrapper.push_raw_span_context(span_context)
+        # Some auto-instrumentations are not under our control, so they
+        # don't have access to our isolated context. We attach the context
+        # to the OTEL global context, so that spans know their parent
+        # span and trace_id.
+        context_token = context_api.attach(context)
+    except Exception as e:
+        logger.debug("Error pushing span context: %s", e)
+    try:
+        return await wrapped(*args, **kwargs)
+    finally:
+        if context_token:
+            context_api.detach(context_token)
+        if wrapper and context:
+            wrapper.pop_span_context()
+
+
+class BubusInstrumentor(BaseInstrumentor):
+    def __init__(self):
+        super().__init__()
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        try:
+            wrap_function_wrapper("bubus.service", "EventBus.dispatch", wrap_dispatch)
+        except (ModuleNotFoundError, ImportError):
+            pass
+        try:
+            wrap_function_wrapper(
+                "bubus.service", "EventBus.process_event", wrap_process_event
+            )
+        except (ModuleNotFoundError, ImportError):
+            pass
+
+    def _uninstrument(self, **kwargs):
+        try:
+            unwrap("bubus.service", "EventBus.dispatch")
+        except (ModuleNotFoundError, ImportError):
+            pass
+        try:
+            unwrap("bubus.service", "EventBus.process_event")
+        except (ModuleNotFoundError, ImportError):
+            pass
+        event_id_to_span_context.clear()

--- a/src/lmnr/sdk/browser/bubus_otel.py
+++ b/src/lmnr/sdk/browser/bubus_otel.py
@@ -1,15 +1,14 @@
 from typing import Collection
 
-from lmnr.opentelemetry_lib.tracing import TracerWrapper
+from lmnr import Laminar
 from lmnr.opentelemetry_lib.tracing.context import get_current_context
+from lmnr.sdk.log import get_default_logger
 
-from opentelemetry import context as context_api
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import get_current_span
+from opentelemetry.trace import NonRecordingSpan, get_current_span
 from wrapt import wrap_function_wrapper
 
-from lmnr.sdk.log import get_default_logger
 
 _instruments = ("bubus >= 1.3.0",)
 event_id_to_span_context = {}
@@ -35,28 +34,10 @@ async def wrap_process_event(wrapped, instance, args, kwargs):
             span_context = event_id_to_span_context.get(event_id)
     if not span_context:
         return await wrapped(*args, **kwargs)
-    if not TracerWrapper.verify_initialized():
+    if not Laminar.is_initialized():
         return await wrapped(*args, **kwargs)
-    wrapper = None
-    context = None
-    context_token = None
-    try:
-        wrapper = TracerWrapper()
-        context = wrapper.push_raw_span_context(span_context)
-        # Some auto-instrumentations are not under our control, so they
-        # don't have access to our isolated context. We attach the context
-        # to the OTEL global context, so that spans know their parent
-        # span and trace_id.
-        context_token = context_api.attach(context)
-    except Exception as e:
-        logger.debug("Error pushing span context: %s", e)
-    try:
+    with Laminar.use_span(NonRecordingSpan(span_context)):
         return await wrapped(*args, **kwargs)
-    finally:
-        if context_token:
-            context_api.detach(context_token)
-        if wrapper and context:
-            wrapper.pop_span_context()
 
 
 class BubusInstrumentor(BaseInstrumentor):

--- a/src/lmnr/sdk/browser/cdp_utils.py
+++ b/src/lmnr/sdk/browser/cdp_utils.py
@@ -633,12 +633,10 @@ async def get_isolated_context_id(cdp_session) -> int | None:
     frame = tree.get("frameTree", {}).get("frame", {})
     frame_id = frame.get("id", str(uuid.uuid4()))
     loader_id = frame.get("loaderId", str(uuid.uuid4()))
-    url = frame.get("url", "about:blank")
 
-    key = f"{frame_id}_{loader_id}_{url}"
+    key = f"{frame_id}_{loader_id}"
 
     if key in frame_to_isolated_context_id:
-        print(f"Key: {key} existing context id: {frame_to_isolated_context_id[key]}")
         return frame_to_isolated_context_id[key]
 
     try:
@@ -657,7 +655,6 @@ async def get_isolated_context_id(cdp_session) -> int | None:
         return None
     isolated_context_id = result["executionContextId"]
     frame_to_isolated_context_id[key] = isolated_context_id
-    print(f"Key: {key} new context id: {isolated_context_id}")
     return isolated_context_id
 
 
@@ -881,9 +878,7 @@ async def is_recorder_present(cdp_session) -> bool:
 
 async def take_full_snapshot(cdp_session):
     cdp_client = cdp_session.cdp_client
-    print("Taking full snapshot")
     isolated_context_id = await get_isolated_context_id(cdp_session)
-    print(f"Isolated context id: {isolated_context_id}")
     if isolated_context_id is None:
         logger.debug("Failed to get isolated context id")
         return False
@@ -913,14 +908,11 @@ async def take_full_snapshot(cdp_session):
             timeout=CDP_OPERATION_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
-        print("Timeout error when taking full snapshot")
         logger.debug("Timeout error when taking full snapshot")
         return False
     except Exception as e:
-        print(f"Error when taking full snapshot: {e}")
         logger.debug(f"Error when taking full snapshot: {e}")
         return False
-    print(f"Result: {result}")
     if result and "result" in result and "value" in result["result"]:
         return result["result"]["value"]
     return False

--- a/src/lmnr/sdk/browser/cdp_utils.py
+++ b/src/lmnr/sdk/browser/cdp_utils.py
@@ -516,7 +516,11 @@ INJECT_PLACEHOLDER = """
 
 
 async def should_skip_page(cdp_session):
-    """Checks if the page url is an error page or an empty page."""
+    """Checks if the page url is an error page or an empty page.
+    Thius function returns True in case of any error in our code, because
+    it is safer to not record events than to try to inject the recorder
+    into something that is already broken.
+    """
     cdp_client = cdp_session.cdp_client
 
     try:
@@ -597,10 +601,10 @@ async def should_skip_page(cdp_session):
 
     except asyncio.TimeoutError:
         logger.debug("Timeout error when checking if error page")
-        return False
+        return True
     except Exception as e:
         logger.debug(f"Error during checking if error page: {e}")
-        return False
+        return True
 
 
 def get_mask_input_setting() -> MaskInputOptions:

--- a/src/lmnr/sdk/browser/cdp_utils.py
+++ b/src/lmnr/sdk/browser/cdp_utils.py
@@ -517,7 +517,7 @@ INJECT_PLACEHOLDER = """
 
 async def should_skip_page(cdp_session):
     """Checks if the page url is an error page or an empty page.
-    Thius function returns True in case of any error in our code, because
+    This function returns True in case of any error in our code, because
     it is safer to not record events than to try to inject the recorder
     into something that is already broken.
     """

--- a/src/lmnr/sdk/evaluations.py
+++ b/src/lmnr/sdk/evaluations.py
@@ -112,7 +112,12 @@ class Evaluation:
         base_http_url: str | None = None,
         http_port: int | None = None,
         grpc_port: int | None = None,
-        instruments: set[Instruments] | None = None,
+        instruments: (
+            set[Instruments] | list[Instruments] | tuple[Instruments] | None
+        ) = None,
+        disabled_instruments: (
+            set[Instruments] | list[Instruments] | tuple[Instruments] | None
+        ) = None,
         max_export_batch_size: int | None = MAX_EXPORT_BATCH_SIZE,
         trace_export_timeout_seconds: int | None = None,
     ):
@@ -171,6 +176,10 @@ class Evaluation:
                 to auto-instrument. If None, all available instruments will be\
                 used.
                 See https://docs.lmnr.ai/tracing/automatic-instrumentation
+                Defaults to None.
+            disabled_instruments (set[Instruments] | None, optional): Set of modules\
+                to disable auto-instrumentations. If None, only modules passed\
+                as `instruments` will be disabled.
                 Defaults to None.
         """
 
@@ -234,6 +243,7 @@ class Evaluation:
             http_port=http_port,
             grpc_port=grpc_port,
             instruments=instruments,
+            disabled_instruments=disabled_instruments,
             max_export_batch_size=max_export_batch_size,
             export_timeout_seconds=trace_export_timeout_seconds,
         )
@@ -432,7 +442,12 @@ def evaluate(
     base_http_url: str | None = None,
     http_port: int | None = None,
     grpc_port: int | None = None,
-    instruments: set[Instruments] | None = None,
+    instruments: (
+        set[Instruments] | list[Instruments] | tuple[Instruments] | None
+    ) = None,
+    disabled_instruments: (
+        set[Instruments] | list[Instruments] | tuple[Instruments] | None
+    ) = None,
     max_export_batch_size: int | None = MAX_EXPORT_BATCH_SIZE,
     trace_export_timeout_seconds: int | None = None,
 ) -> Awaitable[None] | None:
@@ -493,6 +508,10 @@ def evaluate(
                         auto-instrument. If None, all available instruments\
                         will be used.
                         Defaults to None.
+        disabled_instruments (set[Instruments] | None, optional): Set of modules\
+                        to disable auto-instrumentations. If None, no\
+                        only modules passed as `instruments` will be disabled.
+                        Defaults to None.
         trace_export_timeout_seconds (int | None, optional): The timeout for\
                         trace export on OpenTelemetry exporter. Defaults to None.
     """
@@ -510,6 +529,7 @@ def evaluate(
         http_port=http_port,
         grpc_port=grpc_port,
         instruments=instruments,
+        disabled_instruments=disabled_instruments,
         max_export_batch_size=max_export_batch_size,
         trace_export_timeout_seconds=trace_export_timeout_seconds,
     )

--- a/src/lmnr/sdk/evaluations.py
+++ b/src/lmnr/sdk/evaluations.py
@@ -510,7 +510,7 @@ def evaluate(
                         Defaults to None.
         disabled_instruments (set[Instruments] | None, optional): Set of modules\
                         to disable auto-instrumentations. If None, no\
-                        only modules passed as `instruments` will be disabled.
+                        If None, only modules passed as `instruments` will be disabled.
                         Defaults to None.
         trace_export_timeout_seconds (int | None, optional): The timeout for\
                         trace export on OpenTelemetry exporter. Defaults to None.

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -421,14 +421,14 @@ class Laminar:
 
         Usage example:
         ```python
-        from src.lmnr import Laminar, use_span
+        from src.lmnr import Laminar
         def foo(span):
-            with use_span(span):
+            with Laminar.use_span(span):
                 with Laminar.start_as_current_span("foo_inner"):
                     some_function()
         
         def bar():
-            with use_span(span):
+            with Laminar.use_span(span):
                 openai_client.chat.completions.create()
         
         span = Laminar.start_span("outer")

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.7.10"
+__version__ = "0.7.11"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
Draft: there are still intermittent `ERROR    [cdp_use.client] CDP Error for request 131: {'code': -32000, 'message': 'Cannot find context with specified id'}`
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance instrumentation for `browser-use` and add `bubus` support, improve session recording, and increment version to 0.7.11.
> 
>   - **Instrumentation Enhancements**:
>     - Add `BubusInstrumentorInitializer` and `BrowserUseSessionInstrumentorInitializer` in `_instrument_initializers.py`.
>     - Add `BUBUS` and `BROWSER_USE_SESSION` to `Instruments` enum in `instruments.py`.
>     - Update `INSTRUMENTATION_INITIALIZERS` in `instruments.py` to include new initializers.
>   - **Session Recording**:
>     - Add `get_isolated_context_id()` and `should_skip_page()` in `cdp_utils.py` for better session management.
>     - Modify `inject_session_recorder()` in `cdp_utils.py` to use isolated context IDs.
>     - Improve error handling in `inject_session_recorder()` and `take_full_snapshot()` in `cdp_utils.py`.
>   - **New Instrumentation**:
>     - Add `BubusInstrumentor` in `bubus_otel.py` to handle `bubus` events.
>     - Implement `wrap_dispatch()` and `wrap_process_event()` in `bubus_otel.py` for event handling.
>   - **Miscellaneous**:
>     - Increment version to 0.7.11 in `pyproject.toml` and `version.py`.
>     - Minor refactoring and logging improvements in `browser_use_cdp_otel.py` and `cdp_utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 1fdc895d612c33e627c651c4745afadea270e3ca. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->