### PR TITLE
add bedrock handling to claude code proxy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.45"
+version = "0.7.46"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }
@@ -16,7 +16,7 @@ requires-python = ">=3.10,<4"
 license = "Apache-2.0"
 dependencies = [
   "httpx (>=0.24.0,<1.0.0)",
-  "lmnr-claude-code-proxy>=0.1.14",
+  "lmnr-claude-code-proxy>=0.1.17",
   "opentelemetry-api (>=1.39.0, <2.0.0)",
   "opentelemetry-sdk (>=1.39.0, <2.0.0)",
   "opentelemetry-exporter-otlp-proto-http (>=1.39.0, <2.0.0)",

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
@@ -264,7 +264,6 @@ def setup_proxy_env(proxy_url: str) -> dict[str, str | None]:
     # Handle Bedrock-specific env vars
     if is_truthy_env(os.environ.get(BEDROCK_USE_ENV)):
         snapshot[BEDROCK_BASE_URL_ENV] = os.environ.get(BEDROCK_BASE_URL_ENV)
-        os.environ.pop(BEDROCK_BASE_URL_ENV, None)
         os.environ[BEDROCK_BASE_URL_ENV] = proxy_url
 
     return snapshot

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
@@ -192,8 +192,7 @@ def resolve_target_url_from_env(
         region = get_env_value(BEDROCK_AWS_REGION_ENV)
         if not region:
             aws_profile = get_env_value("AWS_PROFILE") or "default"
-            if aws_profile:
-                region = _get_region_from_aws_config(aws_profile)
+            region = _get_region_from_aws_config(aws_profile)
 
         if region:
             return f"https://bedrock-runtime.{region}.amazonaws.com"

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
@@ -1,8 +1,10 @@
 """Shared utilities for Claude Agent instrumentation."""
 
 import os
+import re
 import socket
 import time
+
 from lmnr.sdk.log import get_default_logger
 
 logger = get_default_logger(__name__)
@@ -11,6 +13,9 @@ DEFAULT_ANTHROPIC_BASE_URL = "https://api.anthropic.com"
 FOUNDRY_BASE_URL_ENV = "ANTHROPIC_FOUNDRY_BASE_URL"
 FOUNDRY_RESOURCE_ENV = "ANTHROPIC_FOUNDRY_RESOURCE"
 FOUNDRY_USE_ENV = "CLAUDE_CODE_USE_FOUNDRY"
+BEDROCK_BASE_URL_ENV = "ANTHROPIC_BEDROCK_BASE_URL"
+BEDROCK_USE_ENV = "CLAUDE_CODE_USE_BEDROCK"
+BEDROCK_AWS_REGION_ENV = "AWS_REGION"
 
 
 def is_truthy_env(value: str | None) -> bool:
@@ -90,6 +95,24 @@ def wait_for_port(port: int, timeout: float = 5.0) -> bool:
     return False
 
 
+def _get_region_from_aws_config(profile: str) -> str | None:
+    """Read region for a given profile from ~/.aws/config."""
+    config_path = os.path.expanduser("~/.aws/config")
+    try:
+        with open(config_path, "r") as f:
+            content = f.read()
+    except OSError:
+        return None
+
+    profile_header = "default" if profile == "default" else f"profile {profile}"
+    match = re.search(
+        rf"\[{re.escape(profile_header)}\][^\[]*?region\s*=\s*([^\s\n]+)",
+        content,
+        re.DOTALL,
+    )
+    return match.group(1) if match else None
+
+
 def resolve_target_url_from_env(
     env_dict: dict[str, str], fallback: str = DEFAULT_ANTHROPIC_BASE_URL
 ) -> str | None:
@@ -101,10 +124,14 @@ def resolve_target_url_from_env(
     Resolution order (highest to lowest priority):
     1. HTTPS_PROXY - if set, use as target (our proxy will forward to it)
     2. HTTP_PROXY - if set, use as target (our proxy will forward to it)
-    3. Third-party provider URLs (e.g., Foundry):
+    3. Third-party provider URLs (e.g., Foundry, Bedrock):
        - If CLAUDE_CODE_USE_FOUNDRY is truthy:
          - Use ANTHROPIC_FOUNDRY_BASE_URL, or
          - Construct from ANTHROPIC_FOUNDRY_RESOURCE
+       - If CLAUDE_CODE_USE_BEDROCK is truthy:
+         - Use ANTHROPIC_BEDROCK_BASE_URL, or
+         - Construct from AWS_REGION env var, or
+         - Construct by reading region from ~/.aws/config via AWS_PROFILE
     4. ANTHROPIC_BASE_URL - standard Anthropic API base URL
     5. Fall back to default (https://api.anthropic.com)
 
@@ -152,6 +179,30 @@ def resolve_target_url_from_env(
             FOUNDRY_USE_ENV,
             FOUNDRY_BASE_URL_ENV,
             FOUNDRY_RESOURCE_ENV,
+        )
+        return None
+
+    # 3b. Check for Bedrock
+    bedrock_enabled = is_truthy_env(get_env_value(BEDROCK_USE_ENV))
+    if bedrock_enabled:
+        bedrock_base_url = get_env_value(BEDROCK_BASE_URL_ENV)
+        if bedrock_base_url:
+            return bedrock_base_url.rstrip("/")
+
+        region = get_env_value(BEDROCK_AWS_REGION_ENV)
+        if not region:
+            aws_profile = get_env_value("AWS_PROFILE") or "default"
+            if aws_profile:
+                region = _get_region_from_aws_config(aws_profile)
+
+        if region:
+            return f"https://bedrock-runtime.{region}.amazonaws.com"
+
+        logger.error(
+            "%s is set but could not determine AWS region. "
+            "Set %s or configure a region in ~/.aws/config for the active profile.",
+            BEDROCK_USE_ENV,
+            BEDROCK_AWS_REGION_ENV,
         )
         return None
 
@@ -210,5 +261,11 @@ def setup_proxy_env(proxy_url: str) -> dict[str, str | None]:
 
         os.environ[FOUNDRY_BASE_URL_ENV] = proxy_url
         os.environ.pop(FOUNDRY_RESOURCE_ENV, None)
+
+    # Handle Bedrock-specific env vars
+    if is_truthy_env(os.environ.get(BEDROCK_USE_ENV)):
+        snapshot[BEDROCK_BASE_URL_ENV] = os.environ.get(BEDROCK_BASE_URL_ENV)
+        os.environ.pop(BEDROCK_BASE_URL_ENV, None)
+        os.environ[BEDROCK_BASE_URL_ENV] = proxy_url
 
     return snapshot

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
@@ -106,9 +106,9 @@ def _get_region_from_aws_config(profile: str) -> str | None:
 
     profile_header = "default" if profile == "default" else f"profile {profile}"
     match = re.search(
-        rf"\[{re.escape(profile_header)}\][^\[]*?region\s*=\s*([^\s\n]+)",
+        rf"\[{re.escape(profile_header)}\][^\[]*?^\s*region\s*=\s*([^\s\n]+)",
         content,
-        re.DOTALL,
+        re.MULTILINE | re.DOTALL,
     )
     return match.group(1) if match else None
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -24,6 +24,8 @@ from .utils import (
     FOUNDRY_BASE_URL_ENV,
     FOUNDRY_RESOURCE_ENV,
     FOUNDRY_USE_ENV,
+    BEDROCK_BASE_URL_ENV,
+    BEDROCK_USE_ENV,
 )
 
 logger = get_default_logger(__name__)
@@ -343,6 +345,8 @@ def snapshot_options_env_for_proxy(options) -> dict[str, str | None]:
         FOUNDRY_BASE_URL_ENV,
         FOUNDRY_RESOURCE_ENV,
         FOUNDRY_USE_ENV,
+        BEDROCK_BASE_URL_ENV,
+        BEDROCK_USE_ENV,
     ]
 
     snapshot = {}
@@ -411,12 +415,17 @@ def update_options_env_for_proxy(options, proxy_url: str, target_url: str) -> No
             options.env["CLAUDE_CODE_USE_FOUNDRY"] = "1"
         options.env[FOUNDRY_BASE_URL_ENV] = proxy_url
 
+    bedrock_enabled = is_truthy_env(get_env_value(BEDROCK_USE_ENV))
+    if bedrock_enabled:
+        if BEDROCK_USE_ENV not in options.env:
+            options.env[BEDROCK_USE_ENV] = "1"
+        options.env[BEDROCK_BASE_URL_ENV] = proxy_url
+
 
 def wrap_query(to_wrap: dict[str, Any]):
     """Wrap query() function - handles custom transport wrapping."""
 
     def wrapper(wrapped, instance, args, kwargs):
-
         transport = kwargs.get("transport")
 
         if transport:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -384,6 +384,8 @@ def update_options_env_for_proxy(options, proxy_url: str, target_url: str) -> No
     - If Foundry enabled:
         - sets ANTHROPIC_FOUNDRY_BASE_URL to proxy URL
         - Removes ANTHROPIC_FOUNDRY_RESOURCE from options.env (mutually exclusive)
+    - If Bedrock enabled:
+        - sets ANTHROPIC_BEDROCK_BASE_URL to proxy URL
     - ALL OTHER env vars passed intact
 
     Note: For SubprocessCLITransport, HTTP_PROXY, HTTPS_PROXY, and ANTHROPIC_FOUNDRY_RESOURCE

--- a/src/lmnr/sdk/utils.py
+++ b/src/lmnr/sdk/utils.py
@@ -275,9 +275,7 @@ def default_json(o):
     return DEFAULT_PLACEHOLDER
 
 
-def json_dumps(data: dict, prevent_double_stringify: bool = False) -> str:
-    if prevent_double_stringify and isinstance(data, str):
-        return data
+def json_dumps(data: dict | list) -> str:
     try:
         return orjson.dumps(
             data,

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import sys
 import httpx
 from packaging import version
 
-__version__ = "0.7.45"
+__version__ = "0.7.46"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes provider URL resolution and environment mutation logic used when spawning/proxying Claude Agent transports, and it also alters the `json_dumps` signature which could impact existing call sites.
> 
> **Overview**
> Adds **AWS Bedrock support** to Claude Agent proxy instrumentation by introducing `CLAUDE_CODE_USE_BEDROCK`/`ANTHROPIC_BEDROCK_BASE_URL` handling, including region-based endpoint construction (from `AWS_REGION` or `~/.aws/config` via `AWS_PROFILE`) and ensuring both global `os.environ` and `options.env` are rewritten to route through the local proxy.
> 
> Bumps the SDK version to `0.7.46`, updates the `lmnr-claude-code-proxy` minimum version, and simplifies `json_dumps` by removing the `prevent_double_stringify` behavior and narrowing the accepted input type to `dict | list`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a37f457c78349639dc1774779d474fde48115edc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->