### PR TITLE
various guards around cas proxy shutdown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.36"
+version = "0.7.37"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }
@@ -67,7 +67,7 @@ lmnr = "lmnr.cli:cli"
 alephalpha=["opentelemetry-instrumentation-alephalpha>=0.47.1"]
 bedrock=["opentelemetry-instrumentation-bedrock>=0.47.1"]
 chromadb=["opentelemetry-instrumentation-chromadb>=0.47.1"]
-claude-agent-sdk=["lmnr-claude-code-proxy>=0.1.11"]
+claude-agent-sdk=["lmnr-claude-code-proxy>=0.1.12"]
 cohere=["opentelemetry-instrumentation-cohere>=0.47.1"]
 crewai=["opentelemetry-instrumentation-crewai>=0.47.1"]
 haystack=["opentelemetry-instrumentation-haystack>=0.47.1"]
@@ -93,7 +93,7 @@ weaviate=["opentelemetry-instrumentation-weaviate>=0.47.1"]
 # we suggest using package-manager-specific commands instead,
 # like `uv add lmnr --all-extras`
 all = [
-  "lmnr-claude-code-proxy>=0.1.11",
+  "lmnr-claude-code-proxy>=0.1.12",
   "opentelemetry-instrumentation-alephalpha>=0.47.1",
   "opentelemetry-instrumentation-bedrock>=0.47.1",
   "opentelemetry-instrumentation-chromadb>=0.47.1",

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/proxy.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/proxy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 
 from lmnr_claude_code_proxy import ProxyServer
@@ -14,19 +15,51 @@ logger = get_default_logger(__name__)
 
 # Thread-safe port allocation
 _PORT_LOCK = threading.Lock()
-_NEXT_PORT = 45667
+_DEFAULT_PORT = 45667
+_NEXT_PORT = _DEFAULT_PORT
 _ALLOCATED_PORTS: set[int] = set()
+_DEFAULT_MAX_PORTS = 5000
+
+# Maximum port range: can be configured via LMNR_CC_PROXY_MAX_PORTS env var
+# Capped at 65535 - DEFAULT_PORT to stay within valid port range
+_MAX_PORTS_ABSOLUTE = 65535 - _DEFAULT_PORT  # = 19868
+
+
+def _get_max_ports() -> int:
+    """Get the configured max ports from env, capped at absolute maximum."""
+    try:
+        env_val = os.environ.get("LMNR_CC_PROXY_MAX_PORTS")
+        if env_val:
+            configured = int(env_val)
+            return min(configured, _MAX_PORTS_ABSOLUTE)
+    except (ValueError, TypeError):
+        pass
+    return min(_DEFAULT_MAX_PORTS, _MAX_PORTS_ABSOLUTE)
 
 
 def _allocate_port() -> int:
-    """Allocate next available port in thread-safe manner."""
+    """Allocate next available port in thread-safe manner with wraparound."""
     with _PORT_LOCK:
         global _NEXT_PORT
+        max_ports = _get_max_ports()
+
+        # Try to find an available port, with wraparound
+        attempts = 0
         while _NEXT_PORT in _ALLOCATED_PORTS:
-            _NEXT_PORT += 1
+            _NEXT_PORT = _DEFAULT_PORT + ((_NEXT_PORT - _DEFAULT_PORT + 1) % max_ports)
+            attempts += 1
+            if attempts >= max_ports:
+                # All ports in range are allocated, expand beyond if possible
+                _NEXT_PORT = _DEFAULT_PORT + max_ports + attempts
+                if _NEXT_PORT > 65535:
+                    raise RuntimeError(
+                        f"All {max_ports} proxy ports are in use. "
+                        "Increase LMNR_CC_PROXY_MAX_PORTS or wait for ports to be released."
+                    )
+
         port = _NEXT_PORT
         _ALLOCATED_PORTS.add(port)
-        _NEXT_PORT += 1
+        _NEXT_PORT = _DEFAULT_PORT + ((_NEXT_PORT - _DEFAULT_PORT + 1) % max_ports)
         return port
 
 
@@ -50,9 +83,7 @@ def create_proxy_for_transport() -> ProxyServer:
     return proxy
 
 
-def start_proxy(
-    proxy: ProxyServer, target_url: str, max_retries: int = 10
-) -> str:
+def start_proxy(proxy: ProxyServer, target_url: str, max_retries: int = 10) -> str:
     """
     Start a proxy server, retrying with different ports if occupied.
 
@@ -136,12 +167,18 @@ def start_proxy(
 
 
 def stop_proxy(proxy: ProxyServer) -> None:
-    """Stop proxy server and release resources."""
+    """
+    Stop proxy server and release resources.
+
+    The Rust proxy handles timeouts internally, so this is safe to call
+    from both sync and async contexts.
+    """
+    port = proxy.port
     try:
         proxy.stop_server()
-        logger.debug("Stopped proxy server on port %d", proxy.port)
+        logger.debug("Stopped proxy server on port %d", port)
     except Exception as e:
-        logger.debug("Error stopping proxy on port %d: %s", proxy.port, e)
+        logger.debug("Error stopping proxy on port %d: %s", port, e)
     finally:
         if hasattr(proxy, "_allocated_port"):
             _release_port(proxy._allocated_port)  # type: ignore

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -28,6 +28,9 @@ from .utils import (
 
 logger = get_default_logger(__name__)
 
+# Timeout for cleanup operations to prevent hanging on stuck underlying calls
+DEFAULT_CLEANUP_TIMEOUT = 4.0
+
 
 def wrap_sync(to_wrap: dict[str, Any]):
     """Wrapper for synchronous methods."""
@@ -95,7 +98,6 @@ def wrap_async_gen(to_wrap: dict[str, Any]):
 
             if to_wrap.get("should_publish_span_context"):
                 with Laminar.use_span(span):
-                    # Get transport from instance (ClaudeSDKClient._transport)
                     if hasattr(instance, "_transport"):
                         publish_span_context_for_transport(instance._transport)
 
@@ -132,15 +134,7 @@ def wrap_async_gen(to_wrap: dict[str, Any]):
                     span.record_exception(e)
                 raise
             finally:
-                # Shield cleanup from cancellation to ensure proper resource cleanup
-                # This prevents orphaned tasks and "Task exception was never retrieved" errors
-                try:
-                    await _cleanup_async_iter(async_iter, span)
-                except (asyncio.CancelledError, GeneratorExit):
-                    # If we're being cancelled/closed during cleanup, still try to clean up
-                    # but don't let it propagate and interfere with our cleanup
-                    pass
-
+                await _cleanup_async_iter(async_iter, span)
                 with Laminar.use_span(span):
                     record_output(span, to_wrap, collected)
                 span.end()
@@ -152,30 +146,26 @@ def wrap_async_gen(to_wrap: dict[str, Any]):
 
 async def _cleanup_async_iter(async_iter, span) -> None:
     """
-    Clean up an async iterator, handling various edge cases.
+    Clean up an async iterator with timeout and cancellation protection.
 
-    This is separated to allow for shielding from cancellation and
-    to handle the race condition where the underlying transport/process
-    might already be closed.
+    Shields cleanup from cancellation and adds timeout to prevent hanging if
+    underlying close operations get stuck. Swallows all exceptions since cleanup
+    failures are expected in scenarios like early user breaks or closed transports.
     """
     if not async_iter or not hasattr(async_iter, "aclose"):
         return
 
     try:
-        # Shield the aclose from cancellation to ensure cleanup completes
-        # This is critical because if aclose is interrupted, we get orphaned tasks
         with Laminar.use_span(span):
-            await async_iter.aclose()
-    # BaseException catches any Exception + "not-exactly-Exceptions", such as GeneratorExit
+            # Shield from cancellation and add timeout to prevent hanging
+            await asyncio.wait_for(
+                asyncio.shield(async_iter.aclose()), timeout=DEFAULT_CLEANUP_TIMEOUT
+            )
     except BaseException:
-        # Common cases:
-        # - ProcessError when subprocess was killed (SIGTERM/-15/143)
-        #     - this will still occasionally occur, because there are nested generators,
-        #       and the user can break out of the loop at any time, which we don't have control over,
-        #       without moving our instrumentation to the deepest level possible.
-        # - GeneratorExit propagating through
-        # - CancelledError from request cancellation
-        # All are expected when user breaks early or transport.close() runs
+        # Swallow all exceptions - cleanup failures are expected when:
+        # - Subprocess already terminated (ProcessError)
+        # - User broke out of generator early (GeneratorExit)
+        # - Request was cancelled (CancelledError, TimeoutError)
         pass
 
 
@@ -188,61 +178,49 @@ def wrap_transport_connect(to_wrap: dict[str, Any]):
                 SubprocessCLITransport,
             )
         except (ImportError, ModuleNotFoundError):
-            # If import fails, just call original without instrumentation
             logger.warning(
                 "Failed to import SubprocessCLITransport, skipping proxy setup"
             )
             return await wrapped(*args, **kwargs)
 
-        # Resolve target URL from transport's options.env (with os.environ fallback)
-        # IMPORTANT: Read options.env BEFORE modifying options.env to avoid circular proxy config
+        # Read options.env BEFORE modifying to avoid circular proxy config
         env_dict = instance._options.env if hasattr(instance, "_options") else {}
         target_url = resolve_target_url_from_env(env_dict)
 
         if target_url is None:
             raise RuntimeError("Invalid provider configuration")
 
-        # Create and start proxy with resolved target URL
         proxy = create_proxy_for_transport()
         proxy_url = start_proxy(proxy, target_url=target_url)
 
-        # Determine if this is a custom transport (not SubprocessCLITransport)
-        # SubprocessCLITransport gets proxy config via options.env, custom ones need global env
+        # Custom transports use global env, SubprocessCLITransport uses options.env
         is_custom = not isinstance(instance, SubprocessCLITransport)
 
-        # For custom transports, we need to set global env vars as fallback
-        # since we can't control how they handle environment.
-        # For SubprocessCLITransport, proxy config is in options.env
         options_env_snapshot = {}
         if is_custom:
             original_env = setup_proxy_env(proxy_url)
             env_set_keys = {k for k, v in original_env.items() if v is not None}
         else:
-            # For SubprocessCLITransport, update options.env with proxy config
             if hasattr(instance, "_options"):
-                # Snapshot options.env before modifying it (for error recovery)
                 options_env_snapshot = snapshot_options_env_for_proxy(instance._options)
                 update_options_env_for_proxy(instance._options, proxy_url, target_url)
 
             original_env = {}
             env_set_keys = set()
 
-            # Remove FOUNDRY_RESOURCE_ENV from os.environ (mutually exclusive with ANTHROPIC_BASE_URL)
+            # Remove from os.environ (mutually exclusive with ANTHROPIC_BASE_URL)
             if FOUNDRY_RESOURCE_ENV in os.environ:
                 original_env[FOUNDRY_RESOURCE_ENV] = os.environ[FOUNDRY_RESOURCE_ENV]
                 env_set_keys.add(FOUNDRY_RESOURCE_ENV)
                 os.environ.pop(FOUNDRY_RESOURCE_ENV)
 
-            # Remove HTTP_PROXY and HTTPS_PROXY from os.environ
-            # Subprocess inherits os.environ, so we must remove these to prevent
-            # the subprocess from routing through corporate proxy instead of lmnr proxy
+            # Prevent subprocess from routing through corporate proxy
             for proxy_var in ["HTTP_PROXY", "HTTPS_PROXY"]:
                 if proxy_var in os.environ:
                     original_env[proxy_var] = os.environ[proxy_var]
                     env_set_keys.add(proxy_var)
                     os.environ.pop(proxy_var)
 
-        # Store context on instance
         context: dict[str, Any] = {
             "proxy": proxy,
             "proxy_url": proxy_url,
@@ -255,23 +233,16 @@ def wrap_transport_connect(to_wrap: dict[str, Any]):
         instance.__lmnr_context = context
         instance.__lmnr_wrapped = True
 
-        # Connect transport
         try:
             result = await wrapped(*args, **kwargs)
-
-            # After successful connection, publish current span context to proxy
             publish_span_context_for_transport(instance)
-
             return result
         except Exception:
-            # If connect fails, clean up proxy
             stop_proxy(proxy)
 
-            # Restore os.environ (for both custom transports and SubprocessCLITransport)
             if original_env:
                 restore_env(original_env, env_set_keys or set())
 
-            # Restore options.env if we modified it
             if options_env_snapshot and hasattr(instance, "_options"):
                 restore_options_env_from_snapshot(
                     instance._options, options_env_snapshot
@@ -291,15 +262,9 @@ def wrap_transport_close(to_wrap: dict[str, Any]):
 
     async def wrapper(wrapped, instance, args, kwargs):
         try:
-            # Close transport first
             return await wrapped(*args, **kwargs)
         finally:
-            # Clean up proxy and restore environment if needed
-            # Shield from cancellation to ensure cleanup completes properly
-            try:
-                await asyncio.shield(_cleanup_transport_context(instance))
-            except Exception:
-                logger.debug("Transport cleanup failed, skipping")
+            await _cleanup_transport_context(instance)
 
     return wrapper
 
@@ -308,54 +273,54 @@ async def _cleanup_transport_context(instance) -> None:
     """
     Cleanup proxy and restore environment when transport closes.
 
-    Runs proxy stop in a thread pool to avoid blocking the event loop,
-    while awaiting completion to ensure cleanup finishes. Protected by
-    asyncio.shield() in the caller to prevent cancellation.
+    Shields from cancellation and adds timeout to prevent hanging. Runs proxy stop
+    in thread pool to avoid blocking event loop while ensuring cleanup completes.
     """
     context: dict[str, Any] | None = getattr(instance, "__lmnr_context", None)
     if not context:
         return
 
-    try:
-        # Restore env vars synchronously (this is fast)
-        if context.get("original_env"):
-            restore_env(
-                context.get("original_env", {}),
-                context.get("env_set_keys", set()),
-            )
+    async def _do_cleanup():
+        try:
+            if context.get("original_env"):
+                restore_env(
+                    context.get("original_env", {}),
+                    context.get("env_set_keys", set()),
+                )
 
-        # Release port immediately and synchronously to prevent port leaks
-        # This must happen before scheduling background cleanup, because if the
-        # event loop shuts down before the background task runs, the port would
-        # never be released from _ALLOCATED_PORTS, causing port exhaustion
-        proxy = context.get("proxy")
-        if proxy and hasattr(proxy, "_allocated_port"):
-            _release_port(proxy._allocated_port)  # type: ignore
-            # Remove the attribute to prevent double-release in stop_proxy
-            # Without this, stop_proxy's finally block would release the port again,
-            # potentially corrupting another request's port ownership
+            # Release port immediately to prevent leaks
+            # Must happen before background cleanup in case event loop shuts down
+            proxy = context.get("proxy")
+            if proxy and hasattr(proxy, "_allocated_port"):
+                _release_port(proxy._allocated_port)  # type: ignore
+                # Prevent double-release in stop_proxy
+                try:
+                    delattr(proxy, "_allocated_port")
+                except Exception:
+                    pass
+
+            if proxy:
+                try:
+                    loop = asyncio.get_running_loop()
+                    await loop.run_in_executor(None, stop_proxy, proxy)
+                except RuntimeError:
+                    try:
+                        stop_proxy(proxy)
+                    except Exception:
+                        pass
+        finally:
             try:
-                delattr(proxy, "_allocated_port")
+                delattr(instance, "__lmnr_context")
             except Exception:
                 pass
 
-        # Run proxy stop in thread pool to avoid blocking event loop
-        # Await completion to ensure cleanup finishes before proceeding
-        if proxy:
-            try:
-                loop = asyncio.get_running_loop()
-                await loop.run_in_executor(None, stop_proxy, proxy)
-            except RuntimeError:
-                # No running loop, call synchronously as fallback
-                try:
-                    stop_proxy(proxy)
-                except Exception:
-                    pass
-    finally:
-        try:
-            delattr(instance, "__lmnr_context")
-        except Exception:
-            pass
+    try:
+        await asyncio.wait_for(
+            asyncio.shield(_do_cleanup()), timeout=DEFAULT_CLEANUP_TIMEOUT
+        )
+    except BaseException:
+        # Swallow all exceptions - cleanup failures are expected
+        pass
 
 
 def snapshot_options_env_for_proxy(options) -> dict[str, str | None]:
@@ -427,24 +392,17 @@ def update_options_env_for_proxy(options, proxy_url: str, target_url: str) -> No
         target_url: Original target URL to forward to (e.g., "https://api.anthropic.com")
     """
 
-    # Simple helper to check env
     def get_env_value(key: str) -> str | None:
         return options.env.get(key) or os.environ.get(key)
 
     foundry_enabled = is_truthy_env(get_env_value("CLAUDE_CODE_USE_FOUNDRY"))
 
-    # Set proxy URL
     options.env["ANTHROPIC_BASE_URL"] = proxy_url
-
-    # Store original target URL so proxy knows where to forward
     options.env["ANTHROPIC_ORIGINAL_BASE_URL"] = target_url
 
-    # Remove HTTP_PROXY and HTTPS_PROXY
-    # Our proxy will handle forwarding to them based on target_url
     for proxy_var in ["HTTP_PROXY", "HTTPS_PROXY"]:
         options.env.pop(proxy_var, None)
 
-    # Remove FOUNDRY_RESOURCE from options.env (mutually exclusive with ANTHROPIC_BASE_URL)
     if FOUNDRY_RESOURCE_ENV in options.env:
         options.env.pop(FOUNDRY_RESOURCE_ENV)
 
@@ -461,25 +419,17 @@ def wrap_query(to_wrap: dict[str, Any]):
 
         transport = kwargs.get("transport")
 
-        # If user provided a custom transport, wrap it for proxy lifecycle
-        # SubprocessCLITransport is already wrapped globally
         if transport:
             try:
                 from claude_agent_sdk._internal.transport.subprocess_cli import (
                     SubprocessCLITransport,
                 )
 
-                # Only wrap non-SubprocessCLITransport (already globally wrapped)
                 if not isinstance(transport, SubprocessCLITransport):
                     wrap_custom_transport_if_needed(transport)
             except (ImportError, ModuleNotFoundError):
-                # If import fails, try wrapping anyway
                 wrap_custom_transport_if_needed(transport)
 
-        # Note: We don't pre-configure proxy URL here because we don't know the port
-        # until the proxy is actually created in wrap_transport_connect
-
-        # Continue with normal async gen wrapping (since query is streaming)
         async def generator():
             with Laminar.start_as_current_span(
                 span_name(to_wrap),
@@ -492,29 +442,19 @@ def wrap_query(to_wrap: dict[str, Any]):
                 try:
                     async_iter = wrapped(*args, **kwargs)
 
-                    # Note: Span context is published in wrap_transport_connect after connection
-
                     async for item in async_iter:
-
                         collected.append(item)
-
                         yield item
                 except GeneratorExit:
-                    # User broke out of the loop - this is normal
                     raise
                 except asyncio.CancelledError:
-                    # Request was cancelled (e.g., FastAPI client disconnect)
                     raise
                 except Exception as e:
                     span.set_status(Status(StatusCode.ERROR))
                     span.record_exception(e)
                     raise
                 finally:
-                    # Shield cleanup from cancellation
-                    try:
-                        await _cleanup_async_iter(async_iter, span)
-                    except (asyncio.CancelledError, GeneratorExit):
-                        pass
+                    await _cleanup_async_iter(async_iter, span)
                     record_output(span, to_wrap, collected)
 
         return generator()
@@ -531,13 +471,11 @@ def wrap_client_init(to_wrap: dict[str, Any]):
                 SubprocessCLITransport,
             )
         except (ImportError, ModuleNotFoundError):
-            # If import fails, just call original without instrumentation
             logger.warning(
                 "Failed to import SubprocessCLITransport, skipping proxy setup"
             )
             return wrapped(*args, **kwargs)
 
-        # Extract transport from args/kwargs
         transport = None
         if args and len(args) > 1:
             transport = args[1]
@@ -569,18 +507,14 @@ def wrap_custom_transport_if_needed(transport):
     if hasattr(transport, "__lmnr_wrapped"):
         return
 
-    # Mark transport as wrapped immediately to prevent double wrapping
     transport.__lmnr_wrapped = True
 
-    # Create wrapper callables using the factory pattern
     connect_wrapper = wrap_transport_connect({"is_transport_connect": True})
     close_wrapper = wrap_transport_close({"is_transport_close": True})
 
-    # Get original methods
     original_connect = transport.connect
     original_close = transport.close
 
-    # Replace methods with wrapped versions
     async def wrapped_connect_custom():
         return await connect_wrapper(original_connect, transport, (), {})
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -166,7 +166,7 @@ async def _cleanup_async_iter(async_iter, span) -> None:
         # This is critical because if aclose is interrupted, we get orphaned tasks
         with Laminar.use_span(span):
             await async_iter.aclose()
-    except Exception:  # pylint: disable=broad-except
+    except (Exception, BaseException):
         # Common cases:
         # - ProcessError when subprocess was killed (SIGTERM/-15/143)
         #     - this will still occasionally occur, because there are nested generators,
@@ -299,7 +299,6 @@ def wrap_transport_close(to_wrap: dict[str, Any]):
                 _cleanup_transport_context(instance)
             except Exception:
                 logger.debug("Transport cleanup failed, skipping")
-                pass
 
     return wrapper
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -330,6 +330,13 @@ def _cleanup_transport_context(instance) -> None:
         proxy = context.get("proxy")
         if proxy and hasattr(proxy, "_allocated_port"):
             _release_port(proxy._allocated_port)  # type: ignore
+            # Remove the attribute to prevent double-release in stop_proxy
+            # Without this, stop_proxy's finally block would release the port again,
+            # potentially corrupting another request's port ownership
+            try:
+                delattr(proxy, "_allocated_port")
+            except Exception:
+                pass
 
         # Schedule proxy stop as a background task
         # This ensures cleanup happens even if the current task is being cancelled

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import httpx
 from packaging import version
 
 
-__version__ = "0.7.36"
+__version__ = "0.7.37"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
Checks will fail, blocked on proxy PR 28/release v0.1.12

- Also allow for many more ports for the entire process lifetime, avoiding overflow beyond 65535

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches proxy lifecycle, env-var mutation, and async cancellation/cleanup paths, which can affect stability of Claude Agent streaming and subprocess routing; changes are localized but timing/edge-case sensitive.
> 
> **Overview**
> Improves `claude_agent` instrumentation robustness around the local Claude Code proxy by adding wraparound, configurable port allocation (`LMNR_CC_PROXY_MAX_PORTS`) with clearer exhaustion errors, and by ensuring ports are released on retries and shutdown.
> 
> Hardens async streaming and transport teardown: async iterator cleanup is now cancellation-aware with timeouts, and transport close cleanup is shielded/timeout-bounded, restores env consistently, releases ports early to avoid leaks, and runs `stop_proxy` off the event loop when needed.
> 
> Bumps versions: package `0.7.37` and `lmnr-claude-code-proxy>=0.1.12` (including the `all` extra).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d5dbf5316277a3fdb36dd24ed2a94d3cea28d79c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances Claude Agent instrumentation reliability by improving proxy management, async streaming cleanup, and updating version to 0.7.37.
> 
>   - **Proxy Management**:
>     - `proxy.py`: Enhances port management with wraparound allocation from `45667`, configurable range via `LMNR_CC_PROXY_MAX_PORTS`, bounds checking, and clearer exhaustion errors.
>     - `stop_proxy()` now ensures consistent logging and port release.
>   - **Async Streaming Cleanup**:
>     - `wrappers.py`: Adds `_cleanup_async_iter()` for cancellation-aware async streaming cleanup.
>     - Shields close cleanup with `_cleanup_transport_context()` that restores env, releases ports immediately, and stops proxy off-thread.
>   - **Transport Connect Flow**:
>     - Updates to snapshot/patch `options.env`, remove conflicting `FOUNDRY_RESOURCE_ENV`/`HTTP[S]_PROXY` from inherited env, and publish span context after connect.
>   - **Version Updates**:
>     - Bumps `lmnr-claude-code-proxy` to `>=0.1.12` in `pyproject.toml`.
>     - Updates package version to `0.7.37` in `pyproject.toml` and `version.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=lmnr-ai%2Flmnr-python&utm_source=github&utm_medium=referral)<sup> for d5dbf5316277a3fdb36dd24ed2a94d3cea28d79c. You can [customize](https://app.ellipsis.dev/lmnr-ai/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->