### PR TITLE
OpenAI agents instrumentation

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -9,14 +9,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build

--- a/.github/workflows/ensure-version-match.yml
+++ b/.github/workflows/ensure-version-match.yml
@@ -5,27 +5,26 @@ on:
     types: [opened, synchronize]
     branches: ["main"]
 
-
 jobs:
   ensure-version-match:
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-    - name: Install uv
-      uses: astral-sh/setup-uv@v6
-      with:
-        activate-environment: true
-    - name: Install toml-cli
-      run: uv add toml-cli
-    - name: Ensure version match
-      run: |
-        SDK_VERSION=$(cat src/lmnr/version.py | grep __version__ | head -n1 | cut -d'=' -f2 | sed 's/[" '"'"']//g')
-        PYPROJECT_VERSION=$(uv run toml get --toml-path=pyproject.toml project.version)
-        if [ "$SDK_VERSION" != "$PYPROJECT_VERSION" ]; then
-          echo "Version mismatch between src/lmnr/version.py and pyproject.toml"
-          echo "LIB_VERSION: $LIB_VERSION"
-          echo "PYPROJECT_VERSION: $PYPROJECT_VERSION"
-          exit 1
-        fi
-        echo "Version match between src/lmnr/version.py and pyproject.toml"
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.0.0
+        with:
+          activate-environment: true
+      - name: Install toml-cli
+        run: uv add toml-cli
+      - name: Ensure version match
+        run: |
+          SDK_VERSION=$(cat src/lmnr/version.py | grep __version__ | head -n1 | cut -d'=' -f2 | sed 's/[" '"'"']//g')
+          PYPROJECT_VERSION=$(uv run toml get --toml-path=pyproject.toml project.version)
+          if [ "$SDK_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "Version mismatch between src/lmnr/version.py and pyproject.toml"
+            echo "LIB_VERSION: $LIB_VERSION"
+            echo "PYPROJECT_VERSION: $PYPROJECT_VERSION"
+            exit 1
+          fi
+          echo "Version match between src/lmnr/version.py and pyproject.toml"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -24,16 +24,16 @@ jobs:
     permissions:
       id-token: write
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.10"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+      - name: Build package
+        run: python -m build
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,13 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           activate-environment: true
       - name: Install the project

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -13,13 +13,13 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           activate-environment: true
       - name: Install the project
@@ -33,7 +33,7 @@ jobs:
     if: always() && needs.test.result == 'failure'
     steps:
       - name: Notify Slack
-        uses: slackapi/slack-github-action@v2.1.0
+        uses: slackapi/slack-github-action@v3.0.1
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook

--- a/examples/fastapi-app/pyproject.toml
+++ b/examples/fastapi-app/pyproject.toml
@@ -6,7 +6,7 @@ readme = "README.md"
 requires-python = ">=3.9, <4"
 dependencies = [
     "fastapi[standard]>=0.115.12",
-    "lmnr[openai]",
+    "lmnr",
     "openai>=1.76.0",
     "pydantic>=2.10.5",
     "python-dotenv>=1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,13 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.10,<4"
 license = "Apache-2.0"
+license-files = ["LICENSE"]
 dependencies = [
+  # grpcio used to have some issues with improper shutdown.
+  # Fixed in opentelemetry-exporter-otlp-proto-grpc >=1.31.0.
+  # Fixed in grpc >= 1.80.0. Remaining related issue to track
+  # https://github.com/grpc/grpc/issues/41672
+  "grpcio>=1",
   "httpx (>=0.24.0,<1.0.0)",
   "lmnr-claude-code-proxy>=0.1.17",
   "opentelemetry-api (>=1.39.0, <2.0.0)",
@@ -26,26 +32,15 @@ dependencies = [
   "opentelemetry-semantic-conventions (==0.60b1)",
   "opentelemetry-semantic-conventions-ai (==0.4.13)",
   "orjson (>=3.0.0,<4.0.0)",
-  "packaging (>=22.0)",
+  "packaging (>=22.0,<27.0)",
   "pydantic (>=2.0.3,<3.0.0)",
   "python-dotenv (>=1.0,<2.0)",
-  "tqdm (>=4.0)",
+  "tqdm (>=4.0,<5.0)",
   "tenacity (>=8.0,<10.0)",
-  # Since 1.68.0, grpcio writes a warning message
-  # that looks scary, but is harmless.
-  # WARNING: All log messages before absl::InitializeLog() is called are written to STDERR
-  # E0000 00:00:1737439981.199902 9456033 init.cc:229] grpc_wait_for_shutdown_with_timeout() timed out.
-  #
-  # Remove this comment when we make sure that grpcio has resolved this.
-  # Related issue:
-  # https://discuss.ai.google.dev/t/warning-all-log-messages-before-absl-initializelog-is-called-are-written-to-stderr-e0000-001731955515-629532-17124-init-cc-229-grpc-wait-for-shutdown-with-timeout-timed-out/50020
-  # https://github.com/grpc/grpc/issues/38490
-  "grpcio>=1",
 ]
 # poetry would auto-generate these based on requires-python, but other build
 # systems don't, so we need to specify them manually.
 classifiers = [
-  "License :: OSI Approved :: Apache Software License",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -60,10 +55,10 @@ lmnr = "lmnr.cli:cli"
 [project.optional-dependencies]
 # List of all possible extras. You can specify one or more of these extras
 # when installing the package, using any of the following examples:
-# `pip install 'lmnr[anthropic,groq]'`
-# `uv pip install 'lmnr[anthropic,groq]'`
-# `uv add lmnr --extra anthropic --extra groq`
-# `poetry add 'lmnr[anthropic,groq]'`
+# `pip install 'lmnr[bedrock,langchain]'`
+# `uv pip install 'lmnr[bedrock,langchain]'`
+# `uv add lmnr --extra bedrock --extra langchain`
+# `poetry add 'lmnr[bedrock,langchain]'`
 
 alephalpha=["opentelemetry-instrumentation-alephalpha==0.52.4"]
 bedrock=["opentelemetry-instrumentation-bedrock==0.52.4"]
@@ -131,14 +126,10 @@ dev = [
   "langchain==1.2.13",
   "langchain-core==1.2.22",
   "langchain-openai==1.1.12",
-  "langgraph==1.1.3",
-  # we don't depend on it directly, but version 1.0.9
-  # has a breaking change incompatible with older pinned
-  # version of langgraph.
-  # See https://github.com/langchain-ai/langgraph/issues/7404
-  "langgraph-prebuilt==1.0.8",
+  "langgraph==1.1.6",
   "litellm==1.81.16",
   "openai==2.30.0",
+  "openai-agents==0.14.1",
   "patchright==1.58.2",
   "playwright==1.58.0",
   "pytest==9.0.2",
@@ -149,7 +140,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.11.3,<0.12"]
+requires = ["uv_build>=0.11.7,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.workspace]

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -637,7 +637,7 @@ async def async_responses_get_or_create_wrapper(
         raise
     parsed_response = parse_response(response)
 
-    response_id = getattr(responses, "id", None)
+    response_id = getattr(parsed_response, "id", None)
     if not response_id:
         return response
     existing_data = responses.get(response_id)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -608,7 +608,6 @@ def _process_response(tracer: Tracer, start_time, response, kwargs):
         )
         responses[response_id] = traced_data
     except Exception:
-        raise
         return response
 
     if parsed_response.status == "completed":
@@ -677,7 +676,10 @@ async def async_responses_cancel_wrapper(
     if isinstance(response, (Stream, AsyncStream)):
         return response
     parsed_response = parse_response(response)
-    existing_data = responses.pop(parsed_response.id, None)
+    response_id = getattr(parsed_response, "id", None)
+    if not response_id:
+        return response
+    existing_data = responses.pop(response_id, None)
     if existing_data is not None:
         span = tracer.start_span(
             SPAN_NAME,

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -572,12 +572,17 @@ def _process_response(tracer: Tracer, start_time, response, kwargs):
         request_reasoning_summary = None
         request_reasoning_effort = None
         request_reasoning = kwargs.get("reasoning", {})
+        response_service_tier = None
         try:
             request_reasoning_summary = request_reasoning.get("summary")
         except Exception:
             pass
         try:
             request_reasoning_effort = request_reasoning.get("effort")
+        except Exception:
+            pass
+        try:
+            response_service_tier = parsed_response.service_tier
         except Exception:
             pass
         traced_data = TracedData(
@@ -594,16 +599,16 @@ def _process_response(tracer: Tracer, start_time, response, kwargs):
             ),
             request_model=existing_data.get("request_model", kwargs.get("model")),
             response_model=existing_data.get("response_model", parsed_response.model),
-            request_reasoning_summary=request_reasoning_summary
-            or existing_data.get("request_reasoning_summary"),
-            request_reasoning_effort=request_reasoning_effort
-            or existing_data.get("request_reasoning_effort"),
+            request_reasoning_summary=existing_data.get("request_reasoning_summary")
+            or request_reasoning_summary,
+            request_reasoning_effort=existing_data.get("request_reasoning_effort")
+            or request_reasoning_effort,
             request_service_tier=existing_data.get(
                 "request_service_tier", kwargs.get("service_tier")
             ),
             response_service_tier=existing_data.get(
                 "response_service_tier",
-                parsed_response.service_tier,
+                response_service_tier,
             ),
         )
         responses[response_id] = traced_data

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -296,7 +296,11 @@ def set_data_attributes(traced_response: TracedData, span: Span):
                         f"gen_ai.prompt.{prompt_index}.role",
                         "computer_call_output",
                     )
-                    output_image_url = block_dict.get("output", {}).get("image_url")
+                    output_image_url = None
+                    try:
+                        output_image_url = block_dict.get("output", {}).get("image_url")
+                    except Exception:
+                        pass
                     if output_image_url:
                         _set_span_attribute(
                             span,
@@ -457,119 +461,9 @@ def responses_get_or_create_wrapper(tracer: Tracer, wrapped, instance, args, kwa
         if isinstance(response, Stream):
             return response
     except Exception as e:
-        response_id = kwargs.get("response_id")
-        existing_data = {}
-        if response_id and response_id in responses:
-            existing_data = responses[response_id].model_dump()
-        try:
-            traced_data = TracedData(
-                start_time=existing_data.get("start_time", start_time),
-                response_id=response_id or "",
-                input=process_input(
-                    kwargs.get("input", existing_data.get("input", []))
-                ),
-                instructions=kwargs.get(
-                    "instructions", existing_data.get("instructions")
-                ),
-                tools=get_tools_from_kwargs(kwargs) or existing_data.get("tools", []),
-                output_blocks=existing_data.get("output_blocks", {}),
-                usage=existing_data.get("usage"),
-                output_text=kwargs.get(
-                    "output_text", existing_data.get("output_text", "")
-                ),
-                request_model=kwargs.get(
-                    "model", existing_data.get("request_model", "")
-                ),
-                response_model=existing_data.get("response_model", ""),
-                request_reasoning_summary=kwargs.get("reasoning", {}).get(
-                    "summary", existing_data.get("request_reasoning_summary")
-                ),
-                request_reasoning_effort=kwargs.get("reasoning", {}).get(
-                    "effort", existing_data.get("request_reasoning_effort")
-                ),
-                request_service_tier=kwargs.get(
-                    "service_tier", existing_data.get("request_service_tier")
-                ),
-                # response_service_tier=existing_data.get("response_service_tier"),
-            )
-        except Exception:
-            traced_data = None
-
-        span = tracer.start_span(
-            SPAN_NAME,
-            kind=SpanKind.CLIENT,
-            start_time=(
-                start_time if traced_data is None else int(traced_data.start_time)
-            ),
-            context=get_current_context(),
-        )
-        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
-        span.record_exception(e, attributes=get_event_attributes_from_context())
-        span.set_status(StatusCode.ERROR, str(e))
-        if traced_data:
-            set_data_attributes(traced_data, span)
-        span.end()
+        _process_exception(tracer, start_time, kwargs, e)
         raise
-    parsed_response = parse_response(response)
-
-    response_id = getattr(parsed_response, "id", None)
-    if not response_id:
-        return response
-    existing_data = responses.get(response_id)
-    if existing_data is None:
-        existing_data = {}
-    else:
-        existing_data = existing_data.model_dump()
-
-    request_tools = get_tools_from_kwargs(kwargs)
-
-    merged_tools = existing_data.get("tools", []) + request_tools
-
-    try:
-        traced_data = TracedData(
-            start_time=existing_data.get("start_time", start_time),
-            response_id=response_id,
-            input=process_input(existing_data.get("input", kwargs.get("input"))),
-            instructions=existing_data.get("instructions", kwargs.get("instructions")),
-            tools=merged_tools if merged_tools else None,
-            output_blocks={block.id: block for block in parsed_response.output}
-            | existing_data.get("output_blocks", {}),
-            usage=existing_data.get("usage", parsed_response.usage),
-            output_text=existing_data.get(
-                "output_text", _get_output_text(parsed_response)
-            ),
-            request_model=existing_data.get("request_model", kwargs.get("model")),
-            response_model=existing_data.get("response_model", parsed_response.model),
-            request_reasoning_summary=existing_data.get(
-                "request_reasoning_summary", kwargs.get("reasoning", {}).get("summary")
-            ),
-            request_reasoning_effort=existing_data.get(
-                "request_reasoning_effort", kwargs.get("reasoning", {}).get("effort")
-            ),
-            request_service_tier=existing_data.get(
-                "request_service_tier", kwargs.get("service_tier")
-            ),
-            response_service_tier=existing_data.get(
-                "response_service_tier",
-                parsed_response.service_tier,
-            ),
-        )
-        responses[response_id] = traced_data
-    except Exception:
-        raise
-        return response
-
-    if parsed_response.status == "completed":
-        span = tracer.start_span(
-            SPAN_NAME,
-            kind=SpanKind.CLIENT,
-            start_time=int(traced_data.start_time),
-            context=get_current_context(),
-        )
-        set_data_attributes(traced_data, span)
-        span.end()
-
-    return response
+    return _process_response(tracer, start_time, response, kwargs)
 
 
 @dont_throw
@@ -586,55 +480,68 @@ async def async_responses_get_or_create_wrapper(
         if isinstance(response, (Stream, AsyncStream)):
             return response
     except Exception as e:
-        response_id = kwargs.get("response_id")
-        existing_data = {}
-        if response_id and response_id in responses:
-            existing_data = responses[response_id].model_dump()
-        try:
-            traced_data = TracedData(
-                start_time=existing_data.get("start_time", start_time),
-                response_id=response_id or "",
-                input=process_input(
-                    kwargs.get("input", existing_data.get("input", []))
-                ),
-                instructions=kwargs.get(
-                    "instructions", existing_data.get("instructions", "")
-                ),
-                tools=get_tools_from_kwargs(kwargs) or existing_data.get("tools", []),
-                output_blocks=existing_data.get("output_blocks", {}),
-                usage=existing_data.get("usage"),
-                output_text=kwargs.get("output_text", existing_data.get("output_text")),
-                request_model=kwargs.get("model", existing_data.get("request_model")),
-                response_model=existing_data.get("response_model"),
-                request_reasoning_summary=kwargs.get("reasoning", {}).get(
-                    "summary", existing_data.get("request_reasoning_summary")
-                ),
-                request_reasoning_effort=kwargs.get("reasoning", {}).get(
-                    "effort", existing_data.get("request_reasoning_effort")
-                ),
-                request_service_tier=kwargs.get(
-                    "service_tier", existing_data.get("request_service_tier")
-                ),
-                # response_service_tier=existing_data.get("response_service_tier"),
-            )
-        except Exception:
-            traced_data = None
-
-        span = tracer.start_span(
-            SPAN_NAME,
-            kind=SpanKind.CLIENT,
-            start_time=(
-                start_time if traced_data is None else int(traced_data.start_time)
-            ),
-            context=get_current_context(),
-        )
-        span.set_attribute(ERROR_TYPE, e.__class__.__name__)
-        span.record_exception(e, attributes=get_event_attributes_from_context())
-        span.set_status(StatusCode.ERROR, str(e))
-        if traced_data:
-            set_data_attributes(traced_data, span)
-        span.end()
+        _process_exception(tracer, start_time, kwargs, e)
         raise
+    return _process_response(tracer, start_time, response, kwargs)
+
+
+@dont_throw
+def _process_exception(tracer: Tracer, start_time, kwargs, e):
+    response_id = kwargs.get("response_id")
+    existing_data = {}
+    if response_id and response_id in responses:
+        existing_data = responses[response_id].model_dump()
+    try:
+        request_reasoning_summary = None
+        request_reasoning_effort = None
+        request_reasoning = kwargs.get("reasoning", {})
+        try:
+            request_reasoning_summary = request_reasoning.get("summary")
+        except Exception:
+            pass
+        try:
+            request_reasoning_effort = request_reasoning.get("effort")
+        except Exception:
+            pass
+        traced_data = TracedData(
+            start_time=existing_data.get("start_time", start_time),
+            response_id=response_id or "",
+            input=process_input(kwargs.get("input", existing_data.get("input", []))),
+            instructions=kwargs.get("instructions", existing_data.get("instructions")),
+            tools=get_tools_from_kwargs(kwargs) or existing_data.get("tools", []),
+            output_blocks=existing_data.get("output_blocks", {}),
+            usage=existing_data.get("usage"),
+            output_text=kwargs.get("output_text", existing_data.get("output_text", "")),
+            request_model=kwargs.get("model", existing_data.get("request_model", "")),
+            response_model=existing_data.get("response_model", ""),
+            request_reasoning_summary=request_reasoning_summary
+            or existing_data.get("request_reasoning_summary"),
+            request_reasoning_effort=request_reasoning_effort
+            or existing_data.get("request_reasoning_effort"),
+            request_service_tier=kwargs.get(
+                "service_tier", existing_data.get("request_service_tier")
+            ),
+            # response_service_tier=existing_data.get("response_service_tier"),
+        )
+    except Exception:
+        traced_data = None
+
+    span = tracer.start_span(
+        SPAN_NAME,
+        kind=SpanKind.CLIENT,
+        start_time=(start_time if traced_data is None else int(traced_data.start_time)),
+        context=get_current_context(),
+    )
+    span.set_attribute(ERROR_TYPE, e.__class__.__name__)
+    span.record_exception(e, attributes=get_event_attributes_from_context())
+    span.set_status(StatusCode.ERROR, str(e))
+    if traced_data:
+        set_data_attributes(traced_data, span)
+    span.end()
+
+
+@dont_throw
+def _process_response(tracer: Tracer, start_time, response, kwargs):
     parsed_response = parse_response(response)
 
     response_id = getattr(parsed_response, "id", None)
@@ -651,6 +558,17 @@ async def async_responses_get_or_create_wrapper(
     merged_tools = existing_data.get("tools", []) + request_tools
 
     try:
+        request_reasoning_summary = None
+        request_reasoning_effort = None
+        request_reasoning = kwargs.get("reasoning", {})
+        try:
+            request_reasoning_summary = request_reasoning.get("summary")
+        except Exception:
+            pass
+        try:
+            request_reasoning_effort = request_reasoning.get("effort")
+        except Exception:
+            pass
         traced_data = TracedData(
             start_time=existing_data.get("start_time", start_time),
             response_id=response_id,
@@ -665,12 +583,10 @@ async def async_responses_get_or_create_wrapper(
             ),
             request_model=existing_data.get("request_model", kwargs.get("model")),
             response_model=existing_data.get("response_model", parsed_response.model),
-            request_reasoning_summary=existing_data.get(
-                "request_reasoning_summary", kwargs.get("reasoning", {}).get("summary")
-            ),
-            request_reasoning_effort=existing_data.get(
-                "request_reasoning_effort", kwargs.get("reasoning", {}).get("effort")
-            ),
+            request_reasoning_summary=request_reasoning_summary
+            or existing_data.get("request_reasoning_summary"),
+            request_reasoning_effort=request_reasoning_effort
+            or existing_data.get("request_reasoning_effort"),
             request_service_tier=existing_data.get(
                 "request_service_tier", kwargs.get("service_tier")
             ),
@@ -681,6 +597,7 @@ async def async_responses_get_or_create_wrapper(
         )
         responses[response_id] = traced_data
     except Exception:
+        raise
         return response
 
     if parsed_response.status == "completed":

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -43,7 +43,7 @@ from lmnr.opentelemetry_lib.tracing.context import (
 from lmnr.sdk.utils import json_dumps
 from openai._legacy_response import LegacyAPIResponse
 from opentelemetry import context as context_api
-from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
+from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_REQUEST_MODEL,
@@ -512,7 +512,10 @@ def responses_get_or_create_wrapper(tracer: Tracer, wrapped, instance, args, kwa
         raise
     parsed_response = parse_response(response)
 
-    existing_data = responses.get(parsed_response.id)
+    response_id = getattr(parsed_response, "id", None)
+    if not response_id:
+        return response
+    existing_data = responses.get(response_id)
     if existing_data is None:
         existing_data = {}
     else:
@@ -525,7 +528,7 @@ def responses_get_or_create_wrapper(tracer: Tracer, wrapped, instance, args, kwa
     try:
         traced_data = TracedData(
             start_time=existing_data.get("start_time", start_time),
-            response_id=parsed_response.id,
+            response_id=response_id,
             input=process_input(existing_data.get("input", kwargs.get("input"))),
             instructions=existing_data.get("instructions", kwargs.get("instructions")),
             tools=merged_tools if merged_tools else None,
@@ -551,7 +554,7 @@ def responses_get_or_create_wrapper(tracer: Tracer, wrapped, instance, args, kwa
                 parsed_response.service_tier,
             ),
         )
-        responses[parsed_response.id] = traced_data
+        responses[response_id] = traced_data
     except Exception:
         raise
         return response
@@ -634,7 +637,10 @@ async def async_responses_get_or_create_wrapper(
         raise
     parsed_response = parse_response(response)
 
-    existing_data = responses.get(parsed_response.id)
+    response_id = getattr(responses, "id", None)
+    if not response_id:
+        return response
+    existing_data = responses.get(response_id)
     if existing_data is None:
         existing_data = {}
     else:
@@ -647,7 +653,7 @@ async def async_responses_get_or_create_wrapper(
     try:
         traced_data = TracedData(
             start_time=existing_data.get("start_time", start_time),
-            response_id=parsed_response.id,
+            response_id=response_id,
             input=process_input(existing_data.get("input", kwargs.get("input"))),
             instructions=existing_data.get("instructions", kwargs.get("instructions")),
             tools=merged_tools if merged_tools else None,
@@ -673,7 +679,7 @@ async def async_responses_get_or_create_wrapper(
                 parsed_response.service_tier,
             ),
         )
-        responses[parsed_response.id] = traced_data
+        responses[response_id] = traced_data
     except Exception:
         return response
 
@@ -700,12 +706,15 @@ def responses_cancel_wrapper(tracer: Tracer, wrapped, instance, args, kwargs):
     if isinstance(response, Stream):
         return response
     parsed_response = parse_response(response)
-    existing_data = responses.pop(parsed_response.id, None)
+    response_id = getattr(parsed_response, "id", None)
+    if not response_id:
+        return response
+    existing_data = responses.pop(response_id, None)
     if existing_data is not None:
         span = tracer.start_span(
             SPAN_NAME,
             kind=SpanKind.CLIENT,
-            start_time=existing_data.start_time,
+            start_time=int(existing_data.start_time),
             record_exception=True,
             context=get_current_context(),
         )
@@ -735,7 +744,7 @@ async def async_responses_cancel_wrapper(
         span = tracer.start_span(
             SPAN_NAME,
             kind=SpanKind.CLIENT,
-            start_time=existing_data.start_time,
+            start_time=int(existing_data.start_time),
             record_exception=True,
             context=get_current_context(),
         )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -1,4 +1,7 @@
 import json
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.openai_agents.helpers import (
+    DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY,
+)
 import pydantic
 import re
 import time
@@ -454,6 +457,10 @@ def set_data_attributes(traced_response: TracedData, span: Span):
 def responses_get_or_create_wrapper(tracer: Tracer, wrapped, instance, args, kwargs):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
+    if context_api.get_value(
+        DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY, get_current_context()
+    ):
+        return wrapped(*args, **kwargs)
     start_time = time.time_ns()
 
     try:
@@ -472,6 +479,10 @@ async def async_responses_get_or_create_wrapper(
     tracer: Tracer, wrapped, instance, args, kwargs
 ):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+        return await wrapped(*args, **kwargs)
+    if context_api.get_value(
+        DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY, get_current_context()
+    ):
         return await wrapped(*args, **kwargs)
     start_time = time.time_ns()
 
@@ -619,6 +630,11 @@ def responses_cancel_wrapper(tracer: Tracer, wrapped, instance, args, kwargs):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
+    if context_api.get_value(
+        DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY, get_current_context()
+    ):
+        return wrapped(*args, **kwargs)
+
     response = wrapped(*args, **kwargs)
     if isinstance(response, Stream):
         return response
@@ -650,6 +666,11 @@ async def async_responses_cancel_wrapper(
     tracer: Tracer, wrapped, instance, args, kwargs
 ):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
+        return await wrapped(*args, **kwargs)
+
+    if context_api.get_value(
+        DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY, get_current_context()
+    ):
         return await wrapped(*args, **kwargs)
 
     response = await wrapped(*args, **kwargs)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/__init__.py
@@ -1,0 +1,10 @@
+"""OpenTelemetry OpenAI Agents SDK instrumentation for Laminar."""
+
+from .instrumentor import OpenAIAgentsInstrumentor, _instruments
+from .processor import LaminarAgentsTraceProcessor
+
+__all__ = [
+    "OpenAIAgentsInstrumentor",
+    "LaminarAgentsTraceProcessor",
+    "_instruments",
+]

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -52,7 +52,7 @@ def span_name(span: Any, span_data: Any) -> str:
     kind = span_kind(span_data)
     if kind:
         if kind in ["agent", "custom", "function", "tool"]:
-            return name_from_span_data(span_data)
+            return name_from_span_data(span_data) or f"agents.{kind}"
         return f"agents.{kind}"
     return "agents.span"
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -1,11 +1,22 @@
 """Span naming, type mapping, and utility helpers for OpenAI Agents instrumentation."""
 
-from __future__ import annotations
+from typing import Any
 
-from typing import TYPE_CHECKING, Any
+from lmnr.sdk.types import LaminarSpanType
+from lmnr.sdk.log import get_default_logger
 
-if TYPE_CHECKING:
-    from lmnr.sdk.types import LaminarSpanType
+from opentelemetry.context import create_key
+from pydantic import BaseModel
+
+logger = get_default_logger(__name__)
+
+
+DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY_RAW = (
+    "LMNR_DISABLE_OPENAI_RESPONSES_INSTRUMENTATION"
+)
+DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY = create_key(
+    DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY_RAW
+)
 
 
 def span_name(span: Any, span_data: Any) -> str:
@@ -130,3 +141,20 @@ def get_attr_not_none(obj: Any, *attrs: str) -> Any:
         if val is not None:
             return val
     return None
+
+
+def to_dict(
+    obj: BaseModel | dict, pydantic_kwargs: dict[str, Any] = {}
+) -> dict[str, Any]:
+    try:
+        if isinstance(obj, BaseModel):
+            return obj.model_dump(**pydantic_kwargs)
+        elif isinstance(obj, dict):
+            return obj
+        elif obj is None:
+            return {}
+        else:
+            return dict(obj)
+    except Exception as e:
+        logger.debug(f"Error converting to dict: {obj}, error: {e}")
+        return dict(obj)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -1,0 +1,132 @@
+"""Span naming, type mapping, and utility helpers for OpenAI Agents instrumentation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lmnr.sdk.types import LaminarSpanType
+
+
+def span_name(span: Any, span_data: Any) -> str:
+    name = getattr(span, "name", None)
+    if name:
+        return name
+    kind = span_kind(span_data)
+    if kind:
+        return f"agents.{kind}"
+    return "agents.span"
+
+
+def span_kind(span_data: Any) -> str:
+    if span_data is None:
+        return ""
+    return getattr(span_data, "type", "")
+
+
+def map_span_type(span_data: Any) -> LaminarSpanType:
+    kind = span_kind(span_data)
+    if kind in {"generation", "response", "transcription", "speech", "speech_group"}:
+        return "LLM"
+    if kind in {"function", "tool", "mcp_list_tools", "mcp_tools"}:
+        return "TOOL"
+    return "DEFAULT"
+
+
+def export_span_data(span_data: Any) -> dict[str, Any]:
+    if span_data is None:
+        return {}
+    if hasattr(span_data, "export"):
+        try:
+            exported = span_data.export()
+            if isinstance(exported, dict):
+                return exported
+        except Exception:
+            return {}
+    return {}
+
+
+def normalize_messages(data: Any, role: str = "user") -> list[dict[str, Any]]:
+    """Normalize various input/output formats into a list of message dicts."""
+    if data is None:
+        return []
+
+    if isinstance(data, str):
+        return [{"role": role, "content": data}]
+
+    if isinstance(data, list):
+        messages = []
+        for item in data:
+            if isinstance(item, dict):
+                messages.append(item)
+            elif hasattr(item, "model_dump"):
+                try:
+                    messages.append(item.model_dump())
+                except Exception:
+                    messages.append({"content": str(item)})
+            else:
+                item_dict = model_as_dict(item)
+                if item_dict:
+                    messages.append(item_dict)
+                else:
+                    messages.append({"content": str(item)})
+        return messages
+
+    if isinstance(data, dict):
+        return [data]
+
+    # If it's a pydantic model or similar
+    as_dict = model_as_dict(data)
+    if as_dict:
+        return [as_dict]
+
+    return [{"content": str(data)}]
+
+
+def model_as_dict(obj: Any) -> dict[str, Any] | None:
+    """Convert a pydantic model or similar object to a dict."""
+    if obj is None:
+        return None
+    if isinstance(obj, dict):
+        return obj
+    if hasattr(obj, "model_dump"):
+        try:
+            return obj.model_dump()
+        except Exception:
+            pass
+    if hasattr(obj, "dict"):
+        try:
+            return obj.dict()
+        except Exception:
+            pass
+    if hasattr(obj, "__dict__"):
+        return {k: v for k, v in obj.__dict__.items() if not k.startswith("_")}
+    return None
+
+
+def agent_name(agent: Any) -> str:
+    if isinstance(agent, dict):
+        return agent.get("name") or ""
+    if isinstance(agent, str):
+        return agent
+    if hasattr(agent, "name"):
+        return getattr(agent, "name") or ""
+    return ""
+
+
+def get_first_not_none(d: dict, *keys: str) -> Any:
+    """Get the first key whose value is not None from a dict."""
+    for key in keys:
+        val = d.get(key)
+        if val is not None:
+            return val
+    return None
+
+
+def get_attr_not_none(obj: Any, *attrs: str) -> Any:
+    """Get the first attribute whose value is not None from an object."""
+    for attr in attrs:
+        val = getattr(obj, attr, None)
+        if val is not None:
+            return val
+    return None

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -51,6 +51,8 @@ def span_name(span: Any, span_data: Any) -> str:
         return name
     kind = span_kind(span_data)
     if kind:
+        if kind in ["agent", "custom", "function", "tool"]:
+            return name_from_span_data(span_data)
         return f"agents.{kind}"
     return "agents.span"
 
@@ -141,7 +143,7 @@ def model_as_dict(obj: Any) -> dict[str, Any] | None:
     return None
 
 
-def agent_name(agent: Any) -> str:
+def name_from_span_data(agent: Any) -> str:
     if isinstance(agent, dict):
         return agent.get("name") or ""
     if isinstance(agent, str):

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -185,4 +185,7 @@ def to_dict(
             return dict(obj)
     except Exception as e:
         logger.debug(f"Error converting to dict: {obj}, error: {e}")
-        return dict(obj)
+        try:
+            return dict(obj)
+        except Exception:
+            return {}

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -28,7 +28,7 @@ def map_span_type(span_data: Any) -> LaminarSpanType:
     kind = span_kind(span_data)
     if kind in {"generation", "response", "transcription", "speech", "speech_group"}:
         return "LLM"
-    if kind in {"function", "tool", "mcp_list_tools", "mcp_tools"}:
+    if kind in {"function", "tool", "mcp_list_tools", "mcp_tools", "handoff"}:
         return "TOOL"
     return "DEFAULT"
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -1,5 +1,6 @@
 """Span naming, type mapping, and utility helpers for OpenAI Agents instrumentation."""
 
+import contextvars
 from typing import Any
 
 from lmnr.sdk.types import LaminarSpanType
@@ -17,6 +18,33 @@ DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY_RAW = (
 DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY = create_key(
     DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY_RAW
 )
+
+
+# Task-local system instructions for the currently-executing model call.
+# Set by the wrapped get_response / stream_response methods in instrumentor.py
+# and read by the response/generation span_data handlers so the system prompt
+# can be prepended to gen_ai.input.messages.
+_current_system_instructions: contextvars.ContextVar[str | None] = (
+    contextvars.ContextVar(
+        "lmnr_openai_agents_system_instructions", default=None
+    )
+)
+
+
+def get_current_system_instructions() -> str | None:
+    return _current_system_instructions.get()
+
+
+def set_current_system_instructions(
+    value: str | None,
+) -> "contextvars.Token[str | None]":
+    return _current_system_instructions.set(value)
+
+
+def reset_current_system_instructions(
+    token: "contextvars.Token[str | None]",
+) -> None:
+    _current_system_instructions.reset(token)
 
 
 def span_name(span: Any, span_data: Any) -> str:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/helpers.py
@@ -25,9 +25,7 @@ DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY = create_key(
 # and read by the response/generation span_data handlers so the system prompt
 # can be prepended to gen_ai.input.messages.
 _current_system_instructions: contextvars.ContextVar[str | None] = (
-    contextvars.ContextVar(
-        "lmnr_openai_agents_system_instructions", default=None
-    )
+    contextvars.ContextVar("lmnr_openai_agents_system_instructions", default=None)
 )
 
 
@@ -172,11 +170,11 @@ def get_attr_not_none(obj: Any, *attrs: str) -> Any:
 
 
 def to_dict(
-    obj: BaseModel | dict, pydantic_kwargs: dict[str, Any] = {}
+    obj: BaseModel | dict, pydantic_kwargs: dict[str, Any] | None = None
 ) -> dict[str, Any]:
     try:
         if isinstance(obj, BaseModel):
-            return obj.model_dump(**pydantic_kwargs)
+            return obj.model_dump(**(pydantic_kwargs or {}))
         elif isinstance(obj, dict):
             return obj
         elif obj is None:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/instrumentor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/instrumentor.py
@@ -122,15 +122,14 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):
             return
         try:
             from agents.tracing import get_trace_provider
+
             provider = get_trace_provider()
             # The SDK has no remove_trace_processor API, so read the
             # internal list and write back via the public set_processors.
             mp = getattr(provider, "_multi_processor", None)
             if mp is not None:
                 current = getattr(mp, "_processors", ())
-                provider.set_processors(
-                    [p for p in current if p is not processor]
-                )
+                provider.set_processors([p for p in current if p is not processor])
         except Exception:
             pass
         processor.shutdown()

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/instrumentor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/instrumentor.py
@@ -2,16 +2,79 @@
 
 from __future__ import annotations
 
-from typing import Collection
+from typing import Any, Collection
 
 from lmnr.sdk.log import get_default_logger
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from opentelemetry.instrumentation.utils import unwrap
+from wrapt import wrap_function_wrapper
 
+from .helpers import (
+    reset_current_system_instructions,
+    set_current_system_instructions,
+)
 from .processor import LaminarAgentsTraceProcessor
 
 logger = get_default_logger(__name__)
 
 _instruments = ("openai-agents >= 0.7.0",)
+
+
+def _extract_system_instructions(args: tuple, kwargs: dict) -> Any:
+    if "system_instructions" in kwargs:
+        return kwargs["system_instructions"]
+    if args:
+        return args[0]
+    return None
+
+
+async def _wrap_get_response(wrapped, instance, args, kwargs):
+    token = set_current_system_instructions(_extract_system_instructions(args, kwargs))
+    try:
+        return await wrapped(*args, **kwargs)
+    finally:
+        reset_current_system_instructions(token)
+
+
+def _wrap_stream_response(wrapped, instance, args, kwargs):
+    # wrapped(*args, **kwargs) returns an async generator; wrap iteration so the
+    # ContextVar stays set while generation_span / response_span exits (which is
+    # where on_span_end fires and we read the system instructions).
+    system_instructions = _extract_system_instructions(args, kwargs)
+
+    async def _gen():
+        token = set_current_system_instructions(system_instructions)
+        try:
+            async for chunk in wrapped(*args, **kwargs):
+                yield chunk
+        finally:
+            reset_current_system_instructions(token)
+
+    return _gen()
+
+
+_WRAPPED_TARGETS: tuple[tuple[str, str, Any], ...] = (
+    (
+        "agents.models.openai_responses",
+        "OpenAIResponsesModel.get_response",
+        _wrap_get_response,
+    ),
+    (
+        "agents.models.openai_responses",
+        "OpenAIResponsesModel.stream_response",
+        _wrap_stream_response,
+    ),
+    (
+        "agents.models.openai_chatcompletions",
+        "OpenAIChatCompletionsModel.get_response",
+        _wrap_get_response,
+    ),
+    (
+        "agents.models.openai_chatcompletions",
+        "OpenAIChatCompletionsModel.stream_response",
+        _wrap_stream_response,
+    ),
+)
 
 
 class OpenAIAgentsInstrumentor(BaseInstrumentor):
@@ -34,9 +97,26 @@ class OpenAIAgentsInstrumentor(BaseInstrumentor):
             logger.warning("Failed to register Laminar Agents processor: %s", exc)
             raise
         self._processor = processor
+
+        for module, name, wrapper in _WRAPPED_TARGETS:
+            try:
+                wrap_function_wrapper(module, name, wrapper)
+            except (AttributeError, ModuleNotFoundError, ImportError):
+                logger.debug("Failed to wrap %s.%s", module, name)
+
         logger.debug("Laminar OpenAI Agents trace processor registered")
 
     def _uninstrument(self, **kwargs):
+        for module, name, _ in _WRAPPED_TARGETS:
+            try:
+                cls_name, func_name = name.split(".", 1)
+                mod = __import__(module, fromlist=[cls_name])
+                cls = getattr(mod, cls_name, None)
+                if cls is not None:
+                    unwrap(cls, func_name)
+            except Exception:
+                logger.debug("Failed to unwrap %s.%s", module, name)
+
         processor = getattr(self, "_processor", None)
         if processor is None:
             return

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/instrumentor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/instrumentor.py
@@ -1,0 +1,57 @@
+"""OpenAIAgentsInstrumentor - BaseInstrumentor for OpenAI Agents SDK."""
+
+from __future__ import annotations
+
+from typing import Collection
+
+from lmnr.sdk.log import get_default_logger
+from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+
+from .processor import LaminarAgentsTraceProcessor
+
+logger = get_default_logger(__name__)
+
+_instruments = ("openai-agents >= 0.7.0",)
+
+
+class OpenAIAgentsInstrumentor(BaseInstrumentor):
+    """Instrumentor for the OpenAI Agents SDK tracing module."""
+
+    def instrumentation_dependencies(self) -> Collection[str]:
+        return _instruments
+
+    def _instrument(self, **kwargs):
+        try:
+            from agents.tracing import add_trace_processor
+        except Exception:
+            logger.debug("OpenAI Agents SDK not available; skipping instrumentation")
+            return
+
+        processor = LaminarAgentsTraceProcessor()
+        try:
+            add_trace_processor(processor)
+        except Exception as exc:
+            logger.warning("Failed to register Laminar Agents processor: %s", exc)
+            raise
+        self._processor = processor
+        logger.debug("Laminar OpenAI Agents trace processor registered")
+
+    def _uninstrument(self, **kwargs):
+        processor = getattr(self, "_processor", None)
+        if processor is None:
+            return
+        try:
+            from agents.tracing import get_trace_provider
+            provider = get_trace_provider()
+            # The SDK has no remove_trace_processor API, so read the
+            # internal list and write back via the public set_processors.
+            mp = getattr(provider, "_multi_processor", None)
+            if mp is not None:
+                current = getattr(mp, "_processors", ())
+                provider.set_processors(
+                    [p for p in current if p is not processor]
+                )
+        except Exception:
+            pass
+        processor.shutdown()
+        self._processor = None

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -8,6 +8,7 @@ if TYPE_CHECKING:
     from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
 
 from lmnr.opentelemetry_lib.tracing.attributes import Attributes
+from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.utils import json_dumps
 
 from .helpers import (
@@ -17,6 +18,8 @@ from .helpers import (
     normalize_messages,
     to_dict,
 )
+
+logger = get_default_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # gen_ai.input.messages / gen_ai.output.messages helpers
@@ -53,7 +56,7 @@ def set_gen_ai_input_messages(
             0,
             {
                 "role": "system",
-                "content": [{"type": "text", "text": system_instructions}],
+                "content": [{"type": "input_text", "text": system_instructions}],
             },
         )
     if messages:
@@ -80,51 +83,21 @@ def set_gen_ai_output_messages_from_response(
     if not output_items:
         return
 
-    messages: list[dict[str, Any]] = []
-    for item in output_items:
-        item_dict = model_as_dict(item)
-        if not item_dict:
-            continue
-        item_type = item_dict.get("type")
-        if item_type == "message":
-            content_list = item_dict.get("content", [])
-            text_parts = []
-            for content in content_list if isinstance(content_list, list) else []:
-                if isinstance(content, dict):
-                    ct = content.get("type", "")
-                    if ct in ("output_text", "text"):
-                        text_parts.append(content.get("text", ""))
-                else:
-                    ct = getattr(content, "type", "")
-                    if ct in ("output_text", "text"):
-                        text_parts.append(getattr(content, "text", ""))
-            if text_parts:
-                messages.append(
-                    {
-                        "role": item_dict.get("role", "assistant"),
-                        "content": "".join(text_parts),
-                    }
-                )
-        elif item_type == "function_call":
-            messages.append(
-                {
-                    "role": "assistant",
-                    "content": None,
-                    "tool_calls": [
-                        {
-                            "id": item_dict.get("call_id", item_dict.get("id", "")),
-                            "type": "function",
-                            "function": {
-                                "name": item_dict.get("name", ""),
-                                "arguments": item_dict.get("arguments", ""),
-                            },
-                        }
-                    ],
-                }
-            )
+    id = getattr(response, "id", None)
 
-    if messages:
-        lmnr_span.set_attribute("gen_ai.output.messages", json_dumps(messages))
+    if not isinstance(output_items, list):
+        logger.debug(
+            "Laminar OpenAI agents instrumentation, failed to parse output items. Expected array"
+        )
+        output_items = []
+
+    result = {
+        "id": id,
+        "object": "response",
+        "output": output_items,
+    }
+
+    lmnr_span.set_attribute("gen_ai.output.messages", json_dumps(result))
 
 
 # ---------------------------------------------------------------------------

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -47,11 +47,27 @@ def set_lmnr_span_io(
         lmnr_span.set_attribute("lmnr.span.output", json_dumps(output_data))
 
 
-def set_gen_ai_input_messages(lmnr_span: LaminarSpan, input_data: Any) -> None:
-    """Set gen_ai.input.messages on the span."""
-    if input_data is None:
+def set_gen_ai_input_messages(
+    lmnr_span: LaminarSpan,
+    input_data: Any,
+    system_instructions: str | None = None,
+) -> None:
+    """Set gen_ai.input.messages on the span.
+
+    If system_instructions is provided, prepend a system message so the span
+    reflects the full prompt actually sent to the model.
+    """
+    if input_data is None and not system_instructions:
         return
-    messages = normalize_messages(input_data)
+    messages = normalize_messages(input_data) if input_data is not None else []
+    if system_instructions:
+        messages.insert(
+            0,
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": system_instructions}],
+            },
+        )
     if messages:
         lmnr_span.set_attribute("gen_ai.input.messages", json_dumps(messages))
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -15,6 +15,7 @@ from .helpers import (
     get_first_not_none,
     model_as_dict,
     normalize_messages,
+    to_dict,
 )
 
 # ---------------------------------------------------------------------------
@@ -64,7 +65,9 @@ def set_gen_ai_output_messages(lmnr_span: LaminarSpan, output_data: Any) -> None
         lmnr_span.set_attribute("gen_ai.output.messages", json_dumps(messages))
 
 
-def set_gen_ai_output_messages_from_response(lmnr_span: LaminarSpan, response: Any) -> None:
+def set_gen_ai_output_messages_from_response(
+    lmnr_span: LaminarSpan, response: Any
+) -> None:
     """Extract and set gen_ai.output.messages from a Response object."""
     if response is None:
         return
@@ -193,6 +196,10 @@ def _apply_usage(lmnr_span: LaminarSpan, usage: Any) -> None:
     """Extract token usage from a usage object or dict, handling zero correctly."""
     if usage is None:
         return
+    cached_input_tokens = 0
+    reasoning_output_tokens = 0
+    input_token_details = None
+    output_token_details = None
 
     if isinstance(usage, dict):
         input_tokens = get_first_not_none(
@@ -202,16 +209,40 @@ def _apply_usage(lmnr_span: LaminarSpan, usage: Any) -> None:
             usage, "output_tokens", "completion_tokens", "output"
         )
         total_tokens = get_first_not_none(usage, "total_tokens", "total")
+        input_token_details = get_first_not_none(
+            usage, "input_token_details", "prompt_token_details"
+        )
+        output_token_details = get_first_not_none(
+            usage, "output_token_details", "completion_token_details"
+        )
     else:
         # Object with attributes (e.g. ResponseUsage)
         input_tokens = get_attr_not_none(usage, "input_tokens", "prompt_tokens")
         output_tokens = get_attr_not_none(usage, "output_tokens", "completion_tokens")
         total_tokens = get_attr_not_none(usage, "total_tokens")
+        input_token_details = get_attr_not_none(
+            usage, "input_token_details", "prompt_token_details"
+        )
+        output_token_details = get_attr_not_none(
+            usage, "output_token_details", "completion_token_details"
+        )
 
+    if input_token_details:
+        cached_input_tokens = to_dict(input_token_details).get("cached_tokens", 0)
+    if output_token_details:
+        reasoning_output_tokens = to_dict(output_token_details).get("reasoning_tokens")
     if input_tokens is not None:
         lmnr_span.set_attribute(Attributes.INPUT_TOKEN_COUNT.value, input_tokens)
+    if cached_input_tokens:
+        lmnr_span.set_attribute(
+            "gen_ai.usage.cache_read_input_tokens", cached_input_tokens
+        )
     if output_tokens is not None:
         lmnr_span.set_attribute(Attributes.OUTPUT_TOKEN_COUNT.value, output_tokens)
+    if reasoning_output_tokens:
+        lmnr_span.set_attribute(
+            "gen_ai.usage.reasoning_output_tokens", reasoning_output_tokens
+        )
     if total_tokens is not None:
         lmnr_span.set_attribute(Attributes.TOTAL_TOKEN_COUNT.value, total_tokens)
     elif input_tokens is not None and output_tokens is not None:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -14,25 +14,38 @@ from .helpers import (
     normalize_messages,
 )
 
-
 # ---------------------------------------------------------------------------
 # gen_ai.input.messages / gen_ai.output.messages helpers
 # ---------------------------------------------------------------------------
 
 
-def _set_gen_ai_messages(
+def set_gen_ai_messages(
     lmnr_span: Any,
     input_data: Any,
     output_data: Any,
 ) -> None:
     """Set gen_ai.input.messages and gen_ai.output.messages on the span."""
     if input_data is not None:
-        _set_gen_ai_input_messages(lmnr_span, input_data)
+        set_gen_ai_input_messages(lmnr_span, input_data)
     if output_data is not None:
-        _set_gen_ai_output_messages(lmnr_span, output_data)
+        set_gen_ai_output_messages(lmnr_span, output_data)
 
 
-def _set_gen_ai_input_messages(lmnr_span: Any, input_data: Any) -> None:
+def set_lmnr_span_io(
+    lmnr_span: Any,
+    input_data: Any,
+    output_data: Any,
+) -> None:
+    """Set gen_ai.input.messages and gen_ai.output.messages on the span."""
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+    if input_data is not None:
+        lmnr_span.set_attribute("lmnr.span.input", json_dumps(input_data))
+    if output_data is not None:
+        lmnr_span.set_attribute("lmnr.span.output", json_dumps(output_data))
+
+
+def set_gen_ai_input_messages(lmnr_span: Any, input_data: Any) -> None:
     """Set gen_ai.input.messages on the span."""
     if input_data is None:
         return
@@ -44,7 +57,7 @@ def _set_gen_ai_input_messages(lmnr_span: Any, input_data: Any) -> None:
         lmnr_span.set_attribute("gen_ai.input.messages", json_dumps(messages))
 
 
-def _set_gen_ai_output_messages(lmnr_span: Any, output_data: Any) -> None:
+def set_gen_ai_output_messages(lmnr_span: Any, output_data: Any) -> None:
     """Set gen_ai.output.messages on the span."""
     if output_data is None:
         return
@@ -56,7 +69,7 @@ def _set_gen_ai_output_messages(lmnr_span: Any, output_data: Any) -> None:
         lmnr_span.set_attribute("gen_ai.output.messages", json_dumps(messages))
 
 
-def _set_gen_ai_output_messages_from_response(lmnr_span: Any, response: Any) -> None:
+def set_gen_ai_output_messages_from_response(lmnr_span: Any, response: Any) -> None:
     """Extract and set gen_ai.output.messages from a Response object."""
     if response is None:
         return
@@ -119,7 +132,7 @@ def _set_gen_ai_output_messages_from_response(lmnr_span: Any, response: Any) -> 
 # ---------------------------------------------------------------------------
 
 
-def _set_tool_definitions_from_response(lmnr_span: Any, response: Any) -> None:
+def set_tool_definitions_from_response(lmnr_span: Any, response: Any) -> None:
     """Extract gen_ai.tool.definitions from a Response object's tools field."""
     if not hasattr(lmnr_span, "set_attribute"):
         return
@@ -165,7 +178,7 @@ def _set_tool_definitions_from_response(lmnr_span: Any, response: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _apply_llm_attributes(lmnr_span: Any, data: dict[str, Any]) -> None:
+def apply_llm_attributes(lmnr_span: Any, data: dict[str, Any]) -> None:
     if not data or not hasattr(lmnr_span, "set_attribute"):
         return
 
@@ -217,7 +230,7 @@ def _apply_usage(lmnr_span: Any, usage: Any) -> None:
         )
 
 
-def _response_to_llm_data(response: Any) -> dict[str, Any]:
+def response_to_llm_data(response: Any) -> dict[str, Any]:
     if response is None:
         return {}
     return {

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -202,8 +202,8 @@ def _apply_usage(lmnr_span: LaminarSpan, usage: Any) -> None:
         return
     cached_input_tokens = 0
     reasoning_output_tokens = 0
-    input_token_details = None
-    output_token_details = None
+    input_tokens_details = None
+    output_tokens_details = None
 
     if isinstance(usage, dict):
         input_tokens = get_first_not_none(
@@ -213,28 +213,28 @@ def _apply_usage(lmnr_span: LaminarSpan, usage: Any) -> None:
             usage, "output_tokens", "completion_tokens", "output"
         )
         total_tokens = get_first_not_none(usage, "total_tokens", "total")
-        input_token_details = get_first_not_none(
-            usage, "input_token_details", "prompt_token_details"
+        input_tokens_details = get_first_not_none(
+            usage, "input_tokens_details", "prompt_tokens_details"
         )
-        output_token_details = get_first_not_none(
-            usage, "output_token_details", "completion_token_details"
+        output_tokens_details = get_first_not_none(
+            usage, "output_tokens_details", "completion_tokens_details"
         )
     else:
         # Object with attributes (e.g. ResponseUsage)
         input_tokens = get_attr_not_none(usage, "input_tokens", "prompt_tokens")
         output_tokens = get_attr_not_none(usage, "output_tokens", "completion_tokens")
         total_tokens = get_attr_not_none(usage, "total_tokens")
-        input_token_details = get_attr_not_none(
-            usage, "input_token_details", "prompt_token_details"
+        input_tokens_details = get_attr_not_none(
+            usage, "input_tokens_details", "prompt_tokens_details"
         )
-        output_token_details = get_attr_not_none(
-            usage, "output_token_details", "completion_token_details"
+        output_tokens_details = get_attr_not_none(
+            usage, "output_tokens_details", "completion_tokens_details"
         )
 
-    if input_token_details:
-        cached_input_tokens = to_dict(input_token_details).get("cached_tokens", 0)
-    if output_token_details:
-        reasoning_output_tokens = to_dict(output_token_details).get("reasoning_tokens")
+    if input_tokens_details:
+        cached_input_tokens = to_dict(input_tokens_details).get("cached_tokens", 0)
+    if output_tokens_details:
+        reasoning_output_tokens = to_dict(output_tokens_details).get("reasoning_tokens")
     if input_tokens is not None:
         lmnr_span.set_attribute(Attributes.INPUT_TOKEN_COUNT.value, input_tokens)
     if cached_input_tokens:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
 
 from lmnr.opentelemetry_lib.tracing.attributes import Attributes
 from lmnr.sdk.utils import json_dumps
@@ -20,7 +23,7 @@ from .helpers import (
 
 
 def set_gen_ai_messages(
-    lmnr_span: Any,
+    lmnr_span: LaminarSpan,
     input_data: Any,
     output_data: Any,
 ) -> None:
@@ -32,48 +35,38 @@ def set_gen_ai_messages(
 
 
 def set_lmnr_span_io(
-    lmnr_span: Any,
+    lmnr_span: LaminarSpan,
     input_data: Any,
     output_data: Any,
 ) -> None:
     """Set gen_ai.input.messages and gen_ai.output.messages on the span."""
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
     if input_data is not None:
         lmnr_span.set_attribute("lmnr.span.input", json_dumps(input_data))
     if output_data is not None:
         lmnr_span.set_attribute("lmnr.span.output", json_dumps(output_data))
 
 
-def set_gen_ai_input_messages(lmnr_span: Any, input_data: Any) -> None:
+def set_gen_ai_input_messages(lmnr_span: LaminarSpan, input_data: Any) -> None:
     """Set gen_ai.input.messages on the span."""
     if input_data is None:
         return
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     messages = normalize_messages(input_data)
     if messages:
         lmnr_span.set_attribute("gen_ai.input.messages", json_dumps(messages))
 
 
-def set_gen_ai_output_messages(lmnr_span: Any, output_data: Any) -> None:
+def set_gen_ai_output_messages(lmnr_span: LaminarSpan, output_data: Any) -> None:
     """Set gen_ai.output.messages on the span."""
     if output_data is None:
         return
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     messages = normalize_messages(output_data, role="assistant")
     if messages:
         lmnr_span.set_attribute("gen_ai.output.messages", json_dumps(messages))
 
 
-def set_gen_ai_output_messages_from_response(lmnr_span: Any, response: Any) -> None:
+def set_gen_ai_output_messages_from_response(lmnr_span: LaminarSpan, response: Any) -> None:
     """Extract and set gen_ai.output.messages from a Response object."""
     if response is None:
-        return
-    if not hasattr(lmnr_span, "set_attribute"):
         return
 
     output_items = getattr(response, "output", None)
@@ -132,11 +125,8 @@ def set_gen_ai_output_messages_from_response(lmnr_span: Any, response: Any) -> N
 # ---------------------------------------------------------------------------
 
 
-def set_tool_definitions_from_response(lmnr_span: Any, response: Any) -> None:
+def set_tool_definitions_from_response(lmnr_span: LaminarSpan, response: Any) -> None:
     """Extract gen_ai.tool.definitions from a Response object's tools field."""
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     tools = getattr(response, "tools", None)
     if not tools:
         return
@@ -178,8 +168,8 @@ def set_tool_definitions_from_response(lmnr_span: Any, response: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def apply_llm_attributes(lmnr_span: Any, data: dict[str, Any]) -> None:
-    if not data or not hasattr(lmnr_span, "set_attribute"):
+def apply_llm_attributes(lmnr_span: LaminarSpan, data: dict[str, Any]) -> None:
+    if not data:
         return
 
     model = data.get("model")
@@ -199,7 +189,7 @@ def apply_llm_attributes(lmnr_span: Any, data: dict[str, Any]) -> None:
         lmnr_span.set_attribute(Attributes.RESPONSE_ID.value, response_id)
 
 
-def _apply_usage(lmnr_span: Any, usage: Any) -> None:
+def _apply_usage(lmnr_span: LaminarSpan, usage: Any) -> None:
     """Extract token usage from a usage object or dict, handling zero correctly."""
     if usage is None:
         return

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -1,0 +1,227 @@
+"""gen_ai message helpers, tool definitions, and LLM attribute helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from lmnr.opentelemetry_lib.tracing.attributes import Attributes
+from lmnr.sdk.utils import json_dumps
+
+from .helpers import (
+    get_attr_not_none,
+    get_first_not_none,
+    model_as_dict,
+    normalize_messages,
+)
+
+
+# ---------------------------------------------------------------------------
+# gen_ai.input.messages / gen_ai.output.messages helpers
+# ---------------------------------------------------------------------------
+
+
+def _set_gen_ai_messages(
+    lmnr_span: Any,
+    input_data: Any,
+    output_data: Any,
+) -> None:
+    """Set gen_ai.input.messages and gen_ai.output.messages on the span."""
+    if input_data is not None:
+        _set_gen_ai_input_messages(lmnr_span, input_data)
+    if output_data is not None:
+        _set_gen_ai_output_messages(lmnr_span, output_data)
+
+
+def _set_gen_ai_input_messages(lmnr_span: Any, input_data: Any) -> None:
+    """Set gen_ai.input.messages on the span."""
+    if input_data is None:
+        return
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    messages = normalize_messages(input_data)
+    if messages:
+        lmnr_span.set_attribute("gen_ai.input.messages", json_dumps(messages))
+
+
+def _set_gen_ai_output_messages(lmnr_span: Any, output_data: Any) -> None:
+    """Set gen_ai.output.messages on the span."""
+    if output_data is None:
+        return
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    messages = normalize_messages(output_data, role="assistant")
+    if messages:
+        lmnr_span.set_attribute("gen_ai.output.messages", json_dumps(messages))
+
+
+def _set_gen_ai_output_messages_from_response(lmnr_span: Any, response: Any) -> None:
+    """Extract and set gen_ai.output.messages from a Response object."""
+    if response is None:
+        return
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    output_items = getattr(response, "output", None)
+    if not output_items:
+        return
+
+    messages: list[dict[str, Any]] = []
+    for item in output_items:
+        item_dict = model_as_dict(item)
+        if not item_dict:
+            continue
+        item_type = item_dict.get("type")
+        if item_type == "message":
+            content_list = item_dict.get("content", [])
+            text_parts = []
+            for content in content_list if isinstance(content_list, list) else []:
+                if isinstance(content, dict):
+                    ct = content.get("type", "")
+                    if ct in ("output_text", "text"):
+                        text_parts.append(content.get("text", ""))
+                else:
+                    ct = getattr(content, "type", "")
+                    if ct in ("output_text", "text"):
+                        text_parts.append(getattr(content, "text", ""))
+            if text_parts:
+                messages.append(
+                    {
+                        "role": item_dict.get("role", "assistant"),
+                        "content": "".join(text_parts),
+                    }
+                )
+        elif item_type == "function_call":
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": item_dict.get("call_id", item_dict.get("id", "")),
+                            "type": "function",
+                            "function": {
+                                "name": item_dict.get("name", ""),
+                                "arguments": item_dict.get("arguments", ""),
+                            },
+                        }
+                    ],
+                }
+            )
+
+    if messages:
+        lmnr_span.set_attribute("gen_ai.output.messages", json_dumps(messages))
+
+
+# ---------------------------------------------------------------------------
+# Tool definitions
+# ---------------------------------------------------------------------------
+
+
+def _set_tool_definitions_from_response(lmnr_span: Any, response: Any) -> None:
+    """Extract gen_ai.tool.definitions from a Response object's tools field."""
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    tools = getattr(response, "tools", None)
+    if not tools:
+        return
+
+    tool_defs = []
+    for tool in tools:
+        tool_dict = model_as_dict(tool)
+        if not tool_dict:
+            continue
+        tool_type = tool_dict.get("type")
+        if tool_type == "function":
+            func_def = {}
+            func_def["type"] = "function"
+            function_info = tool_dict.get("function")
+            if function_info is None:
+                function_info = tool_dict
+            func_def["function"] = {
+                "name": function_info.get("name", ""),
+            }
+            desc = function_info.get("description")
+            if desc:
+                func_def["function"]["description"] = desc
+            params = function_info.get("parameters")
+            if params:
+                func_def["function"]["parameters"] = params
+            strict = function_info.get("strict")
+            if strict is not None:
+                func_def["function"]["strict"] = strict
+            tool_defs.append(func_def)
+        else:
+            tool_defs.append(tool_dict)
+
+    if tool_defs:
+        lmnr_span.set_attribute("gen_ai.tool.definitions", json_dumps(tool_defs))
+
+
+# ---------------------------------------------------------------------------
+# LLM attributes (model, usage, response_id)
+# ---------------------------------------------------------------------------
+
+
+def _apply_llm_attributes(lmnr_span: Any, data: dict[str, Any]) -> None:
+    if not data or not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    model = data.get("model")
+    if model:
+        lmnr_span.set_attribute(Attributes.REQUEST_MODEL.value, model)
+        lmnr_span.set_attribute(Attributes.RESPONSE_MODEL.value, model)
+        lmnr_span.set_attribute(Attributes.PROVIDER.value, "openai")
+
+    usage = data.get("usage")
+    if usage is not None:
+        _apply_usage(lmnr_span, usage)
+
+    response_id = data.get("response_id")
+    if response_id is None:
+        response_id = data.get("id")
+    if response_id is not None:
+        lmnr_span.set_attribute(Attributes.RESPONSE_ID.value, response_id)
+
+
+def _apply_usage(lmnr_span: Any, usage: Any) -> None:
+    """Extract token usage from a usage object or dict, handling zero correctly."""
+    if usage is None:
+        return
+
+    if isinstance(usage, dict):
+        input_tokens = get_first_not_none(
+            usage, "input_tokens", "prompt_tokens", "input"
+        )
+        output_tokens = get_first_not_none(
+            usage, "output_tokens", "completion_tokens", "output"
+        )
+        total_tokens = get_first_not_none(usage, "total_tokens", "total")
+    else:
+        # Object with attributes (e.g. ResponseUsage)
+        input_tokens = get_attr_not_none(usage, "input_tokens", "prompt_tokens")
+        output_tokens = get_attr_not_none(usage, "output_tokens", "completion_tokens")
+        total_tokens = get_attr_not_none(usage, "total_tokens")
+
+    if input_tokens is not None:
+        lmnr_span.set_attribute(Attributes.INPUT_TOKEN_COUNT.value, input_tokens)
+    if output_tokens is not None:
+        lmnr_span.set_attribute(Attributes.OUTPUT_TOKEN_COUNT.value, output_tokens)
+    if total_tokens is not None:
+        lmnr_span.set_attribute(Attributes.TOTAL_TOKEN_COUNT.value, total_tokens)
+    elif input_tokens is not None and output_tokens is not None:
+        lmnr_span.set_attribute(
+            Attributes.TOTAL_TOKEN_COUNT.value, input_tokens + output_tokens
+        )
+
+
+def _response_to_llm_data(response: Any) -> dict[str, Any]:
+    if response is None:
+        return {}
+    return {
+        "model": getattr(response, "model", None),
+        "usage": getattr(response, "usage", None),
+        "response_id": getattr(response, "id", None),
+    }

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/messages.py
@@ -23,18 +23,6 @@ from .helpers import (
 # ---------------------------------------------------------------------------
 
 
-def set_gen_ai_messages(
-    lmnr_span: LaminarSpan,
-    input_data: Any,
-    output_data: Any,
-) -> None:
-    """Set gen_ai.input.messages and gen_ai.output.messages on the span."""
-    if input_data is not None:
-        set_gen_ai_input_messages(lmnr_span, input_data)
-    if output_data is not None:
-        set_gen_ai_output_messages(lmnr_span, output_data)
-
-
 def set_lmnr_span_io(
     lmnr_span: LaminarSpan,
     input_data: Any,

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
@@ -7,7 +7,7 @@ import threading
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
-from lmnr import Laminar
+from opentelemetry.context import get_value, set_value
 
 try:
     from agents.tracing import TracingProcessor as _Base
@@ -21,7 +21,17 @@ if TYPE_CHECKING:
     from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
     from lmnr.sdk.types import LaminarSpanContext
 
-from .helpers import agent_name, export_span_data, map_span_type, span_kind, span_name
+from lmnr import Laminar
+from lmnr.opentelemetry_lib.tracing.context import get_current_context
+
+from .helpers import (
+    DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY,
+    agent_name,
+    export_span_data,
+    map_span_type,
+    span_kind,
+    span_name,
+)
 from .span_data import apply_span_data, apply_span_error
 
 logger = logging.getLogger(__name__)
@@ -110,16 +120,8 @@ class LaminarAgentsTraceProcessor(_Base):
         lmnr_span = None
         try:
             state = self._get_or_create_trace(span)
-            parent_id = getattr(span, "parent_id", None)
-            with self._lock:
-                parent_entry = state.spans.get(parent_id) if parent_id else None
-            parent_lmnr_span = (
-                parent_entry.lmnr_span if parent_entry else state.root_span
-            )
 
             parent_ctx: LaminarSpanContext | None = None
-            if parent_lmnr_span is not None:
-                parent_ctx = parent_lmnr_span.get_laminar_span_context()
 
             span_data = span.span_data
             span_type = map_span_type(span_data)
@@ -128,6 +130,7 @@ class LaminarAgentsTraceProcessor(_Base):
             # If this is an agent span, check if a handoff targeting this agent
             # is pending. If so, make this span a child of the handoff span so
             # the subagent is nested under the handoff that triggered it.
+            this_agent = None
             if span_kind(span_data) == "agent":
                 this_agent = agent_name(
                     export_span_data(span_data).get("name")
@@ -138,12 +141,17 @@ class LaminarAgentsTraceProcessor(_Base):
                 if handoff_ctx is not None:
                     parent_ctx = handoff_ctx
 
-            lmnr_span = Laminar.start_span(
-                name,
-                span_type=span_type,
-                parent_span_context=parent_ctx,
+            otel_ctx = get_current_context()
+            ctx = set_value(
+                DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY, True, otel_ctx
             )
 
+            lmnr_span = Laminar.start_active_span(
+                name=this_agent or name,
+                span_type=span_type,
+                parent_span_context=parent_ctx,
+                context=ctx,
+            )
             # Use span_id as key so parent_id lookups in on_span_start
             # match correctly. The SDK always generates a span_id.
             key = span.span_id
@@ -310,7 +318,7 @@ class LaminarAgentsTraceProcessor(_Base):
             try:
                 # Use a generic name; on_trace_start will update it
                 # to the actual trace name via update_name.
-                root_span = Laminar.start_span(
+                root_span = Laminar.start_active_span(
                     "agents.trace",
                 )
                 state.root_span = root_span

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
@@ -15,8 +15,8 @@ try:
 except ImportError:  # openai-agents not installed
     _Base = object
 
-from .helpers import map_span_type, span_kind, span_name
-from .span_data import _apply_span_data, _apply_span_error
+from .helpers import map_span_type, span_name
+from .span_data import apply_span_data, apply_span_error
 
 logger = logging.getLogger(__name__)
 
@@ -122,13 +122,7 @@ class LaminarAgentsTraceProcessor(_Base):
                 name,
                 span_type=span_type,
                 parent_span_context=parent_ctx,
-                tags=["openai-agents"],
             )
-            if hasattr(lmnr_span, "set_attribute"):
-                lmnr_span.set_attribute("openai.agents.span.type", span_kind(span_data))
-                span_id = getattr(span, "span_id", "")
-                if span_id:
-                    lmnr_span.set_attribute("openai.agents.span.id", span_id)
 
             # Use span_id as key so parent_id lookups in on_span_start
             # match correctly. The SDK always generates a span_id.
@@ -174,8 +168,8 @@ class LaminarAgentsTraceProcessor(_Base):
         span_data = getattr(span, "span_data", None)
         try:
             try:
-                _apply_span_data(entry.lmnr_span, span_data)
-                _apply_span_error(entry.lmnr_span, span)
+                apply_span_data(entry.lmnr_span, span_data)
+                apply_span_error(entry.lmnr_span, span)
             except Exception:
                 pass
             try:
@@ -236,8 +230,8 @@ class LaminarAgentsTraceProcessor(_Base):
             try:
                 if entry.agents_span is not None:
                     span_data = getattr(entry.agents_span, "span_data", None)
-                    _apply_span_data(entry.lmnr_span, span_data)
-                    _apply_span_error(entry.lmnr_span, entry.agents_span)
+                    apply_span_data(entry.lmnr_span, span_data)
+                    apply_span_error(entry.lmnr_span, entry.agents_span)
             except Exception:
                 pass
             try:
@@ -266,7 +260,6 @@ class LaminarAgentsTraceProcessor(_Base):
                 # to the actual trace name via update_name.
                 root_span = Laminar.start_span(
                     "agents.trace",
-                    tags=["openai-agents"],
                 )
                 state.root_span = root_span
             except Exception:
@@ -287,9 +280,6 @@ class LaminarAgentsTraceProcessor(_Base):
         trace_metadata = getattr(trace, "metadata", None)
         if isinstance(trace_metadata, dict):
             metadata.update(trace_metadata)
-        trace_id = getattr(trace, "trace_id", None)
-        if trace_id:
-            metadata["openai.agents.trace_id"] = trace_id
         group_id = getattr(trace, "group_id", None)
         if group_id:
             metadata["openai.agents.group_id"] = group_id
@@ -303,10 +293,6 @@ class LaminarAgentsTraceProcessor(_Base):
                 pass
         session_id = metadata.get("session_id") if metadata else None
         user_id = metadata.get("user_id") if metadata else None
-        if not session_id:
-            session_id = os.getenv("LMNR_SESSION_ID")
-        if not user_id:
-            user_id = os.getenv("LMNR_USER_ID")
         if session_id and hasattr(root_span, "set_trace_session_id"):
             root_span.set_trace_session_id(session_id)
         if user_id and hasattr(root_span, "set_trace_user_id"):

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
@@ -26,7 +26,7 @@ from lmnr.opentelemetry_lib.tracing.context import get_current_context
 
 from .helpers import (
     DISABLE_OPENAI_RESPONSES_INSTRUMENTATION_CONTEXT_KEY,
-    agent_name,
+    name_from_span_data,
     export_span_data,
     map_span_type,
     span_kind,
@@ -130,9 +130,8 @@ class LaminarAgentsTraceProcessor(_Base):
             # If this is an agent span, check if a handoff targeting this agent
             # is pending. If so, make this span a child of the handoff span so
             # the subagent is nested under the handoff that triggered it.
-            this_agent = None
             if span_kind(span_data) == "agent":
-                this_agent = agent_name(
+                this_agent = name_from_span_data(
                     export_span_data(span_data).get("name")
                     or getattr(span_data, "name", None)
                 )
@@ -147,7 +146,7 @@ class LaminarAgentsTraceProcessor(_Base):
             )
 
             lmnr_span = Laminar.start_active_span(
-                name=this_agent or name,
+                name=name,
                 span_type=span_type,
                 parent_span_context=parent_ctx,
                 context=ctx,
@@ -207,7 +206,7 @@ class LaminarAgentsTraceProcessor(_Base):
             # (both children of the handoff's parent).
             if span_kind(span_data) == "handoff":
                 try:
-                    to_agent = agent_name(
+                    to_agent = name_from_span_data(
                         export_span_data(span_data).get("to_agent")
                         or getattr(span_data, "to_agent", None)
                     )
@@ -267,7 +266,7 @@ class LaminarAgentsTraceProcessor(_Base):
         if not state.ready.wait(timeout=self._SHUTDOWN_TIMEOUT) or state.failed:
             return
         # Wait for in-flight on_span_end calls, then atomically snapshot
-        # remaining spans.  Re-check under the lock to close the window
+        # remaining spans. Re-check under the lock to close the window
         # where a new on_span_end increments pending_ends between the
         # wait() return and the lock acquisition.
         for _ in range(3):  # bounded retries

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
@@ -15,7 +15,9 @@ except ImportError:  # openai-agents not installed
     _Base = object
 
 if TYPE_CHECKING:
-    from agents.tracing import Span as AgentsSpan, Trace
+    from agents.tracing import Span as AgentsSpan
+    from agents.tracing import Trace
+
     from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
     from lmnr.sdk.types import LaminarSpanContext
 
@@ -286,11 +288,14 @@ class LaminarAgentsTraceProcessor(_Base):
             except Exception:
                 pass
         try:
-            state.root_span.end()
+            if state.root_span:
+                state.root_span.end()
         except Exception:
             pass
 
-    def _get_or_create_trace(self, trace_or_span: Trace | AgentsSpan[Any]) -> _TraceState:
+    def _get_or_create_trace(
+        self, trace_or_span: Trace | AgentsSpan[Any]
+    ) -> _TraceState:
         trace_id = getattr(trace_or_span, "trace_id", None)
         if not trace_id:
             trace_id = "unknown"
@@ -322,7 +327,9 @@ class LaminarAgentsTraceProcessor(_Base):
                 raise RuntimeError("Root span creation failed for this trace")
         return state
 
-    def _apply_trace_metadata(self, root_span: LaminarSpan | None, trace: Trace) -> None:
+    def _apply_trace_metadata(
+        self, root_span: LaminarSpan | None, trace: Trace
+    ) -> None:
         if root_span is None:
             return
         metadata: dict[str, Any] = {}

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from dataclasses import dataclass, field
 from typing import Any
@@ -15,7 +14,7 @@ try:
 except ImportError:  # openai-agents not installed
     _Base = object
 
-from .helpers import map_span_type, span_name
+from .helpers import agent_name, export_span_data, map_span_type, span_kind, span_name
 from .span_data import apply_span_data, apply_span_error
 
 logger = logging.getLogger(__name__)
@@ -41,6 +40,9 @@ class _TraceState:
     failed: bool = False
     # Guards against double-ending from concurrent on_trace_end and shutdown.
     ended: bool = False
+    # Maps destination agent name -> handoff lmnr span context so that the
+    # subsequent agent span becomes a child of the handoff span.
+    pending_handoff_ctxs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         # Initially no pending ends, so mark as done.
@@ -118,6 +120,19 @@ class LaminarAgentsTraceProcessor(_Base):
             span_type = map_span_type(span_data)
             name = span_name(span, span_data)
 
+            # If this is an agent span, check if a handoff targeting this agent
+            # is pending. If so, make this span a child of the handoff span so
+            # the subagent is nested under the handoff that triggered it.
+            if span_kind(span_data) == "agent":
+                this_agent = agent_name(
+                    export_span_data(span_data).get("name")
+                    or getattr(span_data, "name", None)
+                )
+                with self._lock:
+                    handoff_ctx = state.pending_handoff_ctxs.pop(this_agent, None)
+                if handoff_ctx is not None:
+                    parent_ctx = handoff_ctx
+
             lmnr_span = Laminar.start_span(
                 name,
                 span_type=span_type,
@@ -172,6 +187,37 @@ class LaminarAgentsTraceProcessor(_Base):
                 apply_span_error(entry.lmnr_span, span)
             except Exception:
                 pass
+
+            # When a handoff span ends, save the *parent* span's context keyed
+            # by the destination agent name. on_span_start consumes this so
+            # the subsequent agent span becomes a sibling of the handoff span
+            # (both children of the handoff's parent).
+            if span_kind(span_data) == "handoff":
+                try:
+                    to_agent = agent_name(
+                        export_span_data(span_data).get("to_agent")
+                        or getattr(span_data, "to_agent", None)
+                    )
+                    if to_agent:
+                        parent_id = getattr(span, "parent_id", None)
+                        with self._lock:
+                            parent_entry = (
+                                state.spans.get(parent_id) if parent_id else None
+                            )
+                        parent_lmnr_span = (
+                            parent_entry.lmnr_span
+                            if parent_entry is not None
+                            else state.root_span
+                        )
+                        if parent_lmnr_span is not None and hasattr(
+                            parent_lmnr_span, "get_laminar_span_context"
+                        ):
+                            handoff_ctx = parent_lmnr_span.get_laminar_span_context()
+                            with self._lock:
+                                state.pending_handoff_ctxs[to_agent] = handoff_ctx
+                except Exception:
+                    pass
+
             try:
                 entry.lmnr_span.end()
             except Exception:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
@@ -1,0 +1,313 @@
+"""LaminarAgentsTraceProcessor - mirrors OpenAI Agents spans into Laminar."""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from dataclasses import dataclass, field
+from typing import Any
+
+from lmnr import Laminar
+
+try:
+    from agents.tracing import TracingProcessor as _Base
+except ImportError:  # openai-agents not installed
+    _Base = object
+
+from .helpers import map_span_type, span_kind, span_name
+from .span_data import _apply_span_data, _apply_span_error
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _SpanEntry:
+    lmnr_span: Any
+    agents_span: Any = None
+
+
+@dataclass
+class _TraceState:
+    root_span: Any = None
+    spans: dict[str, _SpanEntry] = field(default_factory=dict)
+    ready: threading.Event = field(default_factory=threading.Event)
+    # Tracks in-flight on_span_end calls so _end_trace_state can wait
+    # for all child spans to finish before ending the root span.
+    pending_ends: int = 0
+    pending_ends_done: threading.Event = field(default_factory=threading.Event)
+    # Set to True when root span creation fails, so waiting threads
+    # know the state is unusable rather than proceeding with root_span=None.
+    failed: bool = False
+    # Guards against double-ending from concurrent on_trace_end and shutdown.
+    ended: bool = False
+
+    def __post_init__(self) -> None:
+        # Initially no pending ends, so mark as done.
+        self.pending_ends_done.set()
+
+
+class LaminarAgentsTraceProcessor(_Base):
+    """TracingProcessor implementation that mirrors OpenAI Agents spans into Laminar."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._traces: dict[str, _TraceState] = {}
+        self._disabled = False
+
+    def on_trace_start(self, trace: Any) -> None:
+        if self._disabled:
+            return
+        trace_id = getattr(trace, "trace_id", None)
+        if not trace_id:
+            return
+        try:
+            state = self._get_or_create_trace(trace)
+            # If a span arrived first, the root span may have a placeholder
+            # name. Update it to the actual trace name.
+            trace_name = getattr(trace, "name", None)
+            if trace_name and hasattr(state.root_span, "update_name"):
+                try:
+                    state.root_span.update_name(trace_name)
+                except Exception:
+                    pass
+            self._apply_trace_metadata(state.root_span, trace)
+        except Exception:
+            logger.debug("Error in on_trace_start", exc_info=True)
+
+    def on_trace_end(self, trace: Any) -> None:
+        if self._disabled:
+            return
+        trace_id = getattr(trace, "trace_id", None)
+        if not trace_id:
+            return
+        with self._lock:
+            state = self._traces.get(trace_id)
+            if not state or state.ended:
+                return
+            state.ended = True
+        self._end_trace_state(state)
+        # Remove after cleanup so concurrent on_span_end calls can still
+        # find the state and finish their spans.
+        with self._lock:
+            self._traces.pop(trace_id, None)
+
+    def on_span_start(self, span: Any) -> None:
+        if self._disabled:
+            return
+        trace_id = getattr(span, "trace_id", None)
+        if not trace_id:
+            return
+        lmnr_span = None
+        try:
+            state = self._get_or_create_trace(span)
+            parent_id = getattr(span, "parent_id", None)
+            with self._lock:
+                parent_entry = state.spans.get(parent_id) if parent_id else None
+            parent_lmnr_span = (
+                parent_entry.lmnr_span if parent_entry else state.root_span
+            )
+
+            parent_ctx = None
+            if parent_lmnr_span is not None and hasattr(
+                parent_lmnr_span, "get_laminar_span_context"
+            ):
+                parent_ctx = parent_lmnr_span.get_laminar_span_context()
+
+            span_data = getattr(span, "span_data", None)
+            span_type = map_span_type(span_data)
+            name = span_name(span, span_data)
+
+            lmnr_span = Laminar.start_span(
+                name,
+                span_type=span_type,
+                parent_span_context=parent_ctx,
+                tags=["openai-agents"],
+            )
+            if hasattr(lmnr_span, "set_attribute"):
+                lmnr_span.set_attribute("openai.agents.span.type", span_kind(span_data))
+                span_id = getattr(span, "span_id", "")
+                if span_id:
+                    lmnr_span.set_attribute("openai.agents.span.id", span_id)
+
+            # Use span_id as key so parent_id lookups in on_span_start
+            # match correctly. The SDK always generates a span_id.
+            key = getattr(span, "span_id", None)
+            if not key:
+                logger.debug("Span missing span_id, cannot track")
+                try:
+                    lmnr_span.end()
+                except Exception:
+                    pass
+                return
+            with self._lock:
+                state.spans[key] = _SpanEntry(lmnr_span=lmnr_span, agents_span=span)
+        except Exception:
+            logger.debug("Error in on_span_start", exc_info=True)
+            if lmnr_span is not None:
+                try:
+                    lmnr_span.end()
+                except Exception:
+                    pass
+
+    def on_span_end(self, span: Any) -> None:
+        if self._disabled:
+            return
+        trace_id = getattr(span, "trace_id", None)
+        if not trace_id:
+            return
+
+        key = getattr(span, "span_id", None)
+        if not key:
+            return
+
+        with self._lock:
+            state = self._traces.get(trace_id)
+            entry = state.spans.pop(key, None) if state else None
+            if entry and state:
+                state.pending_ends += 1
+                state.pending_ends_done.clear()
+
+        if not entry or not state:
+            return
+
+        span_data = getattr(span, "span_data", None)
+        try:
+            try:
+                _apply_span_data(entry.lmnr_span, span_data)
+                _apply_span_error(entry.lmnr_span, span)
+            except Exception:
+                pass
+            try:
+                entry.lmnr_span.end()
+            except Exception:
+                pass
+        finally:
+            with self._lock:
+                if state.pending_ends > 0:
+                    state.pending_ends -= 1
+                if state.pending_ends == 0:
+                    state.pending_ends_done.set()
+
+    def shutdown(self) -> None:
+        self._disabled = True
+        with self._lock:
+            states = [s for s in self._traces.values() if not s.ended]
+            for s in states:
+                s.ended = True
+            self._traces.clear()
+        for state in states:
+            self._end_trace_state(state)
+        try:
+            Laminar.flush()
+        except Exception:
+            pass
+
+    def force_flush(self) -> bool:
+        try:
+            return Laminar.flush()
+        except Exception:
+            return False
+
+    _SHUTDOWN_TIMEOUT = 10.0  # seconds to wait during shutdown/cleanup
+
+    def _end_trace_state(self, state: _TraceState) -> None:
+        """End all child spans (LIFO) then the root span for a trace."""
+        if not state.ready.wait(timeout=self._SHUTDOWN_TIMEOUT) or state.failed:
+            return
+        # Wait for in-flight on_span_end calls, then atomically snapshot
+        # remaining spans.  Re-check under the lock to close the window
+        # where a new on_span_end increments pending_ends between the
+        # wait() return and the lock acquisition.
+        for _ in range(3):  # bounded retries
+            state.pending_ends_done.wait(timeout=self._SHUTDOWN_TIMEOUT)
+            with self._lock:
+                if state.pending_ends == 0:
+                    remaining = list(state.spans.values())
+                    state.spans.clear()
+                    break
+            # pending_ends changed while we waited; retry
+        else:
+            # Give up waiting — snapshot whatever is left to avoid hanging.
+            with self._lock:
+                remaining = list(state.spans.values())
+                state.spans.clear()
+        for entry in reversed(remaining):
+            try:
+                if entry.agents_span is not None:
+                    span_data = getattr(entry.agents_span, "span_data", None)
+                    _apply_span_data(entry.lmnr_span, span_data)
+                    _apply_span_error(entry.lmnr_span, entry.agents_span)
+            except Exception:
+                pass
+            try:
+                entry.lmnr_span.end()
+            except Exception:
+                pass
+        try:
+            state.root_span.end()
+        except Exception:
+            pass
+
+    def _get_or_create_trace(self, trace_or_span: Any) -> _TraceState:
+        trace_id = getattr(trace_or_span, "trace_id", None)
+        if not trace_id:
+            trace_id = "unknown"
+        creator = False
+        with self._lock:
+            state = self._traces.get(trace_id)
+            if state is None:
+                state = _TraceState()
+                self._traces[trace_id] = state
+                creator = True
+        if creator:
+            try:
+                # Use a generic name; on_trace_start will update it
+                # to the actual trace name via update_name.
+                root_span = Laminar.start_span(
+                    "agents.trace",
+                    tags=["openai-agents"],
+                )
+                state.root_span = root_span
+            except Exception:
+                state.failed = True
+                # Remove the broken state so future calls can retry.
+                with self._lock:
+                    self._traces.pop(trace_id, None)
+                raise
+            finally:
+                state.ready.set()
+        else:
+            if not state.ready.wait(timeout=self._SHUTDOWN_TIMEOUT) or state.failed:
+                raise RuntimeError("Root span creation failed for this trace")
+        return state
+
+    def _apply_trace_metadata(self, root_span: Any, trace: Any) -> None:
+        metadata: dict[str, Any] = {}
+        trace_metadata = getattr(trace, "metadata", None)
+        if isinstance(trace_metadata, dict):
+            metadata.update(trace_metadata)
+        trace_id = getattr(trace, "trace_id", None)
+        if trace_id:
+            metadata["openai.agents.trace_id"] = trace_id
+        group_id = getattr(trace, "group_id", None)
+        if group_id:
+            metadata["openai.agents.group_id"] = group_id
+        trace_name = getattr(trace, "name", None)
+        if trace_name:
+            metadata["openai.agents.trace_name"] = trace_name
+        if metadata and hasattr(root_span, "set_trace_metadata"):
+            try:
+                root_span.set_trace_metadata(metadata)
+            except Exception:
+                pass
+        session_id = metadata.get("session_id") if metadata else None
+        user_id = metadata.get("user_id") if metadata else None
+        if not session_id:
+            session_id = os.getenv("LMNR_SESSION_ID")
+        if not user_id:
+            user_id = os.getenv("LMNR_USER_ID")
+        if session_id and hasattr(root_span, "set_trace_session_id"):
+            root_span.set_trace_session_id(session_id)
+        if user_id and hasattr(root_span, "set_trace_user_id"):
+            root_span.set_trace_user_id(user_id)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/processor.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lmnr import Laminar
 
@@ -13,6 +13,11 @@ try:
     from agents.tracing import TracingProcessor as _Base
 except ImportError:  # openai-agents not installed
     _Base = object
+
+if TYPE_CHECKING:
+    from agents.tracing import Span as AgentsSpan, Trace
+    from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
+    from lmnr.sdk.types import LaminarSpanContext
 
 from .helpers import agent_name, export_span_data, map_span_type, span_kind, span_name
 from .span_data import apply_span_data, apply_span_error
@@ -22,13 +27,13 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class _SpanEntry:
-    lmnr_span: Any
-    agents_span: Any = None
+    lmnr_span: LaminarSpan
+    agents_span: AgentsSpan[Any] | None = None
 
 
 @dataclass
 class _TraceState:
-    root_span: Any = None
+    root_span: LaminarSpan | None = None
     spans: dict[str, _SpanEntry] = field(default_factory=dict)
     ready: threading.Event = field(default_factory=threading.Event)
     # Tracks in-flight on_span_end calls so _end_trace_state can wait
@@ -42,7 +47,7 @@ class _TraceState:
     ended: bool = False
     # Maps destination agent name -> handoff lmnr span context so that the
     # subsequent agent span becomes a child of the handoff span.
-    pending_handoff_ctxs: dict[str, Any] = field(default_factory=dict)
+    pending_handoff_ctxs: dict[str, LaminarSpanContext] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         # Initially no pending ends, so mark as done.
@@ -57,18 +62,18 @@ class LaminarAgentsTraceProcessor(_Base):
         self._traces: dict[str, _TraceState] = {}
         self._disabled = False
 
-    def on_trace_start(self, trace: Any) -> None:
+    def on_trace_start(self, trace: Trace) -> None:
         if self._disabled:
             return
-        trace_id = getattr(trace, "trace_id", None)
+        trace_id = trace.trace_id
         if not trace_id:
             return
         try:
             state = self._get_or_create_trace(trace)
             # If a span arrived first, the root span may have a placeholder
             # name. Update it to the actual trace name.
-            trace_name = getattr(trace, "name", None)
-            if trace_name and hasattr(state.root_span, "update_name"):
+            trace_name = trace.name
+            if trace_name and state.root_span is not None:
                 try:
                     state.root_span.update_name(trace_name)
                 except Exception:
@@ -77,10 +82,10 @@ class LaminarAgentsTraceProcessor(_Base):
         except Exception:
             logger.debug("Error in on_trace_start", exc_info=True)
 
-    def on_trace_end(self, trace: Any) -> None:
+    def on_trace_end(self, trace: Trace) -> None:
         if self._disabled:
             return
-        trace_id = getattr(trace, "trace_id", None)
+        trace_id = trace.trace_id
         if not trace_id:
             return
         with self._lock:
@@ -94,10 +99,10 @@ class LaminarAgentsTraceProcessor(_Base):
         with self._lock:
             self._traces.pop(trace_id, None)
 
-    def on_span_start(self, span: Any) -> None:
+    def on_span_start(self, span: AgentsSpan[Any]) -> None:
         if self._disabled:
             return
-        trace_id = getattr(span, "trace_id", None)
+        trace_id = span.trace_id
         if not trace_id:
             return
         lmnr_span = None
@@ -110,13 +115,11 @@ class LaminarAgentsTraceProcessor(_Base):
                 parent_entry.lmnr_span if parent_entry else state.root_span
             )
 
-            parent_ctx = None
-            if parent_lmnr_span is not None and hasattr(
-                parent_lmnr_span, "get_laminar_span_context"
-            ):
+            parent_ctx: LaminarSpanContext | None = None
+            if parent_lmnr_span is not None:
                 parent_ctx = parent_lmnr_span.get_laminar_span_context()
 
-            span_data = getattr(span, "span_data", None)
+            span_data = span.span_data
             span_type = map_span_type(span_data)
             name = span_name(span, span_data)
 
@@ -141,7 +144,7 @@ class LaminarAgentsTraceProcessor(_Base):
 
             # Use span_id as key so parent_id lookups in on_span_start
             # match correctly. The SDK always generates a span_id.
-            key = getattr(span, "span_id", None)
+            key = span.span_id
             if not key:
                 logger.debug("Span missing span_id, cannot track")
                 try:
@@ -159,14 +162,14 @@ class LaminarAgentsTraceProcessor(_Base):
                 except Exception:
                     pass
 
-    def on_span_end(self, span: Any) -> None:
+    def on_span_end(self, span: AgentsSpan[Any]) -> None:
         if self._disabled:
             return
-        trace_id = getattr(span, "trace_id", None)
+        trace_id = span.trace_id
         if not trace_id:
             return
 
-        key = getattr(span, "span_id", None)
+        key = span.span_id
         if not key:
             return
 
@@ -180,7 +183,7 @@ class LaminarAgentsTraceProcessor(_Base):
         if not entry or not state:
             return
 
-        span_data = getattr(span, "span_data", None)
+        span_data = span.span_data
         try:
             try:
                 apply_span_data(entry.lmnr_span, span_data)
@@ -209,9 +212,7 @@ class LaminarAgentsTraceProcessor(_Base):
                             if parent_entry is not None
                             else state.root_span
                         )
-                        if parent_lmnr_span is not None and hasattr(
-                            parent_lmnr_span, "get_laminar_span_context"
-                        ):
+                        if parent_lmnr_span is not None:
                             handoff_ctx = parent_lmnr_span.get_laminar_span_context()
                             with self._lock:
                                 state.pending_handoff_ctxs[to_agent] = handoff_ctx
@@ -289,7 +290,7 @@ class LaminarAgentsTraceProcessor(_Base):
         except Exception:
             pass
 
-    def _get_or_create_trace(self, trace_or_span: Any) -> _TraceState:
+    def _get_or_create_trace(self, trace_or_span: Trace | AgentsSpan[Any]) -> _TraceState:
         trace_id = getattr(trace_or_span, "trace_id", None)
         if not trace_id:
             trace_id = "unknown"
@@ -321,7 +322,9 @@ class LaminarAgentsTraceProcessor(_Base):
                 raise RuntimeError("Root span creation failed for this trace")
         return state
 
-    def _apply_trace_metadata(self, root_span: Any, trace: Any) -> None:
+    def _apply_trace_metadata(self, root_span: LaminarSpan | None, trace: Trace) -> None:
+        if root_span is None:
+            return
         metadata: dict[str, Any] = {}
         trace_metadata = getattr(trace, "metadata", None)
         if isinstance(trace_metadata, dict):
@@ -329,17 +332,16 @@ class LaminarAgentsTraceProcessor(_Base):
         group_id = getattr(trace, "group_id", None)
         if group_id:
             metadata["openai.agents.group_id"] = group_id
-        trace_name = getattr(trace, "name", None)
-        if trace_name:
-            metadata["openai.agents.trace_name"] = trace_name
-        if metadata and hasattr(root_span, "set_trace_metadata"):
+        if trace.name:
+            metadata["openai.agents.trace_name"] = trace.name
+        if metadata:
             try:
                 root_span.set_trace_metadata(metadata)
             except Exception:
                 pass
-        session_id = metadata.get("session_id") if metadata else None
-        user_id = metadata.get("user_id") if metadata else None
-        if session_id and hasattr(root_span, "set_trace_session_id"):
+        session_id = metadata.get("session_id")
+        user_id = metadata.get("user_id")
+        if session_id:
             root_span.set_trace_session_id(session_id)
-        if user_id and hasattr(root_span, "set_trace_user_id"):
+        if user_id:
             root_span.set_trace_user_id(user_id)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
@@ -11,13 +11,14 @@ from lmnr.sdk.utils import json_dumps
 
 from .helpers import agent_name, export_span_data, span_kind
 from .messages import (
-    _apply_llm_attributes,
-    _response_to_llm_data,
-    _set_gen_ai_input_messages,
-    _set_gen_ai_messages,
-    _set_gen_ai_output_messages,
-    _set_gen_ai_output_messages_from_response,
-    _set_tool_definitions_from_response,
+    apply_llm_attributes,
+    response_to_llm_data,
+    set_gen_ai_input_messages,
+    set_gen_ai_messages,
+    set_gen_ai_output_messages,
+    set_gen_ai_output_messages_from_response,
+    set_lmnr_span_io,
+    set_tool_definitions_from_response,
 )
 
 # ---------------------------------------------------------------------------
@@ -25,7 +26,7 @@ from .messages import (
 # ---------------------------------------------------------------------------
 
 
-def _apply_span_error(lmnr_span: Any, span: Any) -> None:
+def apply_span_error(lmnr_span: Any, span: Any) -> None:
     error = getattr(span, "error", None)
     if not error or not hasattr(lmnr_span, "set_status"):
         return
@@ -41,7 +42,7 @@ def _apply_span_error(lmnr_span: Any, span: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _apply_span_data(lmnr_span: Any, span_data: Any) -> None:
+def apply_span_data(lmnr_span: Any, span_data: Any) -> None:
     if span_data is None:
         return
 
@@ -72,7 +73,7 @@ def _apply_span_data(lmnr_span: Any, span_data: Any) -> None:
     else:
         # Fallback: try to set generic I/O
         data = export_span_data(span_data)
-        _set_gen_ai_messages(lmnr_span, data.get("input"), data.get("output"))
+        set_gen_ai_messages(lmnr_span, data.get("input"), data.get("output"))
 
 
 def _apply_agent_span_data(lmnr_span: Any, span_data: Any) -> None:
@@ -101,12 +102,8 @@ def _apply_function_span_data(lmnr_span: Any, span_data: Any) -> None:
     if not hasattr(lmnr_span, "set_attribute"):
         return
 
-    name = data.get("name") or getattr(span_data, "name", None)
-    if name:
-        lmnr_span.set_attribute("openai.agents.tool.name", name)
-
     # Use gen_ai messages for input/output
-    _set_gen_ai_messages(lmnr_span, data.get("input"), data.get("output"))
+    set_lmnr_span_io(lmnr_span, data.get("input"), data.get("output"))
 
 
 def _apply_generation_span_data(lmnr_span: Any, span_data: Any) -> None:
@@ -120,13 +117,13 @@ def _apply_generation_span_data(lmnr_span: Any, span_data: Any) -> None:
     input_data = data.get("input")
     if input_data is None:
         input_data = getattr(span_data, "input", None)
-    _set_gen_ai_input_messages(lmnr_span, input_data)
+    set_gen_ai_input_messages(lmnr_span, input_data)
 
     # Set gen_ai.output.messages from the output
     output_data = data.get("output")
     if output_data is None:
         output_data = getattr(span_data, "output", None)
-    _set_gen_ai_output_messages(lmnr_span, output_data)
+    set_gen_ai_output_messages(lmnr_span, output_data)
 
     # Apply LLM attributes (model, usage, etc.) with fallback to direct attrs
     llm_data = dict(data)
@@ -136,7 +133,7 @@ def _apply_generation_span_data(lmnr_span: Any, span_data: Any) -> None:
         llm_data["usage"] = getattr(span_data, "usage", None)
     if llm_data.get("response_id") is None and llm_data.get("id") is None:
         llm_data["response_id"] = getattr(span_data, "response_id", None)
-    _apply_llm_attributes(lmnr_span, llm_data)
+    apply_llm_attributes(lmnr_span, llm_data)
 
 
 def _apply_response_span_data(lmnr_span: Any, span_data: Any) -> None:
@@ -148,17 +145,17 @@ def _apply_response_span_data(lmnr_span: Any, span_data: Any) -> None:
     response_input = getattr(span_data, "input", None)
 
     # Set gen_ai.input.messages
-    _set_gen_ai_input_messages(lmnr_span, response_input)
+    set_gen_ai_input_messages(lmnr_span, response_input)
 
     # Set gen_ai.output.messages from the response output
     if response is not None:
-        _set_gen_ai_output_messages_from_response(lmnr_span, response)
+        set_gen_ai_output_messages_from_response(lmnr_span, response)
 
         # Set tool definitions from response.tools
-        _set_tool_definitions_from_response(lmnr_span, response)
+        set_tool_definitions_from_response(lmnr_span, response)
 
         # Apply LLM attributes from response
-        _apply_llm_attributes(lmnr_span, _response_to_llm_data(response))
+        apply_llm_attributes(lmnr_span, response_to_llm_data(response))
 
 
 def _apply_handoff_span_data(lmnr_span: Any, span_data: Any) -> None:
@@ -228,7 +225,7 @@ def _apply_speech_span_data(lmnr_span: Any, span_data: Any) -> None:
     if input_text is None:
         input_text = getattr(span_data, "input", None)
     if input_text:
-        _set_gen_ai_input_messages(lmnr_span, input_text)
+        set_gen_ai_input_messages(lmnr_span, input_text)
 
     output_data = data.get("output")
     if output_data is None:
@@ -236,9 +233,9 @@ def _apply_speech_span_data(lmnr_span: Any, span_data: Any) -> None:
     if output_data:
         if isinstance(output_data, dict):
             # Speech output is {data: ..., format: ...}
-            _set_gen_ai_output_messages(lmnr_span, output_data.get("data"))
+            set_gen_ai_output_messages(lmnr_span, output_data.get("data"))
         else:
-            _set_gen_ai_output_messages(lmnr_span, output_data)
+            set_gen_ai_output_messages(lmnr_span, output_data)
 
 
 def _apply_transcription_span_data(lmnr_span: Any, span_data: Any) -> None:
@@ -257,15 +254,15 @@ def _apply_transcription_span_data(lmnr_span: Any, span_data: Any) -> None:
         input_data = getattr(span_data, "input", None)
     if input_data:
         if isinstance(input_data, dict):
-            _set_gen_ai_input_messages(lmnr_span, input_data.get("data"))
+            set_gen_ai_input_messages(lmnr_span, input_data.get("data"))
         else:
-            _set_gen_ai_input_messages(lmnr_span, input_data)
+            set_gen_ai_input_messages(lmnr_span, input_data)
 
     output_text = data.get("output")
     if output_text is None:
         output_text = getattr(span_data, "output", None)
     if output_text:
-        _set_gen_ai_output_messages(lmnr_span, output_text)
+        set_gen_ai_output_messages(lmnr_span, output_text)
 
 
 def _apply_speech_group_span_data(lmnr_span: Any, span_data: Any) -> None:
@@ -277,10 +274,10 @@ def _apply_speech_group_span_data(lmnr_span: Any, span_data: Any) -> None:
     if input_text is None:
         input_text = getattr(span_data, "input", None)
     if input_text:
-        _set_gen_ai_input_messages(lmnr_span, input_text)
+        set_gen_ai_input_messages(lmnr_span, input_text)
 
     output_text = data.get("output")
     if output_text is None:
         output_text = getattr(span_data, "output", None)
     if output_text:
-        _set_gen_ai_output_messages(lmnr_span, output_text)
+        set_gen_ai_output_messages(lmnr_span, output_text)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
@@ -19,7 +19,6 @@ from .messages import (
     apply_llm_attributes,
     response_to_llm_data,
     set_gen_ai_input_messages,
-    set_gen_ai_messages,
     set_gen_ai_output_messages,
     set_gen_ai_output_messages_from_response,
     set_lmnr_span_io,
@@ -83,20 +82,23 @@ def apply_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
 
 def _apply_agent_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
+    res_dict = {}
     name = data.get("name") or getattr(span_data, "name", None)
     if name:
-        lmnr_span.set_attribute("openai.agents.agent.name", name)
+        res_dict["name"] = name
 
     # Record handoffs and tools as metadata
     handoffs = data.get("handoffs")
     if handoffs:
-        lmnr_span.set_attribute("openai.agents.agent.handoffs", json_dumps(handoffs))
+        res_dict["handoffs"] = handoffs
     tools = data.get("tools")
     if tools:
-        lmnr_span.set_attribute("openai.agents.agent.tools", json_dumps(tools))
+        res_dict["tools"] = tools
     output_type = data.get("output_type")
     if output_type:
-        lmnr_span.set_attribute("openai.agents.agent.output_type", output_type)
+        res_dict["output_type"] = output_type
+
+    set_lmnr_span_io(lmnr_span, res_dict, None)
 
 
 def _apply_function_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
@@ -1,0 +1,286 @@
+"""Span data extraction and error handling for OpenAI Agents instrumentation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from opentelemetry.trace import Status, StatusCode
+
+from lmnr.opentelemetry_lib.tracing.attributes import Attributes
+from lmnr.sdk.utils import json_dumps
+
+from .helpers import agent_name, export_span_data, span_kind
+from .messages import (
+    _apply_llm_attributes,
+    _response_to_llm_data,
+    _set_gen_ai_input_messages,
+    _set_gen_ai_messages,
+    _set_gen_ai_output_messages,
+    _set_gen_ai_output_messages_from_response,
+    _set_tool_definitions_from_response,
+)
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+def _apply_span_error(lmnr_span: Any, span: Any) -> None:
+    error = getattr(span, "error", None)
+    if not error or not hasattr(lmnr_span, "set_status"):
+        return
+    try:
+        message = getattr(error, "message", None) or str(error)
+        lmnr_span.set_status(Status(StatusCode.ERROR, message))
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Span data extraction
+# ---------------------------------------------------------------------------
+
+
+def _apply_span_data(lmnr_span: Any, span_data: Any) -> None:
+    if span_data is None:
+        return
+
+    kind = span_kind(span_data)
+
+    if kind == "agent":
+        _apply_agent_span_data(lmnr_span, span_data)
+    elif kind in {"function", "tool"}:
+        _apply_function_span_data(lmnr_span, span_data)
+    elif kind == "generation":
+        _apply_generation_span_data(lmnr_span, span_data)
+    elif kind == "response":
+        _apply_response_span_data(lmnr_span, span_data)
+    elif kind == "handoff":
+        _apply_handoff_span_data(lmnr_span, span_data)
+    elif kind == "guardrail":
+        _apply_guardrail_span_data(lmnr_span, span_data)
+    elif kind == "custom":
+        _apply_custom_span_data(lmnr_span, span_data)
+    elif kind in {"mcp_list_tools", "mcp_tools"}:
+        _apply_mcp_span_data(lmnr_span, span_data)
+    elif kind == "speech":
+        _apply_speech_span_data(lmnr_span, span_data)
+    elif kind == "transcription":
+        _apply_transcription_span_data(lmnr_span, span_data)
+    elif kind == "speech_group":
+        _apply_speech_group_span_data(lmnr_span, span_data)
+    else:
+        # Fallback: try to set generic I/O
+        data = export_span_data(span_data)
+        _set_gen_ai_messages(lmnr_span, data.get("input"), data.get("output"))
+
+
+def _apply_agent_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    name = data.get("name") or getattr(span_data, "name", None)
+    if name:
+        lmnr_span.set_attribute("openai.agents.agent.name", name)
+
+    # Record handoffs and tools as metadata
+    handoffs = data.get("handoffs")
+    if handoffs:
+        lmnr_span.set_attribute("openai.agents.agent.handoffs", json_dumps(handoffs))
+    tools = data.get("tools")
+    if tools:
+        lmnr_span.set_attribute("openai.agents.agent.tools", json_dumps(tools))
+    output_type = data.get("output_type")
+    if output_type:
+        lmnr_span.set_attribute("openai.agents.agent.output_type", output_type)
+
+
+def _apply_function_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    name = data.get("name") or getattr(span_data, "name", None)
+    if name:
+        lmnr_span.set_attribute("openai.agents.tool.name", name)
+
+    # Use gen_ai messages for input/output
+    _set_gen_ai_messages(lmnr_span, data.get("input"), data.get("output"))
+
+
+def _apply_generation_span_data(lmnr_span: Any, span_data: Any) -> None:
+    """Handle 'generation' spans - these are LLM calls with input/output/usage."""
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    data = export_span_data(span_data)
+
+    # Set gen_ai.input.messages from the input messages
+    input_data = data.get("input")
+    if input_data is None:
+        input_data = getattr(span_data, "input", None)
+    _set_gen_ai_input_messages(lmnr_span, input_data)
+
+    # Set gen_ai.output.messages from the output
+    output_data = data.get("output")
+    if output_data is None:
+        output_data = getattr(span_data, "output", None)
+    _set_gen_ai_output_messages(lmnr_span, output_data)
+
+    # Apply LLM attributes (model, usage, etc.) with fallback to direct attrs
+    llm_data = dict(data)
+    if llm_data.get("model") is None:
+        llm_data["model"] = getattr(span_data, "model", None)
+    if llm_data.get("usage") is None:
+        llm_data["usage"] = getattr(span_data, "usage", None)
+    if llm_data.get("response_id") is None and llm_data.get("id") is None:
+        llm_data["response_id"] = getattr(span_data, "response_id", None)
+    _apply_llm_attributes(lmnr_span, llm_data)
+
+
+def _apply_response_span_data(lmnr_span: Any, span_data: Any) -> None:
+    """Handle 'response' spans - these wrap the actual OpenAI API Response."""
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    response = getattr(span_data, "response", None)
+    response_input = getattr(span_data, "input", None)
+
+    # Set gen_ai.input.messages
+    _set_gen_ai_input_messages(lmnr_span, response_input)
+
+    # Set gen_ai.output.messages from the response output
+    if response is not None:
+        _set_gen_ai_output_messages_from_response(lmnr_span, response)
+
+        # Set tool definitions from response.tools
+        _set_tool_definitions_from_response(lmnr_span, response)
+
+        # Apply LLM attributes from response
+        _apply_llm_attributes(lmnr_span, _response_to_llm_data(response))
+
+
+def _apply_handoff_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    from_agent = data.get("from_agent")
+    to_agent = data.get("to_agent")
+    if from_agent:
+        lmnr_span.set_attribute("openai.agents.handoff.from", agent_name(from_agent))
+    if to_agent:
+        lmnr_span.set_attribute("openai.agents.handoff.to", agent_name(to_agent))
+
+
+def _apply_guardrail_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    name = data.get("name")
+    if name:
+        lmnr_span.set_attribute("openai.agents.guardrail.name", name)
+    triggered = data.get("triggered")
+    if triggered is not None:
+        lmnr_span.set_attribute("openai.agents.guardrail.triggered", triggered)
+
+
+def _apply_custom_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    name = data.get("name")
+    if name:
+        lmnr_span.set_attribute("openai.agents.custom.name", name)
+    custom_data = data.get("data")
+    if custom_data is not None:
+        lmnr_span.set_attribute("openai.agents.custom.data", json_dumps(custom_data))
+
+
+def _apply_mcp_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    server = data.get("server")
+    if server:
+        lmnr_span.set_attribute("openai.agents.mcp.server", server)
+    result = data.get("result")
+    if result is not None:
+        lmnr_span.set_attribute("openai.agents.mcp.result", json_dumps(result))
+
+
+def _apply_speech_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    model = data.get("model") or getattr(span_data, "model", None)
+    if model:
+        lmnr_span.set_attribute(Attributes.REQUEST_MODEL.value, model)
+        lmnr_span.set_attribute(Attributes.RESPONSE_MODEL.value, model)
+        lmnr_span.set_attribute(Attributes.PROVIDER.value, "openai")
+
+    input_text = data.get("input")
+    if input_text is None:
+        input_text = getattr(span_data, "input", None)
+    if input_text:
+        _set_gen_ai_input_messages(lmnr_span, input_text)
+
+    output_data = data.get("output")
+    if output_data is None:
+        output_data = getattr(span_data, "output", None)
+    if output_data:
+        if isinstance(output_data, dict):
+            # Speech output is {data: ..., format: ...}
+            _set_gen_ai_output_messages(lmnr_span, output_data.get("data"))
+        else:
+            _set_gen_ai_output_messages(lmnr_span, output_data)
+
+
+def _apply_transcription_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    model = data.get("model") or getattr(span_data, "model", None)
+    if model:
+        lmnr_span.set_attribute(Attributes.REQUEST_MODEL.value, model)
+        lmnr_span.set_attribute(Attributes.RESPONSE_MODEL.value, model)
+        lmnr_span.set_attribute(Attributes.PROVIDER.value, "openai")
+
+    input_data = data.get("input")
+    if input_data is None:
+        input_data = getattr(span_data, "input", None)
+    if input_data:
+        if isinstance(input_data, dict):
+            _set_gen_ai_input_messages(lmnr_span, input_data.get("data"))
+        else:
+            _set_gen_ai_input_messages(lmnr_span, input_data)
+
+    output_text = data.get("output")
+    if output_text is None:
+        output_text = getattr(span_data, "output", None)
+    if output_text:
+        _set_gen_ai_output_messages(lmnr_span, output_text)
+
+
+def _apply_speech_group_span_data(lmnr_span: Any, span_data: Any) -> None:
+    data = export_span_data(span_data)
+    if not hasattr(lmnr_span, "set_attribute"):
+        return
+
+    input_text = data.get("input")
+    if input_text is None:
+        input_text = getattr(span_data, "input", None)
+    if input_text:
+        _set_gen_ai_input_messages(lmnr_span, input_text)
+
+    output_text = data.get("output")
+    if output_text is None:
+        output_text = getattr(span_data, "output", None)
+    if output_text:
+        _set_gen_ai_output_messages(lmnr_span, output_text)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from opentelemetry.trace import Status, StatusCode
+
+if TYPE_CHECKING:
+    from agents.tracing import Span as AgentsSpan
+    from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
 
 from lmnr.opentelemetry_lib.tracing.attributes import Attributes
 from lmnr.sdk.utils import json_dumps
@@ -26,9 +30,9 @@ from .messages import (
 # ---------------------------------------------------------------------------
 
 
-def apply_span_error(lmnr_span: Any, span: Any) -> None:
+def apply_span_error(lmnr_span: LaminarSpan, span: AgentsSpan[Any]) -> None:
     error = getattr(span, "error", None)
-    if not error or not hasattr(lmnr_span, "set_status"):
+    if not error:
         return
     try:
         message = getattr(error, "message", None) or str(error)
@@ -42,7 +46,7 @@ def apply_span_error(lmnr_span: Any, span: Any) -> None:
 # ---------------------------------------------------------------------------
 
 
-def apply_span_data(lmnr_span: Any, span_data: Any) -> None:
+def apply_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     if span_data is None:
         return
 
@@ -76,11 +80,8 @@ def apply_span_data(lmnr_span: Any, span_data: Any) -> None:
         set_gen_ai_messages(lmnr_span, data.get("input"), data.get("output"))
 
 
-def _apply_agent_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_agent_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     name = data.get("name") or getattr(span_data, "name", None)
     if name:
         lmnr_span.set_attribute("openai.agents.agent.name", name)
@@ -97,20 +98,14 @@ def _apply_agent_span_data(lmnr_span: Any, span_data: Any) -> None:
         lmnr_span.set_attribute("openai.agents.agent.output_type", output_type)
 
 
-def _apply_function_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_function_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     # Use gen_ai messages for input/output
     set_lmnr_span_io(lmnr_span, data.get("input"), data.get("output"))
 
 
-def _apply_generation_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_generation_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     """Handle 'generation' spans - these are LLM calls with input/output/usage."""
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     data = export_span_data(span_data)
 
     # Set gen_ai.input.messages from the input messages
@@ -136,11 +131,8 @@ def _apply_generation_span_data(lmnr_span: Any, span_data: Any) -> None:
     apply_llm_attributes(lmnr_span, llm_data)
 
 
-def _apply_response_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_response_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     """Handle 'response' spans - these wrap the actual OpenAI API Response."""
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     response = getattr(span_data, "response", None)
     response_input = getattr(span_data, "input", None)
 
@@ -158,11 +150,8 @@ def _apply_response_span_data(lmnr_span: Any, span_data: Any) -> None:
         apply_llm_attributes(lmnr_span, response_to_llm_data(response))
 
 
-def _apply_handoff_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_handoff_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     from_agent = data.get("from_agent")
     to_agent = data.get("to_agent")
     if from_agent:
@@ -171,11 +160,8 @@ def _apply_handoff_span_data(lmnr_span: Any, span_data: Any) -> None:
         lmnr_span.set_attribute("openai.agents.handoff.to", agent_name(to_agent))
 
 
-def _apply_guardrail_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_guardrail_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     name = data.get("name")
     if name:
         lmnr_span.set_attribute("openai.agents.guardrail.name", name)
@@ -184,11 +170,8 @@ def _apply_guardrail_span_data(lmnr_span: Any, span_data: Any) -> None:
         lmnr_span.set_attribute("openai.agents.guardrail.triggered", triggered)
 
 
-def _apply_custom_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_custom_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     name = data.get("name")
     if name:
         lmnr_span.set_attribute("openai.agents.custom.name", name)
@@ -197,11 +180,8 @@ def _apply_custom_span_data(lmnr_span: Any, span_data: Any) -> None:
         lmnr_span.set_attribute("openai.agents.custom.data", json_dumps(custom_data))
 
 
-def _apply_mcp_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_mcp_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     server = data.get("server")
     if server:
         lmnr_span.set_attribute("openai.agents.mcp.server", server)
@@ -210,11 +190,8 @@ def _apply_mcp_span_data(lmnr_span: Any, span_data: Any) -> None:
         lmnr_span.set_attribute("openai.agents.mcp.result", json_dumps(result))
 
 
-def _apply_speech_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_speech_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     model = data.get("model") or getattr(span_data, "model", None)
     if model:
         lmnr_span.set_attribute(Attributes.REQUEST_MODEL.value, model)
@@ -238,11 +215,8 @@ def _apply_speech_span_data(lmnr_span: Any, span_data: Any) -> None:
             set_gen_ai_output_messages(lmnr_span, output_data)
 
 
-def _apply_transcription_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_transcription_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     model = data.get("model") or getattr(span_data, "model", None)
     if model:
         lmnr_span.set_attribute(Attributes.REQUEST_MODEL.value, model)
@@ -265,11 +239,8 @@ def _apply_transcription_span_data(lmnr_span: Any, span_data: Any) -> None:
         set_gen_ai_output_messages(lmnr_span, output_text)
 
 
-def _apply_speech_group_span_data(lmnr_span: Any, span_data: Any) -> None:
+def _apply_speech_group_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     data = export_span_data(span_data)
-    if not hasattr(lmnr_span, "set_attribute"):
-        return
-
     input_text = data.get("input")
     if input_text is None:
         input_text = getattr(span_data, "input", None)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
@@ -8,6 +8,7 @@ from opentelemetry.trace import Status, StatusCode
 
 if TYPE_CHECKING:
     from agents.tracing import Span as AgentsSpan
+
     from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
 
 from lmnr.opentelemetry_lib.tracing.attributes import Attributes
@@ -77,7 +78,7 @@ def apply_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     else:
         # Fallback: try to set generic I/O
         data = export_span_data(span_data)
-        set_gen_ai_messages(lmnr_span, data.get("input"), data.get("output"))
+        set_lmnr_span_io(lmnr_span, data.get("input"), data.get("output"))
 
 
 def _apply_agent_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
@@ -14,7 +14,12 @@ if TYPE_CHECKING:
 from lmnr.opentelemetry_lib.tracing.attributes import Attributes
 from lmnr.sdk.utils import json_dumps
 
-from .helpers import agent_name, export_span_data, span_kind
+from .helpers import (
+    agent_name,
+    export_span_data,
+    get_current_system_instructions,
+    span_kind,
+)
 from .messages import (
     apply_llm_attributes,
     response_to_llm_data,
@@ -115,7 +120,9 @@ def _apply_generation_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     input_data = data.get("input")
     if input_data is None:
         input_data = getattr(span_data, "input", None)
-    set_gen_ai_input_messages(lmnr_span, input_data)
+    set_gen_ai_input_messages(
+        lmnr_span, input_data, system_instructions=get_current_system_instructions()
+    )
 
     # Set gen_ai.output.messages from the output
     output_data = data.get("output")
@@ -139,8 +146,13 @@ def _apply_response_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     response = getattr(span_data, "response", None)
     response_input = getattr(span_data, "input", None)
 
-    # Set gen_ai.input.messages
-    set_gen_ai_input_messages(lmnr_span, response_input)
+    # Set gen_ai.input.messages, prepending the agent's system instructions
+    # captured during the model call.
+    set_gen_ai_input_messages(
+        lmnr_span,
+        response_input,
+        system_instructions=get_current_system_instructions(),
+    )
 
     # Set gen_ai.output.messages from the response output
     if response is not None:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai_agents/span_data.py
@@ -15,9 +15,9 @@ from lmnr.opentelemetry_lib.tracing.attributes import Attributes
 from lmnr.sdk.utils import json_dumps
 
 from .helpers import (
-    agent_name,
     export_span_data,
     get_current_system_instructions,
+    name_from_span_data,
     span_kind,
 )
 from .messages import (
@@ -170,9 +170,13 @@ def _apply_handoff_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:
     from_agent = data.get("from_agent")
     to_agent = data.get("to_agent")
     if from_agent:
-        lmnr_span.set_attribute("openai.agents.handoff.from", agent_name(from_agent))
+        lmnr_span.set_attribute(
+            "openai.agents.handoff.from", name_from_span_data(from_agent)
+        )
     if to_agent:
-        lmnr_span.set_attribute("openai.agents.handoff.to", agent_name(to_agent))
+        lmnr_span.set_attribute(
+            "openai.agents.handoff.to", name_from_span_data(to_agent)
+        )
 
 
 def _apply_guardrail_span_data(lmnr_span: LaminarSpan, span_data: Any) -> None:

--- a/src/lmnr/opentelemetry_lib/tracing/__init__.py
+++ b/src/lmnr/opentelemetry_lib/tracing/__init__.py
@@ -2,39 +2,41 @@ import atexit
 import logging
 import threading
 
-from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
+from opentelemetry import trace
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.context import Context
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import SpanProcessor, TracerProvider
+from opentelemetry.sdk.trace.export import SpanExporter
+
+from lmnr.opentelemetry_lib.tracing.context import (
+    attach_context,
+    clear_context,
+    get_current_context,
+    get_token_stack,
+    set_token_stack,
+)
+from lmnr.opentelemetry_lib.tracing.context import (
+    pop_span_context as ctx_pop_span_context,
+)
+from lmnr.opentelemetry_lib.tracing.context import (
+    push_span_context as ctx_push_span_context,
+)
 from lmnr.opentelemetry_lib.tracing.exporter import LaminarLogExporter
-from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-from lmnr.sdk.types import SessionRecordingOptions
-from lmnr.sdk.log import VerboseColorfulFormatter
 from lmnr.opentelemetry_lib.tracing.instruments import (
     Instruments,
     init_instrumentations,
 )
-from lmnr.opentelemetry_lib.tracing.context import (
-    attach_context,
-    clear_context,
-    pop_span_context as ctx_pop_span_context,
-    get_current_context,
-    get_token_stack,
-    push_span_context as ctx_push_span_context,
-    set_token_stack,
-)
-
-from opentelemetry import trace
-from opentelemetry.context import Context
-
-from lmnr.sdk.log import get_default_logger
+from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
+from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
+from lmnr.sdk.log import VerboseColorfulFormatter, get_default_logger
+from lmnr.sdk.types import SessionRecordingOptions
 
 # instead of importing from opentelemetry.instrumentation.threading,
 # we import from our modified copy to use Laminar's isolated context.
 from ..opentelemetry.instrumentation.threading import ThreadingInstrumentor
-from opentelemetry.sdk.resources import Resource
-from opentelemetry.sdk.trace import TracerProvider, SpanProcessor
-from opentelemetry.sdk.trace.export import SpanExporter
-from opentelemetry._logs import set_logger_provider
-from opentelemetry.sdk._logs import LoggerProvider
-from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
 
 TRACER_NAME = "lmnr.tracer"
 
@@ -213,9 +215,11 @@ class TracerWrapper(object):
         """Get the current isolated context."""
         return get_current_context()
 
-    def push_span_context(self, span: trace.Span) -> Context:
+    def push_span_context(
+        self, span: trace.Span, from_ctx: Context | None = None
+    ) -> Context:
         """Push a new context with the given span onto the stack."""
-        current_ctx = get_current_context()
+        current_ctx = from_ctx or get_current_context()
         new_context = trace.set_span_in_context(span, current_ctx)
         ctx_push_span_context(new_context)
         return new_context

--- a/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
+++ b/src/lmnr/opentelemetry_lib/tracing/_instrument_initializers.py
@@ -363,6 +363,18 @@ class OpenAIInstrumentorInitializer(InstrumentorInitializer):
         return OpenAIInstrumentor()
 
 
+class OpenAIAgentsInstrumentorInitializer(InstrumentorInitializer):
+    def init_instrumentor(self, *args, **kwargs) -> BaseInstrumentor | None:
+        if not is_package_installed("openai-agents"):
+            return None
+
+        from ..opentelemetry.instrumentation.openai_agents import (
+            OpenAIAgentsInstrumentor,
+        )
+
+        return OpenAIAgentsInstrumentor()
+
+
 class OpenTelemetryInstrumentorInitializer(InstrumentorInitializer):
     def init_instrumentor(self, *args, **kwargs) -> BaseInstrumentor | None:
         from ..opentelemetry.instrumentation.opentelemetry import (

--- a/src/lmnr/opentelemetry_lib/tracing/instruments.py
+++ b/src/lmnr/opentelemetry_lib/tracing/instruments.py
@@ -44,6 +44,7 @@ class Instruments(Enum):
     MISTRAL = "mistral"
     OLLAMA = "ollama"
     OPENAI = "openai"
+    OPENAI_AGENTS = "openai_agents"
     # Patch OpenTelemetry to fix DataDog's broken Span context
     # See lmnr.opentelemetry_lib.opentelemetry.instrumentation.opentelemetry
     # for more details.
@@ -94,6 +95,7 @@ INSTRUMENTATION_INITIALIZERS: dict[
     Instruments.MISTRAL: initializers.MistralInstrumentorInitializer(),
     Instruments.OLLAMA: initializers.OllamaInstrumentorInitializer(),
     Instruments.OPENAI: initializers.OpenAIInstrumentorInitializer(),
+    Instruments.OPENAI_AGENTS: initializers.OpenAIAgentsInstrumentorInitializer(),
     Instruments.OPENTELEMETRY: initializers.OpenTelemetryInstrumentorInitializer(),
     Instruments.PATCHRIGHT: initializers.PatchrightInstrumentorInitializer(),
     Instruments.PINECONE: initializers.PineconeInstrumentorInitializer(),

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -1,9 +1,33 @@
 import asyncio
-from contextlib import contextmanager
-from contextvars import Context
+import datetime
+import logging
+import os
+import re
+import uuid
 import warnings
+from contextlib import contextmanager
+from typing import Any, Generator, Literal
+
+from opentelemetry import context as context_api
+from opentelemetry import trace
+from opentelemetry.context import Context, get_value
+from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
+from opentelemetry.trace import INVALID_TRACE_ID, Span, Status, StatusCode, use_span
+from opentelemetry.util.types import AttributeValue
+from typing_extensions import TypedDict
+
 from lmnr.opentelemetry_lib import TracerManager
-from lmnr.opentelemetry_lib.tracing import TracerWrapper, get_current_context
+from lmnr.opentelemetry_lib.tracing import TracerWrapper
+from lmnr.opentelemetry_lib.tracing.attributes import (
+    ASSOCIATION_PROPERTIES,
+    PARENT_SPAN_IDS_PATH,
+    PARENT_SPAN_PATH,
+    SESSION_ID,
+    SPAN_TYPE,
+    TRACE_TYPE,
+    USER_ID,
+    Attributes,
+)
 from lmnr.opentelemetry_lib.tracing.context import (
     CONTEXT_METADATA_KEY,
     CONTEXT_SESSION_ID_KEY,
@@ -11,47 +35,24 @@ from lmnr.opentelemetry_lib.tracing.context import (
     CONTEXT_USER_ID_KEY,
     attach_context,
     detach_context,
+    get_current_context,
     get_event_attributes_from_context,
     push_span_context,
     set_association_prop_context,
-)
-from opentelemetry.context import get_value
-from lmnr.opentelemetry_lib.tracing.attributes import (
-    ASSOCIATION_PROPERTIES,
-    PARENT_SPAN_IDS_PATH,
-    PARENT_SPAN_PATH,
-    USER_ID,
-    Attributes,
-    SPAN_TYPE,
 )
 from lmnr.opentelemetry_lib.tracing.instruments import Instruments
 from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
 from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
 from lmnr.opentelemetry_lib.tracing.tracer import get_tracer_with_context
 from lmnr.opentelemetry_lib.tracing.utils import set_association_props_in_context
-from lmnr.sdk.utils import get_otel_env_var
-
-from opentelemetry import trace
-from opentelemetry import context as context_api
-from opentelemetry.trace import INVALID_TRACE_ID, Span, Status, StatusCode, use_span
-from opentelemetry.sdk.trace.id_generator import RandomIdGenerator
-from opentelemetry.util.types import AttributeValue
-
-from typing import Any, Iterator, Literal
-from typing_extensions import TypedDict
-
-import datetime
-import logging
-import os
-import re
-import uuid
-
-from lmnr.opentelemetry_lib.tracing.attributes import SESSION_ID, TRACE_TYPE
-
-from lmnr.sdk.utils import from_env, is_otel_attribute_value_type, json_dumps
+from lmnr.sdk.utils import (
+    from_env,
+    get_otel_env_var,
+    is_otel_attribute_value_type,
+    json_dumps,
+)
 
 from .log import VerboseColorfulFormatter
-
 from .types import (
     LaminarSpanContext,
     LaminarSpanType,
@@ -437,7 +438,7 @@ class Laminar:
         session_id: str | None = None,
         metadata: dict[str, AttributeValue] | None = None,
         attributes: dict[str, AttributeValue] | None = None,
-    ) -> Iterator[LaminarSpan]:
+    ) -> Generator[LaminarSpan]:
         """Start a new span as the current span. Useful for manual
         instrumentation. If `span_type` is set to `"LLM"`, you should report
         usage and response attributes manually. See `Laminar.set_span_attributes`
@@ -826,7 +827,7 @@ class Laminar:
         end_on_exit: bool = False,
         record_exception: bool = True,
         set_status_on_exception: bool = True,
-    ) -> Iterator[LaminarSpan | Span]:
+    ) -> Generator[LaminarSpan | Span]:
         """Use a span as the current span. Useful for manual instrumentation.
 
         Fully copies the implementation of `use_span` from opentelemetry.trace
@@ -1022,7 +1023,7 @@ class Laminar:
         if assoc_props_token and isinstance(span, LaminarSpan):
             span._lmnr_assoc_props_token = assoc_props_token
 
-        context = wrapper.push_span_context(span)
+        context = wrapper.push_span_context(span, from_ctx=context)
         context_token = context_api.attach(context)
         isolated_context_token = attach_context(context)
         span._lmnr_ctx_token = context_token

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -54,6 +54,7 @@ from .log import VerboseColorfulFormatter
 
 from .types import (
     LaminarSpanContext,
+    LaminarSpanType,
     SessionRecordingOptions,
     TraceType,
 )
@@ -427,7 +428,7 @@ class Laminar:
         cls,
         name: str,
         input: Any = None,
-        span_type: Literal["DEFAULT", "LLM", "TOOL"] = "DEFAULT",
+        span_type: LaminarSpanType = "DEFAULT",
         context: Context | None = None,
         labels: list[str] | None = None,
         parent_span_context: LaminarSpanContext | None = None,
@@ -609,7 +610,7 @@ class Laminar:
         cls,
         name: str,
         input: Any = None,
-        span_type: Literal["DEFAULT", "LLM", "TOOL"] = "DEFAULT",
+        span_type: LaminarSpanType = "DEFAULT",
         context: Context | None = None,
         parent_span_context: LaminarSpanContext | None = None,
         labels: dict[str, str] | None = None,

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -438,7 +438,7 @@ class Laminar:
         session_id: str | None = None,
         metadata: dict[str, AttributeValue] | None = None,
         attributes: dict[str, AttributeValue] | None = None,
-    ) -> Generator[LaminarSpan]:
+    ) -> Generator[LaminarSpan, None, None]:
         """Start a new span as the current span. Useful for manual
         instrumentation. If `span_type` is set to `"LLM"`, you should report
         usage and response attributes manually. See `Laminar.set_span_attributes`
@@ -827,7 +827,7 @@ class Laminar:
         end_on_exit: bool = False,
         record_exception: bool = True,
         set_status_on_exception: bool = True,
-    ) -> Generator[LaminarSpan | Span]:
+    ) -> Generator[LaminarSpan | Span, None, None]:
         """Use a span as the current span. Useful for manual instrumentation.
 
         Fully copies the implementation of `use_span` from opentelemetry.trace

--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -22,6 +22,11 @@ NumericTypes = (int, float)  # for use with isinstance
 EvaluationDatapointData = Any  # non-null, must be JSON-serializable
 EvaluationDatapointTarget = Any | None  # must be JSON-serializable
 EvaluationDatapointMetadata = Any | None  # must be JSON-serializable
+LaminarSpanType = Literal[
+    "DEFAULT",
+    "LLM",
+    "TOOL",
+]
 
 
 # EvaluationDatapoint is a single data point in the evaluation

--- a/tests/test_instrumentations/test_openai_agents/cassettes/test_agents_integration/test_agent_with_tool.yaml
+++ b/tests/test_instrumentations/test_openai_agents/cassettes/test_agents_integration/test_agent_with_tool.yaml
@@ -1,0 +1,55 @@
+interactions:
+- request:
+    body: '{"model":"gpt-4o-mini","input":[{"role":"system","content":"You are a helpful
+      assistant. Use the get_weather tool to answer weather questions."},{"role":"user","content":"What
+      is the weather in NYC?"}],"tools":[{"type":"function","name":"get_weather","description":"Get
+      the current weather for a city.","parameters":{"type":"object","properties":{"city":{"type":"string","description":"The
+      city name"}},"required":["city"]},"strict":true}],"parallel_tool_calls":false,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: '{"id":"resp_test_tool_001","object":"response","created_at":1709000001,"status":"completed","model":"gpt-4o-mini","output":[{"type":"function_call","id":"fc_test001","call_id":"call_test001","name":"get_weather","arguments":"{\"city\":\"NYC\"}","status":"completed"}],"parallel_tool_calls":false,"usage":{"input_tokens":40,"output_tokens":12,"total_tokens":52,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"model":"gpt-4o-mini","input":[{"role":"system","content":"You are a helpful
+      assistant. Use the get_weather tool to answer weather questions."},{"role":"user","content":"What
+      is the weather in NYC?"},{"type":"function_call","id":"fc_test001","call_id":"call_test001","name":"get_weather","arguments":"{\"city\":\"NYC\"}","status":"completed"},{"type":"function_call_output","call_id":"call_test001","output":"72\u00b0F
+      and sunny"}],"tools":[{"type":"function","name":"get_weather","description":"Get
+      the current weather for a city.","parameters":{"type":"object","properties":{"city":{"type":"string","description":"The
+      city name"}},"required":["city"]},"strict":true}],"parallel_tool_calls":false,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: '{"id":"resp_test_tool_002","object":"response","created_at":1709000002,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_test002","status":"completed","role":"assistant","content":[{"type":"output_text","text":"The weather in NYC is currently 72\u00b0F and sunny!","annotations":[]}]}],"parallel_tool_calls":false,"usage":{"input_tokens":55,"output_tokens":15,"total_tokens":70,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_instrumentations/test_openai_agents/cassettes/test_agents_integration/test_agent_with_tool.yaml
+++ b/tests/test_instrumentations/test_openai_agents/cassettes/test_agents_integration/test_agent_with_tool.yaml
@@ -1,54 +1,221 @@
 interactions:
 - request:
-    body: '{"model":"gpt-4o-mini","input":[{"role":"system","content":"You are a helpful
-      assistant. Use the get_weather tool to answer weather questions."},{"role":"user","content":"What
-      is the weather in NYC?"}],"tools":[{"type":"function","name":"get_weather","description":"Get
-      the current weather for a city.","parameters":{"type":"object","properties":{"city":{"type":"string","description":"The
-      city name"}},"required":["city"]},"strict":true}],"parallel_tool_calls":false,"stream":false}'
+    body: '{"include":[],"input":[{"content":"What is the weather in NYC?","role":"user"}],"instructions":"You
+      are a helpful assistant. Use the get_weather tool to answer weather questions.","model":"gpt-4.1-nano","prompt_cache_key":"agents-sdk:run:49265e0d13cf433d8123d770c5acf7ea","tools":[{"name":"get_weather","parameters":{"properties":{"city":{"title":"City","type":"string"}},"required":["city"],"title":"get_weather_args","type":"object","additionalProperties":false},"strict":true,"type":"function","description":"Get
+      the current weather for a city."}]}'
     headers:
-      accept:
+      Accept:
       - application/json
-      content-type:
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '551'
+      Content-Type:
       - application/json
-      host:
+      Host:
       - api.openai.com
-      user-agent:
-      - OpenAI/Python
+      User-Agent:
+      - Agents/Python 0.14.1
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.30.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: '{"id":"resp_test_tool_001","object":"response","created_at":1709000001,"status":"completed","model":"gpt-4o-mini","output":[{"type":"function_call","id":"fc_test001","call_id":"call_test001","name":"get_weather","arguments":"{\"city\":\"NYC\"}","status":"completed"}],"parallel_tool_calls":false,"usage":{"input_tokens":40,"output_tokens":12,"total_tokens":52,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}'
+      string: !!binary |
+        H4sIAAAAAAAA/31VTW/jNhC951cIOseBZEmWndtiD0VRoOgHimDRLIQxObJZU6TKj2yMwP+9Q8qW
+        ZCfpxbDmcYZvHt+Qb3dJkgqePiapQds3WYVrKACx3mygXrEsW21w3ZbtkpWb9TrfbLdlWbBtWdV5
+        va2Kuk7vQwm9/QeZu5TRyuIQZwbBIW8gYHldr9Z1WRfriFkHztuQw3TXS6R1Q9IW2GFntFeBVwvS
+        4hAWUgq1o9gbfVKghyOakM/xBaXu6YOA07DxpeTN1puIojE6ZCovZQy0Bv/1qNix6VGBdEcCs4cs
+        YkJdijUcHQhp55lCWWc8c4KaDly+aZ+AwQSSPcq+9TIBawX1qtxD8pfFxO0x2aFrfpAyezSJ01rS
+        TwLK/qDPS5jo2Fj0YRClg9dGe9d71zh9QHVFIoChTsNAXtPrNEcZeO16tygf8oUCpRfLbFktsnKR
+        l+m4ykDYbp47bEeRv6Peg+qjX1r2uVuKCldlcMu6bqHaQJsvWcurzSpuF4u4Y4+xjFdRvEh9gj8z
+        RwTB7HyHykX87Tllwh2f08fn9NdvX5/T07Qw1GwGuvHvk61WX34WXfb7L6/L4o+OH57yJ5H/OWUo
+        6CKt2QmlETvR7/coSw+GaqG8VpxMMNi0pwkgJ+EHTiLoRWhvm8uQDNxGwXtDvToqyfbYHDCkprAL
+        jS4sPzwarx7LzXJVYcbzgrVlUfB1vix4XWesAtbWCOn7QobEU+ezJbs2HXbaHIeFNJ5Wq6upwrbV
+        xs1ohdPwXQfmeA6OQ2ahRXekJkL9VuDVSFk0L4JkcOIypC146dLz7GuDc9Ucdn2woI/h/CyYw1c3
+        MSNeHUzfMxPFdcMxnRm/oNlqK6L8aYdc+G66HIaD22uiFyX2TqcjYN8b/tark104WmZEf1H3J3Rx
+        vpk3hjQZh5mY04UQbPrw/1YbwWCyjg7O2Fm/w8mSTqTpdTx4fWh2HgvUhZNxl68Bvr8Bz33RDRYs
+        MANP4//TlJOGS1IY5KNC863HwPdZxrj9rMmGxtem80VnGudHZIYA5yJoC/K3ed/xTbi74Re7iG9Q
+        MNXNzDrdN1LvSL1tKJCNwX7uNhowdrkFUy4sbOXlTfKWBnGyolBXF3Fd3r+Pz16Lt+lCoonkU2J2
+        Zdrb+71YfgR8VHec489KO+1ATmCercZp8PZ6cMl2wMFBqH+6O/0H/OzXWiMIAAA=
     headers:
-      content-type:
+      CF-RAY:
+      - 9f05f28cbe9d26c6-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
       - application/json
+      Date:
+      - Wed, 22 Apr 2026 16:18:59 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - user-xzaeeoqlanzncr8pomspsknu
+      openai-processing-ms:
+      - '704'
+      openai-project:
+      - proj_aT4OgTR5NJ9iNjg4xWc82hiE
+      openai-version:
+      - '2020-10-01'
+      set-cookie:
+      - __cf_bm=VNrh6W_Tdx.0qFE3o9SyxiUhDBdWX..35QW7Xd3Qd2E-1776874738.6764646-1.0.1.1-TPCTbcaIloiGwctunXxLrIAPmcSXeSLWyFNP5geSxXfHia1bwOX2oVaExmZCZdzTfereB48GbwPUj1Ockay8e2TbQ19ReHVJ82zNJKNfyKXHxkVoDs.1ga_NeVpFkxj3;
+        HttpOnly; Secure; Path=/; Domain=api.openai.com; Expires=Wed, 22 Apr 2026
+        16:48:59 GMT
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999707'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_8fc7c4dc56a940c185518d6b8f5da97d
     status:
       code: 200
       message: OK
 - request:
-    body: '{"model":"gpt-4o-mini","input":[{"role":"system","content":"You are a helpful
-      assistant. Use the get_weather tool to answer weather questions."},{"role":"user","content":"What
-      is the weather in NYC?"},{"type":"function_call","id":"fc_test001","call_id":"call_test001","name":"get_weather","arguments":"{\"city\":\"NYC\"}","status":"completed"},{"type":"function_call_output","call_id":"call_test001","output":"72\u00b0F
-      and sunny"}],"tools":[{"type":"function","name":"get_weather","description":"Get
-      the current weather for a city.","parameters":{"type":"object","properties":{"city":{"type":"string","description":"The
-      city name"}},"required":["city"]},"strict":true}],"parallel_tool_calls":false,"stream":false}'
+    body: "{\"include\":[],\"input\":[{\"content\":\"What is the weather in NYC?\",\"role\":\"user\"},{\"arguments\":\"{\\\"city\\\":\\\"NYC\\\"}\",\"call_id\":\"call_Ws56AIim0QKx23RmdkW1Wi1S\",\"name\":\"get_weather\",\"type\":\"function_call\",\"id\":\"fc_05e8a3aee799a76c0069e8f4f35e64819b87fa59af12cfd596\",\"status\":\"completed\"},{\"call_id\":\"call_Ws56AIim0QKx23RmdkW1Wi1S\",\"output\":\"72\xB0F
+      and sunny\",\"type\":\"function_call_output\"}],\"instructions\":\"You are a
+      helpful assistant. Use the get_weather tool to answer weather questions.\",\"model\":\"gpt-4.1-nano\",\"prompt_cache_key\":\"agents-sdk:run:49265e0d13cf433d8123d770c5acf7ea\",\"tools\":[{\"name\":\"get_weather\",\"parameters\":{\"properties\":{\"city\":{\"title\":\"City\",\"type\":\"string\"}},\"required\":[\"city\"],\"title\":\"get_weather_args\",\"type\":\"object\",\"additionalProperties\":false},\"strict\":true,\"type\":\"function\",\"description\":\"Get
+      the current weather for a city.\"}]}"
     headers:
-      accept:
+      Accept:
       - application/json
-      content-type:
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '855'
+      Content-Type:
       - application/json
-      host:
+      Cookie:
+      - __cf_bm=VNrh6W_Tdx.0qFE3o9SyxiUhDBdWX..35QW7Xd3Qd2E-1776874738.6764646-1.0.1.1-TPCTbcaIloiGwctunXxLrIAPmcSXeSLWyFNP5geSxXfHia1bwOX2oVaExmZCZdzTfereB48GbwPUj1Ockay8e2TbQ19ReHVJ82zNJKNfyKXHxkVoDs.1ga_NeVpFkxj3
+      Host:
       - api.openai.com
-      user-agent:
-      - OpenAI/Python
+      User-Agent:
+      - Agents/Python 0.14.1
+      X-Stainless-Arch:
+      - arm64
+      X-Stainless-Async:
+      - async:asyncio
+      X-Stainless-Lang:
+      - python
+      X-Stainless-OS:
+      - MacOS
+      X-Stainless-Package-Version:
+      - 2.30.0
+      X-Stainless-Runtime:
+      - CPython
+      X-Stainless-Runtime-Version:
+      - 3.14.3
+      x-stainless-read-timeout:
+      - '600'
+      x-stainless-retry-count:
+      - '0'
     method: POST
     uri: https://api.openai.com/v1/responses
   response:
     body:
-      string: '{"id":"resp_test_tool_002","object":"response","created_at":1709000002,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_test002","status":"completed","role":"assistant","content":[{"type":"output_text","text":"The weather in NYC is currently 72\u00b0F and sunny!","annotations":[]}]}],"parallel_tool_calls":false,"usage":{"input_tokens":55,"output_tokens":15,"total_tokens":70,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}'
+      string: !!binary |
+        H4sIAAAAAAAA/3VVTY/jNgy9z68wfJ4EduzE8VwXaG9FD+1hsS0M2qIT7ciSq4/ZNRb576Xk+Csz
+        cwliUnx6JB+pX09RFHMWv0SxRtNXyRHPkAFiUZZQnJokOZV4bvM2z8+Qn9OyPh+yrGbJoW7qEysg
+        j589hKq/Y2MnGCUNjvZGI1hkFXhfWhSnc5EXeRJ8xoJ1xsc0qusF0rkxqIbm9aKVk55XC8LgaOZC
+        cHkh2y/6JEMPA2ofz/ANherpgxy38eIJ8uHqNHhRa+UjpRMiGFqN/zmUzVD1KEHYgZzJfuTJ5QRW
+        MbTAhVlHcmmsdo3llLTn8lW5CDRGEF1R9K0TERjDKVdp99HfBiN7xeiCtvpBlbmijqxSgn4ikOYH
+        fU5momMC6H4sSgc/K+Vs72xl1SvKDQnv9DhVA2JLr1MMhed16e0u36c7CVLtDsnhuEvyXXpvnz+l
+        wV+3jh2vI8u3UO+x6rNeOnP5XC7HY50FuQCmSZY0JUBZsxKzcF9AsUOPAQeNgQsujs90EZyNkhbl
+        QmpNbAM71Qp/2jk6HAAplYWpX9/+3TiFuvRa1R94AhDh/kXtm3rEZfTH1y8RN1HjtCZaYoiKwz8u
+        SerkN2ooi4yTctjHM9Dt/m/GjrUSge+skvGwPxgOkco1NRXFtsGkuXEqeho4Ei5+IFxyvXHlTDXN
+        ZBU6N/eXMu16S5DNFatXHAKNC6Vhdoa9vmgnX/LycDpiwtKsafMsY+f0kLGiSJojNG2BEL8H0ugb
+        NEqJpqPqsFN6GA/SNjBKboYY21Zpu6LlFeC6DvRwN84zbaBFO1ASHr/luJlgg/qNUxksn3ZCC06M
+        vSdJKY3rqlnseq94F8zpvWD3Ht+ZEa8Olu+VtsK5sU13xm+oa2V4KD8pmnHXLbtobNxVEb1QYmdV
+        PDvM+/marmmdDHtlUT9D02jeT9X9HW1YJ3f1zbok5rR/GqKzX2IldAF1tXsWpxdZR43TZpXv2Fmq
+        E9V0a/eDOCa7tnnq3I5y/uLdzw/Oe160ML0EVs7bMiBLTOx3MtfINsM+XT0bVmO6XL9KsgJ9MfH6
+        0LQhxjdr5QHGuK8tiD/XeYcn6OmBX8giPHleVA8za1VfrVZJMhv7tdpowJpp6caMG6jF9AS6sBJn
+        KXK52ftl+fzevnqcZiWFiWRLYLIR7eNzkuYfOT7Cnef4M2hLK1askNNsngZntoNLsgMGFjz+7en2
+        P0Nk1g2SCAAA
     headers:
-      content-type:
+      CF-RAY:
+      - 9f05f2933c69ba87-LHR
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
       - application/json
+      Date:
+      - Wed, 22 Apr 2026 16:19:02 GMT
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      cf-cache-status:
+      - DYNAMIC
+      openai-organization:
+      - user-xzaeeoqlanzncr8pomspsknu
+      openai-processing-ms:
+      - '1728'
+      openai-project:
+      - proj_aT4OgTR5NJ9iNjg4xWc82hiE
+      openai-version:
+      - '2020-10-01'
+      x-ratelimit-limit-requests:
+      - '30000'
+      x-ratelimit-limit-tokens:
+      - '150000000'
+      x-ratelimit-remaining-requests:
+      - '29999'
+      x-ratelimit-remaining-tokens:
+      - '149999682'
+      x-ratelimit-reset-requests:
+      - 2ms
+      x-ratelimit-reset-tokens:
+      - 0s
+      x-request-id:
+      - req_778dd0d3360a4b549e69c97748fd6f02
     status:
       code: 200
       message: OK

--- a/tests/test_instrumentations/test_openai_agents/cassettes/test_agents_integration/test_simple_agent.yaml
+++ b/tests/test_instrumentations/test_openai_agents/cassettes/test_agents_integration/test_simple_agent.yaml
@@ -1,0 +1,26 @@
+interactions:
+- request:
+    body: '{"model":"gpt-4o-mini","input":[{"role":"system","content":"You are a helpful
+      assistant."},{"role":"user","content":"What is 2+2?"}],"parallel_tool_calls":false,"stream":false}'
+    headers:
+      accept:
+      - application/json
+      content-type:
+      - application/json
+      host:
+      - api.openai.com
+      user-agent:
+      - OpenAI/Python
+    method: POST
+    uri: https://api.openai.com/v1/responses
+  response:
+    body:
+      string: '{"id":"resp_test_simple_001","object":"response","created_at":1709000000,"status":"completed","model":"gpt-4o-mini","output":[{"type":"message","id":"msg_test001","status":"completed","role":"assistant","content":[{"type":"output_text","text":"2
+        + 2 equals 4.","annotations":[]}]}],"parallel_tool_calls":false,"usage":{"input_tokens":25,"output_tokens":8,"total_tokens":33,"input_tokens_details":{"cached_tokens":0},"output_tokens_details":{"reasoning_tokens":0}}}'
+    headers:
+      content-type:
+      - application/json
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_instrumentations/test_openai_agents/conftest.py
+++ b/tests/test_instrumentations/test_openai_agents/conftest.py
@@ -1,0 +1,36 @@
+"""Conftest for OpenAI Agents SDK integration tests."""
+
+import os
+
+import pytest
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.openai_agents import (
+    OpenAIAgentsInstrumentor,
+)
+
+
+@pytest.fixture(autouse=True)
+def environment():
+    had_key = "OPENAI_API_KEY" in os.environ
+    if not had_key:
+        os.environ["OPENAI_API_KEY"] = "test_api_key"
+    yield
+    if not had_key:
+        os.environ.pop("OPENAI_API_KEY", None)
+
+
+@pytest.fixture(scope="function")
+def instrument_openai_agents(span_exporter):
+    instrumentor = OpenAIAgentsInstrumentor()
+    was_already_instrumented = instrumentor.is_instrumented_by_opentelemetry
+    if not was_already_instrumented:
+        instrumentor.instrument()
+
+    yield instrumentor
+
+    if not was_already_instrumented and instrumentor.is_instrumented_by_opentelemetry:
+        instrumentor.uninstrument()
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    return {"filter_headers": ["authorization", "api-key", "openai-organization"]}

--- a/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
+++ b/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
@@ -22,18 +22,12 @@ def _get_spans(span_exporter):
 
 def _attrs(spans):
     """Build a list of {name, attributes} dicts from spans for easy inspection."""
-    return [
-        {"name": s.name, "attributes": dict(s.attributes or {})}
-        for s in spans
-    ]
+    return [{"name": s.name, "attributes": dict(s.attributes or {})} for s in spans]
 
 
 def _find_spans_with_model(span_data):
     """Find spans that have the model attribute set (response/generation spans)."""
-    return [
-        s for s in span_data
-        if s["attributes"].get(Attributes.REQUEST_MODEL.value)
-    ]
+    return [s for s in span_data if s["attributes"].get(Attributes.REQUEST_MODEL.value)]
 
 
 def _find_spans_by_attr(span_data, key, value=None):
@@ -97,7 +91,7 @@ def test_agent_with_tool(instrument_openai_agents, span_exporter):
     agent = Agent(
         name="WeatherBot",
         instructions="You are a helpful assistant. Use the get_weather tool to answer weather questions.",
-        model="gpt-4o-mini",
+        model="gpt-4.1-nano",
         tools=[get_weather],
     )
 
@@ -122,9 +116,7 @@ def test_agent_with_tool(instrument_openai_agents, span_exporter):
     assert any("72" in str(m) for m in all_output)
 
     # Should have a function/tool span for get_weather
-    tool_spans = _find_spans_by_attr(
-        span_data, "openai.agents.span.type", "function"
-    )
+    tool_spans = _find_spans_by_attr(span_data, "lmnr.span.type", "TOOL")
     assert len(tool_spans) >= 1
 
     # Verify token usage on at least one model span

--- a/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
+++ b/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
@@ -75,6 +75,13 @@ def test_simple_agent(instrument_openai_agents, span_exporter):
     input_messages = json.loads(resp["attributes"]["gen_ai.input.messages"])
     assert any("2+2" in str(m) or "2 + 2" in str(m) for m in input_messages)
 
+    # The system instructions from the agent must be prepended as the first
+    # message so the full prompt is visible in the trace.
+    assert input_messages[0] == {
+        "role": "system",
+        "content": [{"type": "text", "text": "You are a helpful assistant."}],
+    }
+
     # Verify response ID was recorded
     assert resp["attributes"].get(Attributes.RESPONSE_ID.value)
 
@@ -124,3 +131,23 @@ def test_agent_with_tool(instrument_openai_agents, span_exporter):
         s["attributes"].get(Attributes.INPUT_TOKEN_COUNT.value) is not None
         for s in model_spans
     )
+
+    # Every span that records input messages should carry the agent's system
+    # instructions as the first entry.
+    expected_system = {
+        "role": "system",
+        "content": [
+            {
+                "type": "text",
+                "text": (
+                    "You are a helpful assistant. Use the get_weather tool "
+                    "to answer weather questions."
+                ),
+            }
+        ],
+    }
+    input_spans = [s for s in span_data if "gen_ai.input.messages" in s["attributes"]]
+    assert input_spans, "expected at least one span with gen_ai.input.messages"
+    for s in input_spans:
+        msgs = json.loads(s["attributes"]["gen_ai.input.messages"])
+        assert msgs[0] == expected_system

--- a/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
+++ b/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
@@ -69,7 +69,7 @@ def test_simple_agent(instrument_openai_agents, span_exporter):
 
     # Verify gen_ai.output.messages contains the response text
     output_messages = json.loads(resp["attributes"]["gen_ai.output.messages"])
-    assert any("4" in str(m) for m in output_messages)
+    assert any("4" in str(m) for m in output_messages["output"])
 
     # Verify gen_ai.input.messages contains the user message
     input_messages = json.loads(resp["attributes"]["gen_ai.input.messages"])
@@ -79,7 +79,7 @@ def test_simple_agent(instrument_openai_agents, span_exporter):
     # message so the full prompt is visible in the trace.
     assert input_messages[0] == {
         "role": "system",
-        "content": [{"type": "text", "text": "You are a helpful assistant."}],
+        "content": [{"type": "input_text", "text": "You are a helpful assistant."}],
     }
 
     # Verify response ID was recorded
@@ -119,7 +119,7 @@ def test_agent_with_tool(instrument_openai_agents, span_exporter):
     for s in span_data:
         if "gen_ai.output.messages" in s["attributes"]:
             msgs = json.loads(s["attributes"]["gen_ai.output.messages"])
-            all_output.extend(msgs)
+            all_output.extend(msgs["output"])
     assert any("72" in str(m) for m in all_output)
 
     # Should have a function/tool span for get_weather
@@ -138,7 +138,7 @@ def test_agent_with_tool(instrument_openai_agents, span_exporter):
         "role": "system",
         "content": [
             {
-                "type": "text",
+                "type": "input_text",
                 "text": (
                     "You are a helpful assistant. Use the get_weather tool "
                     "to answer weather questions."

--- a/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
+++ b/tests/test_instrumentations/test_openai_agents/test_agents_integration.py
@@ -1,0 +1,134 @@
+"""Integration tests for OpenAI Agents SDK instrumentation.
+
+These tests verify the full pipeline: Agent SDK -> Trace Processor -> Laminar spans.
+They use VCR to record/replay actual OpenAI API calls and verify the resulting
+spans via InMemorySpanExporter.
+"""
+
+import json
+import time
+
+import pytest
+from agents import Agent, Runner, function_tool
+
+from lmnr.opentelemetry_lib.tracing.attributes import Attributes
+
+
+def _get_spans(span_exporter):
+    """Helper to get spans with a small delay for flush."""
+    time.sleep(0.1)
+    return span_exporter.get_finished_spans()
+
+
+def _attrs(spans):
+    """Build a list of {name, attributes} dicts from spans for easy inspection."""
+    return [
+        {"name": s.name, "attributes": dict(s.attributes or {})}
+        for s in spans
+    ]
+
+
+def _find_spans_with_model(span_data):
+    """Find spans that have the model attribute set (response/generation spans)."""
+    return [
+        s for s in span_data
+        if s["attributes"].get(Attributes.REQUEST_MODEL.value)
+    ]
+
+
+def _find_spans_by_attr(span_data, key, value=None):
+    """Find spans that have a specific attribute, optionally matching a value."""
+    if value is None:
+        return [s for s in span_data if key in s["attributes"]]
+    return [s for s in span_data if s["attributes"].get(key) == value]
+
+
+@pytest.mark.vcr
+def test_simple_agent(instrument_openai_agents, span_exporter):
+    """Run a simple agent and verify span structure and attributes."""
+    agent = Agent(
+        name="Assistant",
+        instructions="You are a helpful assistant.",
+        model="gpt-4o-mini",
+    )
+
+    result = Runner.run_sync(agent, "What is 2+2?")
+    assert "4" in result.final_output
+
+    spans = _get_spans(span_exporter)
+    assert len(spans) > 0
+
+    span_data = _attrs(spans)
+
+    # Should have a response span with LLM attributes
+    response_spans = _find_spans_with_model(span_data)
+    assert len(response_spans) >= 1
+
+    resp = response_spans[0]
+    assert resp["attributes"][Attributes.REQUEST_MODEL.value] == "gpt-4o-mini"
+    assert resp["attributes"][Attributes.PROVIDER.value] == "openai"
+
+    # Verify token usage was recorded
+    assert resp["attributes"][Attributes.INPUT_TOKEN_COUNT.value] == 25
+    assert resp["attributes"][Attributes.OUTPUT_TOKEN_COUNT.value] == 8
+    assert resp["attributes"][Attributes.TOTAL_TOKEN_COUNT.value] == 33
+
+    # Verify gen_ai.output.messages contains the response text
+    output_messages = json.loads(resp["attributes"]["gen_ai.output.messages"])
+    assert any("4" in str(m) for m in output_messages)
+
+    # Verify gen_ai.input.messages contains the user message
+    input_messages = json.loads(resp["attributes"]["gen_ai.input.messages"])
+    assert any("2+2" in str(m) or "2 + 2" in str(m) for m in input_messages)
+
+    # Verify response ID was recorded
+    assert resp["attributes"].get(Attributes.RESPONSE_ID.value)
+
+
+@pytest.mark.vcr
+def test_agent_with_tool(instrument_openai_agents, span_exporter):
+    """Run an agent that calls a tool and verify tool + LLM spans."""
+
+    @function_tool
+    def get_weather(city: str) -> str:
+        """Get the current weather for a city."""
+        return "72°F and sunny"
+
+    agent = Agent(
+        name="WeatherBot",
+        instructions="You are a helpful assistant. Use the get_weather tool to answer weather questions.",
+        model="gpt-4o-mini",
+        tools=[get_weather],
+    )
+
+    result = Runner.run_sync(agent, "What is the weather in NYC?")
+    assert "72" in result.final_output
+
+    spans = _get_spans(span_exporter)
+    assert len(spans) > 0
+
+    span_data = _attrs(spans)
+
+    # Should have response spans with model info
+    model_spans = _find_spans_with_model(span_data)
+    assert len(model_spans) >= 1
+
+    # Verify at least one span recorded the tool call output containing the answer
+    all_output = []
+    for s in span_data:
+        if "gen_ai.output.messages" in s["attributes"]:
+            msgs = json.loads(s["attributes"]["gen_ai.output.messages"])
+            all_output.extend(msgs)
+    assert any("72" in str(m) for m in all_output)
+
+    # Should have a function/tool span for get_weather
+    tool_spans = _find_spans_by_attr(
+        span_data, "openai.agents.span.type", "function"
+    )
+    assert len(tool_spans) >= 1
+
+    # Verify token usage on at least one model span
+    assert any(
+        s["attributes"].get(Attributes.INPUT_TOKEN_COUNT.value) is not None
+        for s in model_spans
+    )

--- a/tests/test_instrumentations/test_openai_agents/test_system_instructions.py
+++ b/tests/test_instrumentations/test_openai_agents/test_system_instructions.py
@@ -1,0 +1,97 @@
+"""Unit tests for system-instructions handling in the openai_agents instrumentation."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import MagicMock
+
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.openai_agents.helpers import (  # noqa: E501
+    get_current_system_instructions,
+    reset_current_system_instructions,
+    set_current_system_instructions,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.openai_agents.messages import (  # noqa: E501
+    set_gen_ai_input_messages,
+)
+
+
+def _captured_attrs() -> tuple[MagicMock, dict[str, object]]:
+    """A minimal LaminarSpan stand-in that records set_attribute calls."""
+    span = MagicMock()
+    captured: dict[str, object] = {}
+
+    def _set_attribute(key: str, value: object) -> None:
+        captured[key] = value
+
+    span.set_attribute.side_effect = _set_attribute
+    return span, captured
+
+
+def test_set_gen_ai_input_messages_without_system_instructions_unchanged():
+    """No system_instructions → output matches pre-change behavior."""
+    span, captured = _captured_attrs()
+    set_gen_ai_input_messages(span, "hello there")
+    messages = json.loads(captured["gen_ai.input.messages"])
+    assert messages == [{"role": "user", "content": "hello there"}]
+
+
+def test_set_gen_ai_input_messages_prepends_system_instructions():
+    span, captured = _captured_attrs()
+    set_gen_ai_input_messages(
+        span,
+        [{"role": "user", "content": "What is 2+2?"}],
+        system_instructions="You are a calculator.",
+    )
+    messages = json.loads(captured["gen_ai.input.messages"])
+    assert messages == [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "You are a calculator."}],
+        },
+        {"role": "user", "content": "What is 2+2?"},
+    ]
+
+
+def test_set_gen_ai_input_messages_system_only_still_emits():
+    """If the model was called with only system instructions and no other
+    input, the span should still surface the system turn."""
+    span, captured = _captured_attrs()
+    set_gen_ai_input_messages(
+        span, None, system_instructions="Always respond in French."
+    )
+    messages = json.loads(captured["gen_ai.input.messages"])
+    assert messages == [
+        {
+            "role": "system",
+            "content": [{"type": "text", "text": "Always respond in French."}],
+        }
+    ]
+
+
+def test_set_gen_ai_input_messages_noop_when_both_missing():
+    span, captured = _captured_attrs()
+    set_gen_ai_input_messages(span, None, system_instructions=None)
+    assert captured == {}
+    span.set_attribute.assert_not_called()
+
+
+def test_system_instructions_contextvar_is_task_local():
+    """Concurrent tasks must see their own system instructions so multi-agent
+    runs (handoffs, parallel sub-agents) do not leak the prompt."""
+
+    async def _scenario(prompt: str) -> str | None:
+        token = set_current_system_instructions(prompt)
+        try:
+            # Yield control so other tasks may run while we hold our value.
+            await asyncio.sleep(0)
+            return get_current_system_instructions()
+        finally:
+            reset_current_system_instructions(token)
+
+    async def _runner() -> tuple[str | None, str | None]:
+        return await asyncio.gather(_scenario("alpha"), _scenario("beta"))
+
+    results = asyncio.run(_runner())
+    assert sorted([s for s in results if s is not None]) == ["alpha", "beta"]
+    assert get_current_system_instructions() is None

--- a/tests/test_instrumentations/test_openai_agents/test_system_instructions.py
+++ b/tests/test_instrumentations/test_openai_agents/test_system_instructions.py
@@ -47,7 +47,7 @@ def test_set_gen_ai_input_messages_prepends_system_instructions():
     assert messages == [
         {
             "role": "system",
-            "content": [{"type": "text", "text": "You are a calculator."}],
+            "content": [{"type": "input_text", "text": "You are a calculator."}],
         },
         {"role": "user", "content": "What is 2+2?"},
     ]
@@ -64,7 +64,7 @@ def test_set_gen_ai_input_messages_system_only_still_emits():
     assert messages == [
         {
             "role": "system",
-            "content": [{"type": "text", "text": "Always respond in French."}],
+            "content": [{"type": "input_text", "text": "Always respond in French."}],
         }
     ]
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new tracing/instrumentation path for `openai-agents` and changes OpenAI response span wrappers/context propagation, which could affect span nesting, suppression behavior, and emitted telemetry. Dependency/CI workflow bumps are low risk but widen surface area for compatibility issues (e.g., new `grpcio` dep and version pin changes).
> 
> **Overview**
> **Adds first-class OpenAI Agents SDK instrumentation.** Introduces `openai_agents` instrumentation (instrumentor + trace processor + span-data extraction) that mirrors Agents traces/spans into Laminar, including mapping span kinds to Laminar span types, capturing model/usage/tool definitions, and prepending agent system instructions into `gen_ai.input.messages` via a task-local `ContextVar`.
> 
> **Prevents double-instrumentation and hardens OpenAI response wrappers.** OpenAI `responses` wrappers now honor a Laminar context key to disable OpenAI Responses instrumentation (used by the Agents processor), refactor exception/response handling into shared helpers, add defensive parsing for optional fields, and switch to `opentelemetry.context._SUPPRESS_INSTRUMENTATION_KEY`.
> 
> **Build/test and packaging updates.** GitHub workflows bump action versions (checkout/setup-python/setup-uv/slack), `pyproject.toml` adds `license-files`, adds `grpcio` dependency, tightens `packaging`/`tqdm` upper bounds, updates dev deps (incl. `openai-agents`) and `uv_build`, and the FastAPI example drops the `lmnr[openai]` extra. New VCR-based integration tests validate Agents instrumentation output and system-instructions handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c4baadaa02c5db3d9bfedc9488deee270d9a724. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->