### PR TITLE
tiny fix claude agent sdk test

### DIFF
--- a/tests/test_instrumentations/test_claude_agent/test_claude_sdk_client.py
+++ b/tests/test_instrumentations/test_claude_agent/test_claude_sdk_client.py
@@ -1,4 +1,4 @@
-import asyncio
+import pytest
 
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from claude_agent_sdk import ClaudeSDKClient
@@ -6,18 +6,16 @@ from claude_agent_sdk import ClaudeSDKClient
 from mock_transport import MockClaudeTransport
 
 
-def test_claude_agent_query(span_exporter: InMemorySpanExporter):
-    async def _collect_messages():
-        async with ClaudeSDKClient(transport=MockClaudeTransport()) as client:
-            await client.query("What's the capital of France?")
-            async for _ in client.receive_response():
-                pass
+@pytest.mark.asyncio
+async def test_claude_agent_query(span_exporter: InMemorySpanExporter):
+    async with ClaudeSDKClient(transport=MockClaudeTransport()) as client:
+        await client.query("What's the capital of France?")
+        async for _ in client.receive_response():
+            pass
 
-            await client.query("What's the population of that city?")
-            async for _ in client.receive_response():
-                pass
-
-    asyncio.run(_collect_messages())
+        await client.query("What's the population of that city?")
+        async for _ in client.receive_response():
+            pass
 
     spans_tuple = span_exporter.get_finished_spans()
     spans = sorted(list(spans_tuple), key=lambda x: x.start_time)

--- a/tests/test_instrumentations/test_claude_agent/test_query.py
+++ b/tests/test_instrumentations/test_claude_agent/test_query.py
@@ -1,35 +1,27 @@
-import asyncio
+import claude_agent_sdk
+import pytest
 
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from claude_agent_sdk import ClaudeAgentOptions
-import claude_agent_sdk
 
 from mock_transport import MockClaudeTransport
 
-# Note: can not use alias "query" aka "from claude_agent_sdk import query" because it is not wrapped by Laminar
 
-
-def test_claude_agent_query(span_exporter: InMemorySpanExporter):
+@pytest.mark.asyncio
+async def test_claude_agent_query(span_exporter: InMemorySpanExporter):
     options = ClaudeAgentOptions(
         model="claude-sonnet-4-5",
         system_prompt="You are an expert software engineer.",
         permission_mode="acceptEdits",
     )
 
-    async def _collect_messages():
-        messages = []
-        async for message in claude_agent_sdk.query(
-            # prompt="Create a readme doc for the test_claude_agent package. Then delete it. Return task status.",
-            prompt="What is the capital of France?",
-            options=options,
-            transport=MockClaudeTransport(
-                auto_respond_on_connect=True, close_after_responses=True
-            ),
-        ):
-            messages.append(message)
-        return messages
-
-    for _ in asyncio.run(_collect_messages()):
+    async for message in claude_agent_sdk.query(
+        prompt="What is the capital of France?",
+        options=options,
+        transport=MockClaudeTransport(
+            auto_respond_on_connect=True, close_after_responses=True
+        ),
+    ):
         pass
 
     spans = span_exporter.get_finished_spans()

--- a/tests/test_instrumentations/test_claude_agent/test_query_with_alias.py
+++ b/tests/test_instrumentations/test_claude_agent/test_query_with_alias.py
@@ -1,4 +1,4 @@
-import asyncio
+import pytest
 
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from claude_agent_sdk import ClaudeAgentOptions, query as claude_query
@@ -6,27 +6,21 @@ from claude_agent_sdk import ClaudeAgentOptions, query as claude_query
 from mock_transport import MockClaudeTransport
 
 
-def test_claude_agent_query(span_exporter: InMemorySpanExporter):
+@pytest.mark.asyncio
+async def test_claude_agent_query(span_exporter: InMemorySpanExporter):
     options = ClaudeAgentOptions(
         model="claude-sonnet-4-5",
         system_prompt="You are an expert software engineer.",
         permission_mode="acceptEdits",
     )
 
-    async def _collect_messages():
-        messages = []
-        async for message in claude_query(
-            # prompt="Create a readme doc for the test_claude_agent package. Then delete it. Return task status.",
-            prompt="What is the capital of France?",
-            options=options,
-            transport=MockClaudeTransport(
-                auto_respond_on_connect=True, close_after_responses=True
-            ),
-        ):
-            messages.append(message)
-        return messages
-
-    for _ in asyncio.run(_collect_messages()):
+    async for message in claude_query(
+        prompt="What is the capital of France?",
+        options=options,
+        transport=MockClaudeTransport(
+            auto_respond_on_connect=True, close_after_responses=True
+        ),
+    ):
         pass
 
     spans = span_exporter.get_finished_spans()


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Convert Claude Agent instrumentation tests to native async tests using pytest-asyncio, removing asyncio.run wrappers and inlining async contexts/loops.
> 
> - **Tests (Claude Agent instrumentation)**:
>   - Migrate to `pytest.mark.asyncio` with `async def` tests in `tests/test_instrumentations/test_claude_agent/*`.
>     - Replace `asyncio.run(...)` wrappers with inline `async with` and `async for` usage of `ClaudeSDKClient` and query streams.
>     - Remove unused `asyncio` imports; add `pytest` imports where needed.
>   - Preserve existing span assertions and behaviors for `query`, alias `query`, SDK client flows, and tool interactions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d41d3d88898a3da235c856f702beafa81995c8c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update test cases to use `pytest.mark.asyncio` for async testing in `claude_agent_sdk` tests.
> 
>   - **Testing**:
>     - Replace `asyncio.run()` with `@pytest.mark.asyncio` in `test_claude_sdk_client.py`, `test_query.py`, `test_query_with_alias.py`, and `test_tool.py`.
>     - Update test functions to be directly asynchronous, removing nested async functions.
>   - **Imports**:
>     - Remove `import asyncio` from all affected test files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for d41d3d88898a3da235c856f702beafa81995c8c7. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->