### PR TITLE
bump opentelemetry instrumentations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.12"
+version = "0.7.13"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }
@@ -62,57 +62,57 @@ lmnr = "lmnr.cli:cli"
 # `uv add lmnr --extra anthropic --extra groq`
 # `poetry add 'lmnr[anthropic,groq]'`
 
-alephalpha=["opentelemetry-instrumentation-alephalpha>=0.46.2"]
-bedrock=["opentelemetry-instrumentation-bedrock>=0.46.2"]
-chromadb=["opentelemetry-instrumentation-chromadb>=0.46.2"]
-cohere=["opentelemetry-instrumentation-cohere>=0.46.2"]
-crewai=["opentelemetry-instrumentation-crewai>=0.46.2"]
-haystack=["opentelemetry-instrumentation-haystack>=0.46.2"]
-lancedb=["opentelemetry-instrumentation-lancedb>=0.46.2"]
-langchain=["opentelemetry-instrumentation-langchain>=0.46.2"]
-llamaindex=["opentelemetry-instrumentation-llamaindex>=0.46.2"]
-marqo=["opentelemetry-instrumentation-marqo>=0.46.2"]
-mcp=["opentelemetry-instrumentation-mcp>=0.46.2"]
-milvus=["opentelemetry-instrumentation-milvus>=0.46.2"]
-mistralai=["opentelemetry-instrumentation-mistralai>=0.46.2"]
-ollama=["opentelemetry-instrumentation-ollama>=0.46.2"]
-pinecone=["opentelemetry-instrumentation-pinecone>=0.46.2"]
-qdrant=["opentelemetry-instrumentation-qdrant>=0.46.2"]
-replicate=["opentelemetry-instrumentation-replicate>=0.46.2"]
-sagemaker=["opentelemetry-instrumentation-sagemaker>=0.46.2"]
-together=["opentelemetry-instrumentation-together>=0.46.2"]
-transformers=["opentelemetry-instrumentation-transformers>=0.46.2"]
-vertexai=["opentelemetry-instrumentation-vertexai>=0.46.2"]
-watsonx=["opentelemetry-instrumentation-watsonx>=0.46.2"]
-weaviate=["opentelemetry-instrumentation-weaviate>=0.46.2"]
+alephalpha=["opentelemetry-instrumentation-alephalpha>=0.47.1"]
+bedrock=["opentelemetry-instrumentation-bedrock>=0.47.1"]
+chromadb=["opentelemetry-instrumentation-chromadb>=0.47.1"]
+cohere=["opentelemetry-instrumentation-cohere>=0.47.1"]
+crewai=["opentelemetry-instrumentation-crewai>=0.47.1"]
+haystack=["opentelemetry-instrumentation-haystack>=0.47.1"]
+lancedb=["opentelemetry-instrumentation-lancedb>=0.47.1"]
+langchain=["opentelemetry-instrumentation-langchain>=0.47.1"]
+llamaindex=["opentelemetry-instrumentation-llamaindex>=0.47.1"]
+marqo=["opentelemetry-instrumentation-marqo>=0.47.1"]
+mcp=["opentelemetry-instrumentation-mcp>=0.47.1"]
+milvus=["opentelemetry-instrumentation-milvus>=0.47.1"]
+mistralai=["opentelemetry-instrumentation-mistralai>=0.47.1"]
+ollama=["opentelemetry-instrumentation-ollama>=0.47.1"]
+pinecone=["opentelemetry-instrumentation-pinecone>=0.47.1"]
+qdrant=["opentelemetry-instrumentation-qdrant>=0.47.1"]
+replicate=["opentelemetry-instrumentation-replicate>=0.47.1"]
+sagemaker=["opentelemetry-instrumentation-sagemaker>=0.47.1"]
+together=["opentelemetry-instrumentation-together>=0.47.1"]
+transformers=["opentelemetry-instrumentation-transformers>=0.47.1"]
+vertexai=["opentelemetry-instrumentation-vertexai>=0.47.1"]
+watsonx=["opentelemetry-instrumentation-watsonx>=0.47.1"]
+weaviate=["opentelemetry-instrumentation-weaviate>=0.47.1"]
 # `all` is the group added for convenience, if you want to install all
 # the instrumentations.
 # we suggest using package-manager-specific commands instead,
 # like `uv add lmnr --all-extras`
 all = [
-  "opentelemetry-instrumentation-alephalpha>=0.46.2",
-  "opentelemetry-instrumentation-bedrock>=0.46.2",
-  "opentelemetry-instrumentation-chromadb>=0.46.2",
-  "opentelemetry-instrumentation-cohere>=0.46.2",
-  "opentelemetry-instrumentation-crewai>=0.46.2",
-  "opentelemetry-instrumentation-haystack>=0.46.2",
-  "opentelemetry-instrumentation-lancedb>=0.46.2",
-  "opentelemetry-instrumentation-langchain>=0.46.2",
-  "opentelemetry-instrumentation-llamaindex>=0.46.2",
-  "opentelemetry-instrumentation-marqo>=0.46.2",
-  "opentelemetry-instrumentation-mcp>=0.46.2",
-  "opentelemetry-instrumentation-milvus>=0.46.2",
-  "opentelemetry-instrumentation-mistralai>=0.46.2",
-  "opentelemetry-instrumentation-ollama>=0.46.2",
-  "opentelemetry-instrumentation-pinecone>=0.46.2",
-  "opentelemetry-instrumentation-qdrant>=0.46.2",
-  "opentelemetry-instrumentation-replicate>=0.46.2",
-  "opentelemetry-instrumentation-sagemaker>=0.46.2",
-  "opentelemetry-instrumentation-together>=0.46.2",
-  "opentelemetry-instrumentation-transformers>=0.46.2",
-  "opentelemetry-instrumentation-vertexai>=0.46.2",
-  "opentelemetry-instrumentation-watsonx>=0.46.2",
-  "opentelemetry-instrumentation-weaviate>=0.46.2"
+  "opentelemetry-instrumentation-alephalpha>=0.47.1",
+  "opentelemetry-instrumentation-bedrock>=0.47.1",
+  "opentelemetry-instrumentation-chromadb>=0.47.1",
+  "opentelemetry-instrumentation-cohere>=0.47.1",
+  "opentelemetry-instrumentation-crewai>=0.47.1",
+  "opentelemetry-instrumentation-haystack>=0.47.1",
+  "opentelemetry-instrumentation-lancedb>=0.47.1",
+  "opentelemetry-instrumentation-langchain>=0.47.1",
+  "opentelemetry-instrumentation-llamaindex>=0.47.1",
+  "opentelemetry-instrumentation-marqo>=0.47.1",
+  "opentelemetry-instrumentation-mcp>=0.47.1",
+  "opentelemetry-instrumentation-milvus>=0.47.1",
+  "opentelemetry-instrumentation-mistralai>=0.47.1",
+  "opentelemetry-instrumentation-ollama>=0.47.1",
+  "opentelemetry-instrumentation-pinecone>=0.47.1",
+  "opentelemetry-instrumentation-qdrant>=0.47.1",
+  "opentelemetry-instrumentation-replicate>=0.47.1",
+  "opentelemetry-instrumentation-sagemaker>=0.47.1",
+  "opentelemetry-instrumentation-together>=0.47.1",
+  "opentelemetry-instrumentation-transformers>=0.47.1",
+  "opentelemetry-instrumentation-vertexai>=0.47.1",
+  "opentelemetry-instrumentation-watsonx>=0.47.1",
+  "opentelemetry-instrumentation-weaviate>=0.47.1"
 ]
 
 [dependency-groups]

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.7.12"
+__version__ = "0.7.13"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Bump `lmnr` version to `0.7.13` and update `opentelemetry` instrumentation versions to `0.47.1` in `pyproject.toml`.
> 
>   - **Version Update**:
>     - Bump `lmnr` version from `0.7.12` to `0.7.13` in `pyproject.toml` and `version.py`.
>   - **Dependency Updates**:
>     - Update `opentelemetry` instrumentation versions from `0.46.2` to `0.47.1` for multiple packages in `pyproject.toml`.
>     - Affects `alephalpha`, `bedrock`, `chromadb`, `cohere`, `crewai`, `haystack`, `lancedb`, `langchain`, `llamaindex`, `marqo`, `mcp`, `milvus`, `mistralai`, `ollama`, `pinecone`, `qdrant`, `replicate`, `sagemaker`, `together`, `transformers`, `vertexai`, `watsonx`, `weaviate`, and `all` group.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 5d806dc137182ec6fd0e3efb27a2f66860a4c489. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->