### PR TITLE
bump version to 0.7.53 for release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.52"
+version = "0.7.53"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }
@@ -23,7 +23,7 @@ dependencies = [
   "blake3 (>=1.0.0,<2.0.0)",
   "grpcio>=1",
   "httpx (>=0.24.0,<1.0.0)",
-  "lmnr-claude-code-proxy>=0.1.17",
+  "lmnr-claude-code-proxy>=0.1.22",
   "opentelemetry-api (>=1.39.0, <2.0.0)",
   "opentelemetry-sdk (>=1.39.0, <2.0.0)",
   "opentelemetry-exporter-otlp-proto-http (>=1.39.0, <2.0.0)",

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import sys
 import httpx
 from packaging import version
 
-__version__ = "0.7.52"
+__version__ = "0.7.53"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Version and dependency floor updates only; no application logic changes in this diff.
> 
> **Overview**
> Prepares **lmnr 0.7.53** for release by aligning the package version in `pyproject.toml` and `src/lmnr/version.py`.
> 
> Also raises the minimum **`lmnr-claude-code-proxy`** dependency from `>=0.1.17` to `>=0.1.22`, so installs of this SDK pick up a newer Claude Code proxy used by Claude Agent instrumentation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44ecfcf706aae46acd91910ba8f91071da1c0cd3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->