### PR TITLE
replace id with session_id in kernel api functions

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/kernel/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/kernel/__init__.py
@@ -196,9 +196,13 @@ def _wrap(
         f"{to_wrap.get('class_name')}.{to_wrap.get('method')}",
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
+        input_kv = get_input_from_func_args(wrapped, True, args, kwargs)
+        if "id" in input_kv:
+            input_kv["session_id"] = input_kv.get("id")
+            input_kv.pop("id")
         span.set_attribute(
             "lmnr.span.input",
-            json_dumps(get_input_from_func_args(wrapped, True, args, kwargs)),
+            json_dumps(input_kv),
         )
         try:
             result = wrapped(*args, **kwargs)
@@ -223,9 +227,13 @@ async def _wrap_async(
         f"{to_wrap.get('class_name')}.{to_wrap.get('method')}",
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
+        input_kv = get_input_from_func_args(wrapped, True, args, kwargs)
+        if "id" in input_kv:
+            input_kv["session_id"] = input_kv.get("id")
+            input_kv.pop("id")
         span.set_attribute(
             "lmnr.span.input",
-            json_dumps(get_input_from_func_args(wrapped, True, args, kwargs)),
+            json_dumps(input_kv),
         )
         try:
             result = await wrapped(*args, **kwargs)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Maps input `id` to `session_id` in kernel instrumentation span inputs for both sync and async wrappers.
> 
> - **Instrumentation (kernel)**:
>   - Map `id` to `session_id` in `lmnr.span.input` before serialization for both sync (`_wrap`) and async (`_wrap_async`) wrappers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e3ee2ffb3326369f2d05ef2b269d37d1aee506b5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Replaces `id` with `session_id` in input key-value pairs in `_wrap` and `_wrap_async` functions in `__init__.py`.
> 
>   - **Behavior**:
>     - Replace `id` with `session_id` in input key-value pairs in `_wrap` and `_wrap_async` functions.
>     - Applied before setting `lmnr.span.input` attribute.
>   - **Functions**:
>     - Modifies `_wrap` and `_wrap_async` in `__init__.py` to handle `session_id` instead of `id`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for e3ee2ffb3326369f2d05ef2b269d37d1aee506b5. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->