### PR TITLE
pop span from maps on span end

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.46"
+version = "0.7.47"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }
@@ -132,6 +132,11 @@ dev = [
   "langchain-core==1.2.22",
   "langchain-openai==1.1.12",
   "langgraph==1.1.3",
+  # we don't depend on it directly, but version 1.0.9
+  # has a breaking change incompatible with older pinned
+  # version of langgraph.
+  # See https://github.com/langchain-ai/langgraph/issues/7404
+  "langgraph-prebuilt==1.0.8",
   "litellm==1.81.16",
   "openai==2.30.0",
   "patchright==1.58.2",
@@ -144,7 +149,7 @@ dev = [
 ]
 
 [build-system]
-requires = ["uv_build>=0.9.7,<0.10"]
+requires = ["uv_build>=0.11.3,<0.12"]
 build-backend = "uv_build"
 
 [tool.uv.workspace]

--- a/src/lmnr/opentelemetry_lib/tracing/processor.py
+++ b/src/lmnr/opentelemetry_lib/tracing/processor.py
@@ -195,10 +195,6 @@ class LaminarSpanProcessor(SpanProcessor):
             self.instance.on_start(span, parent_context)
 
     def on_end(self, span: ReadableSpan):
-        if (from_env("LMNR_DISABLE_TRACING") or "false").lower().strip() == "true" or (
-            span.attributes and span.attributes.get("lmnr.internal.disabled")
-        ):
-            return
         span_context = span.get_span_context()
         if span_context is not None:
             with self._paths_lock:
@@ -210,6 +206,10 @@ class LaminarSpanProcessor(SpanProcessor):
                     self.__span_id_to_path.pop(span_context.span_id)
                 except KeyError:
                     pass
+        if (from_env("LMNR_DISABLE_TRACING") or "false").lower().strip() == "true" or (
+            span.attributes and span.attributes.get("lmnr.internal.disabled")
+        ):
+            return
 
         with self._instance_lock:
             self.instance.on_end(span)

--- a/src/lmnr/opentelemetry_lib/tracing/processor.py
+++ b/src/lmnr/opentelemetry_lib/tracing/processor.py
@@ -1,16 +1,16 @@
 import logging
 import threading
+import time
 import uuid
 from typing import TYPE_CHECKING
 
+from opentelemetry.context import Context, get_value
+from opentelemetry.sdk.trace import ReadableSpan, Span, SpanProcessor
 from opentelemetry.sdk.trace.export import (
-    SpanProcessor,
-    SpanExporter,
     BatchSpanProcessor,
     SimpleSpanProcessor,
+    SpanExporter,
 )
-from opentelemetry.sdk.trace import Span
-from opentelemetry.context import Context, get_value
 
 if TYPE_CHECKING:
     from lmnr.sdk.client.synchronous.sync_client import LaminarClient
@@ -125,13 +125,16 @@ class LaminarSpanProcessor(SpanProcessor):
                 if parent_span_path
                 else [span_name_in_path]
             )
+            span_context = span.get_span_context()
+            if span_context is None:
+                raise ValueError("Improperly setup span, no span_context")
             span_ids_path = parent_span_ids_path + [
-                str(uuid.UUID(int=span.get_span_context().span_id))
+                str(uuid.UUID(int=span_context.span_id))
             ]
             span.set_attribute(SPAN_PATH, span_path)
             span.set_attribute(SPAN_IDS_PATH, span_ids_path)
-            self.__span_id_to_path[span.get_span_context().span_id] = span_path
-            self.__span_id_lists[span.get_span_context().span_id] = span_ids_path
+            self.__span_id_to_path[span_context.span_id] = span_path
+            self.__span_id_lists[span_context.span_id] = span_ids_path
 
         if is_disabled:
             return
@@ -191,11 +194,23 @@ class LaminarSpanProcessor(SpanProcessor):
         with self._instance_lock:
             self.instance.on_start(span, parent_context)
 
-    def on_end(self, span: Span):
+    def on_end(self, span: ReadableSpan):
         if (from_env("LMNR_DISABLE_TRACING") or "false").lower().strip() == "true" or (
             span.attributes and span.attributes.get("lmnr.internal.disabled")
         ):
             return
+        span_context = span.get_span_context()
+        if span_context is not None:
+            with self._paths_lock:
+                try:
+                    self.__span_id_lists.pop(span_context.span_id)
+                except KeyError:
+                    pass
+                try:
+                    self.__span_id_to_path.pop(span_context.span_id)
+                except KeyError:
+                    pass
+
         with self._instance_lock:
             self.instance.on_end(span)
 
@@ -277,8 +292,9 @@ class LaminarSpanProcessor(SpanProcessor):
             span: The span to stream
         """
         try:
-            from lmnr.sdk.rollout_control import get_rollout_session_id
             import datetime
+
+            from lmnr.sdk.rollout_control import get_rollout_session_id
 
             if not self._rollout_client:
                 return
@@ -292,7 +308,11 @@ class LaminarSpanProcessor(SpanProcessor):
                 return
 
             start_time_ns = span.start_time
-            start_time_seconds = start_time_ns / 1e9
+            if start_time_ns is None:
+                self.logger.warning("Span not started")
+                start_time_seconds = time.time()
+            else:
+                start_time_seconds = start_time_ns / 1e9
             start_time_dt = datetime.datetime.fromtimestamp(
                 start_time_seconds, tz=datetime.timezone.utc
             )
@@ -330,7 +350,10 @@ class LaminarSpanProcessor(SpanProcessor):
 
             def stream_task():
                 try:
-                    self._rollout_client.rollout.update_span_info(session_id, span_data)
+                    if self._rollout_client:
+                        self._rollout_client.rollout.update_span_info(
+                            session_id, span_data
+                        )
                 except Exception as e:
                     self.logger.debug(f"Error in span streaming task: {e}")
 
@@ -376,6 +399,9 @@ class LaminarSpanProcessor(SpanProcessor):
                     self.exporter, max_export_batch_size=self.max_export_batch_size
                 )
             )
+            # Force reinit protocol is a clear state, so clear
+            # any remaining internal state
+            self.clear()
 
     def shutdown(self):
         with self._instance_lock:

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import sys
 import httpx
 from packaging import version
 
-__version__ = "0.7.46"
+__version__ = "0.7.47"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,22 @@
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from lmnr.opentelemetry_lib.tracing import TracerWrapper
+from lmnr.opentelemetry_lib.tracing.processor import LaminarSpanProcessor
+from lmnr.sdk.decorators import observe
+
+
+def test_span_processor_cleanup(span_exporter: InMemorySpanExporter):
+    processor: LaminarSpanProcessor = TracerWrapper()._span_processor
+
+    @observe()
+    def foo():
+        assert processor._LaminarSpanProcessor__span_id_lists  # not empty
+        assert processor._LaminarSpanProcessor__span_id_to_path  # not empty
+        return "bar"
+
+    foo()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    assert not processor._LaminarSpanProcessor__span_id_lists
+    assert not processor._LaminarSpanProcessor__span_id_to_path


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core tracing span lifecycle and rollout streaming behavior; regressions could affect span linking or real-time UI updates, but changes are localized and covered by a new test.
> 
> **Overview**
> Fixes `LaminarSpanProcessor` to **remove per-span path/id entries** from its internal maps when a span ends, preventing stale state/memory growth across traces.
> 
> Also hardens rollout span streaming by handling missing `start_time`, guarding `_rollout_client` usage, and clearing processor internal state on `force_reinit`. Bumps package version to `0.7.47`, updates `uv_build`, pins `langgraph-prebuilt==1.0.8`, and adds a test asserting the new cleanup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c87c4dcbc0aa10dd7d6bbe52d171cbebfdec397. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->