### PR TITLE
Py3.14

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v5
       - name: Set up Python


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a full datasets CLI and SDK (async/sync) resources, links evaluations to datasets, updates logging, tightens langchain extra, and expands CI to Python 3.14.
> 
> - **CLI**:
>   - Introduces `lmnr` CLI with subcommands: `eval`, `add-cursor-rules`, and new `datasets` (`list`, `push`, `pull`, `create`).
>   - Refactors evaluation runner into `lmnr.cli.evals`.
> - **SDK (Client/Resources)**:
>   - Adds datasets resources: `AsyncDatasets` and `Datasets` with `list`, `get_dataset_by_name`, `push`, `pull` and exposes `.datasets` on clients.
> - **SDK (Datasets module)**:
>   - New `lmnr.sdk.datasets` with `LaminarDataset` (push/pull, paging) and file loaders `datasets/file_utils.py` (JSON/CSV/JSONL, recursive).
> - **Types**:
>   - Extends `Datapoint` (adds `id`, `createdAt`, defaults for `target`/`metadata`).
>   - Adds `Dataset`, `PushDatapointsResponse`, `EvaluationDatapointDatasetLink`; `GetDatapointsResponse.total_count` alias.
> - **Evaluations**:
>   - Links eval datapoints to datasets when using `LaminarDataset`; resolves dataset ID by name; validates non-empty input; gathers background uploads; minor reporter/log tweaks.
> - **Logging**:
>   - `get_default_logger` gains `verbose` flag and simplified formatter.
> - **CI/Deps**:
>   - Adds Python `3.14` to test matrix and classifiers.
>   - Constrains `opentelemetry-instrumentation-langchain` extra to `<0.48.0`.
> - **Tests**:
>   - Update tests to new module paths, dataset mocks, and OpenAI/langchain cassette (model `gpt-5-nano`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bd565d77271544966db9c90cee3100031653f1ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->