### PR TITLE
bump version to 0.7.48, bump some dev deps

### DIFF
--- a/examples/fastapi-app/pyproject.toml
+++ b/examples/fastapi-app/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "lmnr",
     "openai>=1.76.0",
     "pydantic>=2.10.5",
-    "python-dotenv>=1.1.0",
+    "python-dotenv>=1.0.0",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.47"
+version = "0.7.48"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }
@@ -115,24 +115,23 @@ all = [
 
 [dependency-groups]
 dev = [
-  "anthropic[bedrock]==0.86.0",
+  "anthropic[bedrock]==0.95.0",
   "autopep8==2.3.2",
   "claude-agent-sdk==0.1.50",
-  "fastapi==0.135.2",
   "flake8==7.3.0",
   "google-genai==1.68.0",
   "groq==1.1.2",
   "kernel==0.44.0",
-  "langchain==1.2.13",
-  "langchain-core==1.2.22",
-  "langchain-openai==1.1.12",
+  "langchain==1.2.15",
+  "langchain-core==1.3.0",
+  "langchain-openai==1.1.14",
   "langgraph==1.1.6",
-  "litellm==1.81.16",
+  "litellm==1.83.7",
   "openai==2.30.0",
   "openai-agents==0.14.1",
   "patchright==1.58.2",
   "playwright==1.58.0",
-  "pytest==9.0.2",
+  "pytest==9.0.3",
   "pytest-asyncio==1.3.0",
   "pytest-recording==0.13.4",
   "pytest-sugar==1.1.1",

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import sys
 import httpx
 from packaging import version
 
-__version__ = "0.7.47"
+__version__ = "0.7.48"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to version metadata and dependency pin updates, with no production logic modifications beyond the version constant.
> 
> **Overview**
> Bumps the `lmnr` package version from `0.7.47` to `0.7.48` (in `pyproject.toml` and `src/lmnr/version.py`).
> 
> Updates several *dev-only* dependency pins (e.g., `anthropic`, `langchain*`, `litellm`, `pytest`) and relaxes the example FastAPI app’s `python-dotenv` requirement from `>=1.1.0` to `>=1.0.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c212f754f40cbb0d298004ac4013a491e669ffa9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->