### PR TITLE
pin to older aiohttp to fix tests (vcrpy)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,6 +115,14 @@ all = [
 
 [dependency-groups]
 dev = [
+  # `vcrpy` mocks an internal class, in particular
+  # https://github.com/kevin1024/vcrpy/blob/master/vcr/stubs/aiohttp_stubs.py#L21
+  # relise on `aiohttp.streams.AsyncStreamReaderMixin` that has been removed in
+  # version 3.14.
+  # Created issue with vcrpy https://github.com/kevin1024/vcrpy/issues/995
+  # Pinning to older aiohttp for now
+  "aiohttp (>=3.0.0, <3.14.0)",
+
   "anthropic[bedrock]==0.95.0",
   "autopep8==2.3.2",
   "claude-agent-sdk==0.1.50",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dev-only dependency constraint for tests; no production SDK or security surface changes.
> 
> **Overview**
> Pins **`aiohttp`** in the **`dev`** dependency group to **`>=3.0.0, <3.14.0`** so test recording with **`vcrpy`** keeps working after **`aiohttp` 3.14** dropped **`AsyncStreamReaderMixin`**, which vcrpy’s aiohttp stubs still rely on.
> 
> Adds inline comments pointing at the upstream vcrpy issue; this is a **dev/test** workaround only and does not change runtime **`lmnr`** dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 92e4beda36d46e57f7a5fff3ba36c9bc8f880e80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->