### PR TITLE
hotfix followup to #192

### DIFF
--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -80,11 +80,25 @@ class PartialEvaluationDatapoint(pydantic.BaseModel):
 
     # uuid is not serializable by default, so we need to convert it to a string
     def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
+        serialized_data = serialize(self.data)
+        serialized_target = serialize(self.target)
+        # TODO: use json_dumps instead of json.dumps once we
+        # move it to utils so we can avoid circular imports
+        str_data = json.dumps(serialized_data)
+        str_target = json.dumps(serialized_target)
         try:
             return {
                 "id": str(self.id),
-                "data": str(serialize(self.data))[:max_data_length],
-                "target": str(serialize(self.target))[:max_data_length],
+                "data": (
+                    str_data[:max_data_length]
+                    if len(str_data) > max_data_length
+                    else serialized_data
+                ),
+                "target": (
+                    str_target[:max_data_length]
+                    if len(str_target) > max_data_length
+                    else serialized_target
+                ),
                 "index": self.index,
                 "traceId": str(self.trace_id),
                 "executorSpanId": str(self.executor_span_id),
@@ -110,15 +124,31 @@ class EvaluationResultDatapoint(pydantic.BaseModel):
     # uuid is not serializable by default, so we need to convert it to a string
     def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
         try:
+            serialized_data = serialize(self.data)
+            serialized_target = serialize(self.target)
+            serialized_executor_output = serialize(self.executor_output)
+            str_data = json.dumps(serialized_data)
+            str_target = json.dumps(serialized_target)
+            str_executor_output = json.dumps(serialized_executor_output)
             return {
                 # preserve only preview of the data, target and executor output
                 # (full data is in trace)
                 "id": str(self.id),
-                "data": str(serialize(self.data))[:max_data_length],
-                "target": str(serialize(self.target))[:max_data_length],
-                "executorOutput": str(serialize(self.executor_output))[
-                    :max_data_length
-                ],
+                "data": (
+                    str_data[:max_data_length]
+                    if len(str_data) > max_data_length
+                    else serialized_data
+                ),
+                "target": (
+                    str_target[:max_data_length]
+                    if len(str_target) > max_data_length
+                    else serialized_target
+                ),
+                "executorOutput": (
+                    str_executor_output[:max_data_length]
+                    if len(str_executor_output) > max_data_length
+                    else serialized_executor_output
+                ),
                 "scores": self.scores,
                 "traceId": str(self.trace_id),
                 "executorSpanId": str(self.executor_span_id),


### PR DESCRIPTION
only stringify dicts if they are actually too long
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimize `to_dict` methods in `PartialEvaluationDatapoint` and `EvaluationResultDatapoint` to conditionally stringify serialized data based on length.
> 
>   - **Behavior**:
>     - In `PartialEvaluationDatapoint.to_dict()`, only stringify `data` and `target` if their serialized JSON strings exceed `max_data_length`.
>     - In `EvaluationResultDatapoint.to_dict()`, only stringify `data`, `target`, and `executorOutput` if their serialized JSON strings exceed `max_data_length`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for fe19065637f69e12fc04a5a621438374b5b6d442. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->