### PR TITLE
remove grace sleep on cc proxy shutdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ lmnr = "lmnr.cli:cli"
 alephalpha=["opentelemetry-instrumentation-alephalpha>=0.47.1"]
 bedrock=["opentelemetry-instrumentation-bedrock>=0.47.1"]
 chromadb=["opentelemetry-instrumentation-chromadb>=0.47.1"]
-claude-agent-sdk=["lmnr-claude-code-proxy>=0.1.0a3"]
+claude-agent-sdk=["lmnr-claude-code-proxy>=0.1.0a4"]
 cohere=["opentelemetry-instrumentation-cohere>=0.47.1"]
 crewai=["opentelemetry-instrumentation-crewai>=0.47.1"]
 haystack=["opentelemetry-instrumentation-haystack>=0.47.1"]

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/proxy.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/proxy.py
@@ -16,7 +16,6 @@ logger = get_default_logger(__name__)
 DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 DEFAULT_CC_PROXY_PORT = 45667
 CC_PROXY_PORT_ATTEMPTS = 5
-GRACE_TO_FLUSH_SECONDS = 3
 
 _CC_PROXY_LOCK = threading.Lock()
 _CC_PROXY_PORT: int | None = None
@@ -67,13 +66,8 @@ def _stop_cc_proxy_locked():
 
 
 def _stop_cc_proxy():
-    def _stop_in_background():
-        time.sleep(GRACE_TO_FLUSH_SECONDS)
-        with _CC_PROXY_LOCK:
-            _stop_cc_proxy_locked()
-
-    thread = threading.Thread(target=_stop_in_background, daemon=True)
-    thread.start()
+    with _CC_PROXY_LOCK:
+        _stop_cc_proxy_locked()
 
 
 def _register_proxy_shutdown():


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make cc-proxy shutdown synchronous (remove grace sleep/thread) and bump `lmnr-claude-code-proxy` extra to `>=0.1.0a4`.
> 
> - **Claude Agent Proxy**:
>   - Synchronous shutdown: `_stop_cc_proxy()` now stops immediately under lock; removed background thread and `GRACE_TO_FLUSH_SECONDS` in `opentelemetry/instrumentation/claude_agent/proxy.py`.
> - **Dependencies**:
>   - Update optional extra `claude-agent-sdk` to `lmnr-claude-code-proxy>=0.1.0a4` in `pyproject.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 571388823ada366bd38a1a8dc70ee89c65435694. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removes grace period sleep during Claude code proxy shutdown and updates `lmnr-claude-code-proxy` version.
> 
>   - **Behavior**:
>     - Removes grace period sleep in `_stop_cc_proxy()` in `proxy.py`, simplifying shutdown by directly acquiring lock and stopping the proxy.
>   - **Dependencies**:
>     - Updates `lmnr-claude-code-proxy` version to `>=0.1.0a4` in `pyproject.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for 571388823ada366bd38a1a8dc70ee89c65435694. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->