### PR TITLE
Fix/observe error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,14 +116,6 @@ all = [
 
 [dependency-groups]
 dev = [
-  # `vcrpy` mocks an internal class, in particular
-  # https://github.com/kevin1024/vcrpy/blob/master/vcr/stubs/aiohttp_stubs.py#L21
-  # relise on `aiohttp.streams.AsyncStreamReaderMixin` that has been removed in
-  # version 3.14.
-  # Created issue with vcrpy https://github.com/kevin1024/vcrpy/issues/995
-  # Pinning to older aiohttp for now
-  "aiohttp (>=3.0.0, <3.14.0)",
-
   "anthropic[bedrock]==0.95.0",
   "autopep8==2.3.2",
   "claude-agent-sdk==0.1.50",
@@ -141,13 +133,13 @@ dev = [
   "openai-agents==0.14.1",
   "patchright==1.58.2",
   "playwright==1.58.0",
-  "pydantic-ai-slim==1.99.0",
+  "pydantic-ai-slim==1.107.0",
   "pytest==9.0.3",
   "pytest-asyncio==1.3.0",
   "pytest-recording==0.13.4",
   "pytest-sugar==1.1.1",
   "temporalio==1.28.0",
-  "vcrpy==8.1.1",
+  "vcrpy==8.3.0",
 ]
 
 [build-system]

--- a/src/lmnr/opentelemetry_lib/decorators/__init__.py
+++ b/src/lmnr/opentelemetry_lib/decorators/__init__.py
@@ -1,29 +1,31 @@
 import asyncio
-from functools import wraps
 import types
+from functools import wraps
 from typing import Any, AsyncGenerator, Callable, Generator, Literal, TypeVar
 
 from opentelemetry import context as context_api
 from opentelemetry.trace import Span, Status, StatusCode
 
-from lmnr.opentelemetry_lib.tracing.context import (
-    CONTEXT_METADATA_KEY,
-    attach_context,
-    detach_context,
-    get_event_attributes_from_context,
-)
-from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
-from lmnr.opentelemetry_lib.tracing.utils import set_association_props_in_context
-from lmnr.sdk.utils import get_input_from_func_args, is_method
-from lmnr.opentelemetry_lib.tracing.tracer import get_tracer_with_context
+from lmnr.opentelemetry_lib.tracing import TracerWrapper
 from lmnr.opentelemetry_lib.tracing.attributes import (
     ASSOCIATION_PROPERTIES,
     METADATA,
     SPAN_TYPE,
 )
-from lmnr.opentelemetry_lib.tracing import TracerWrapper
+from lmnr.opentelemetry_lib.tracing.context import (
+    CONTEXT_METADATA_KEY,
+    get_event_attributes_from_context,
+)
+from lmnr.opentelemetry_lib.tracing.span import LaminarSpan
+from lmnr.opentelemetry_lib.tracing.tracer import get_tracer_with_context
+from lmnr.opentelemetry_lib.tracing.utils import set_association_props_in_context
 from lmnr.sdk.log import get_default_logger
-from lmnr.sdk.utils import is_otel_attribute_value_type, json_dumps
+from lmnr.sdk.utils import (
+    get_input_from_func_args,
+    is_method,
+    is_otel_attribute_value_type,
+    json_dumps,
+)
 
 logger = get_default_logger(__name__)
 
@@ -209,7 +211,6 @@ def observe_base(
             ctx_token = None
             current_task = None
             current_context_id = None
-            isolated_ctx_token = None
             did_push_context = False
             try:
                 try:
@@ -224,7 +225,6 @@ def observe_base(
                 # to the OTEL global context, so that spans know their parent
                 # span and trace_id.
                 ctx_token = context_api.attach(new_context)
-                isolated_ctx_token = attach_context(new_context)
             except Exception:
                 logger.debug("Failed to setup span context", exc_info=True)
 
@@ -254,10 +254,6 @@ def observe_base(
                     logger.debug(
                         "Not detaching global context, not in the same context"
                     )
-                try:
-                    detach_context(isolated_ctx_token)
-                except Exception:
-                    logger.debug("Failed to detach isolated context", exc_info=True)
             # span will be ended in the generator
             if isinstance(res, types.GeneratorType):
                 return _handle_generator(
@@ -350,7 +346,6 @@ def async_observe_base(
             ctx_token = None
             current_task = None
             current_context_id = None
-            isolated_ctx_token = None
             did_push_context = False
             try:
                 try:
@@ -365,7 +360,6 @@ def async_observe_base(
                 # to the OTEL global context, so that spans know their parent
                 # span and trace_id.
                 ctx_token = context_api.attach(new_context)
-                isolated_ctx_token = attach_context(new_context)
             except Exception:
                 logger.debug("Failed to setup span context", exc_info=True)
 
@@ -378,7 +372,7 @@ def async_observe_base(
             except Exception as e:
                 _process_exception(span, e)
                 _cleanup_span(span, wrapper, did_push_context)
-                raise e
+                raise
             finally:
                 # Always restore global context if we are in the same asyncio context
                 current_task = None
@@ -395,10 +389,6 @@ def async_observe_base(
                     logger.debug(
                         "Not detaching global context, not in the same context"
                     )
-                try:
-                    detach_context(isolated_ctx_token)
-                except Exception:
-                    logger.debug("Failed to detach isolated context", exc_info=True)
 
             # span will be ended in the generator
             if isinstance(res, types.AsyncGeneratorType):

--- a/src/lmnr/opentelemetry_lib/tracing/span.py
+++ b/src/lmnr/opentelemetry_lib/tracing/span.py
@@ -419,11 +419,6 @@ class LaminarSpan(LaminarSpanInterfaceMixin, SpanDelegationMixin, Span, Readable
                 self._popped = True
             except Exception:
                 self.logger.debug("Failed to pop span context", exc_info=True)
-        if hasattr(self, "_lmnr_isolated_ctx_token"):
-            try:
-                detach_context(self._lmnr_isolated_ctx_token)
-            except Exception:
-                self.logger.debug("Failed to detach isolated context", exc_info=True)
         if hasattr(self, "_lmnr_assoc_props_token") and self._lmnr_assoc_props_token:
             try:
                 detach_context(self._lmnr_assoc_props_token)

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -1315,7 +1315,6 @@ class Laminar:
             # don't have access to our isolated context. We attach the context
             # to the OTEL global context, so that spans know their parent
             # span and trace_id.
-            isolated_context_token = attach_context(context)
             context_token = context_api.attach(context)
             if isinstance(span, LaminarSpan):
                 yield span
@@ -1351,7 +1350,6 @@ class Laminar:
         finally:
             try:
                 context_api.detach(context_token)
-                detach_context(isolated_context_token)
                 wrapper.pop_span_context()
             finally:
                 if end_on_exit:
@@ -1416,9 +1414,7 @@ class Laminar:
             parsed["user_id"] if parsed["user_id"] is not None else ctx_user_id
         )
         final_session_id = (
-            parsed["session_id"]
-            if parsed["session_id"] is not None
-            else ctx_session_id
+            parsed["session_id"] if parsed["session_id"] is not None else ctx_session_id
         )
 
         ctx = set_association_prop_context(
@@ -1565,9 +1561,7 @@ class Laminar:
 
         context = wrapper.push_span_context(span, from_ctx=context)
         context_token = context_api.attach(context)
-        isolated_context_token = attach_context(context)
         span._lmnr_ctx_token = context_token
-        span._lmnr_isolated_ctx_token = isolated_context_token
         try:
             current_task = asyncio.current_task()
         except Exception:
@@ -1797,9 +1791,7 @@ class Laminar:
                 lmnr_span_processor=wrapper._span_processor,
             )
         except Exception as exc:  # pylint: disable=broad-exception-caught
-            logger.warning(
-                "Failed to install Laminar/Langfuse bridge: %s", exc
-            )
+            logger.warning("Failed to install Laminar/Langfuse bridge: %s", exc)
             return False
         return LangfuseInstrumentor._installed
 

--- a/tests/test_observe.py
+++ b/tests/test_observe.py
@@ -134,6 +134,90 @@ def test_observe_exception_with_session_id_and_name(
     assert events[0].attributes["exception.message"] == "test"
 
 
+# At the time of writing this test, an erroring observed function would break the context for
+# the following sibling spans
+def test_observe_exception_preserves_context(span_exporter: InMemorySpanExporter):
+    @observe()
+    def err():
+        raise ValueError("test")
+
+    @observe()
+    def success():
+        pass
+
+    @observe()
+    def parent():
+        try:
+            err()
+        except Exception:
+            pass
+        success()
+
+    parent()
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 3
+    err_span = [span for span in spans if span.name == "err"][0]
+    success_span = [span for span in spans if span.name == "success"][0]
+    parent_span = [span for span in spans if span.name == "parent"][0]
+    assert getattr(err_span.get_span_context(), "trace_id") == getattr(
+        parent_span.get_span_context(), "trace_id"
+    )
+    assert getattr(success_span.get_span_context(), "trace_id") == getattr(
+        parent_span.get_span_context(), "trace_id"
+    )
+    assert getattr(err_span.parent, "span_id") == getattr(
+        parent_span.get_span_context(), "span_id"
+    )
+    assert getattr(success_span.parent, "span_id") == getattr(
+        parent_span.get_span_context(), "span_id"
+    )
+    assert err_span.attributes.get("lmnr.span.path") == ("parent", "err")
+    assert success_span.attributes.get("lmnr.span.path") == ("parent", "success")
+
+
+# Async counterpart of test_observe_exception_preserves_context above.
+@pytest.mark.asyncio
+async def test_observe_async_exception_preserves_context(
+    span_exporter: InMemorySpanExporter,
+):
+    @observe()
+    async def err():
+        raise ValueError("test")
+
+    @observe()
+    async def success():
+        pass
+
+    @observe()
+    async def parent():
+        try:
+            await err()
+        except Exception:
+            pass
+        await success()
+
+    await parent()
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 3
+    err_span = [span for span in spans if span.name == "err"][0]
+    success_span = [span for span in spans if span.name == "success"][0]
+    parent_span = [span for span in spans if span.name == "parent"][0]
+    assert getattr(err_span.get_span_context(), "trace_id") == getattr(
+        parent_span.get_span_context(), "trace_id"
+    )
+    assert getattr(success_span.get_span_context(), "trace_id") == getattr(
+        parent_span.get_span_context(), "trace_id"
+    )
+    assert getattr(err_span.parent, "span_id") == getattr(
+        parent_span.get_span_context(), "span_id"
+    )
+    assert getattr(success_span.parent, "span_id") == getattr(
+        parent_span.get_span_context(), "span_id"
+    )
+    assert err_span.attributes.get("lmnr.span.path") == ("parent", "err")
+    assert success_span.attributes.get("lmnr.span.path") == ("parent", "success")
+
+
 @pytest.mark.asyncio
 async def test_observe_async(span_exporter: InMemorySpanExporter):
     @observe()

--- a/tests/test_observe_exceptions.py
+++ b/tests/test_observe_exceptions.py
@@ -357,48 +357,6 @@ async def test_context_api_attach_failure_async(span_exporter: InMemorySpanExpor
 
 
 # =============================================================================
-# Context setup failures — lmnr isolated attach_context raises
-# Same outer try/except catches it; isolated_ctx_token stays None.
-# Result: 1 span, function returns correctly.
-# =============================================================================
-
-
-def test_attach_context_failure_sync(span_exporter: InMemorySpanExporter):
-    @observe()
-    def observed_foo():
-        return "foo"
-
-    with patch(
-        "lmnr.opentelemetry_lib.decorators.attach_context",
-        side_effect=RuntimeError("attach_context exploded"),
-    ):
-        result = observed_foo()
-
-    assert result == "foo"
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    assert spans[0].name == "observed_foo"
-
-
-@pytest.mark.asyncio
-async def test_attach_context_failure_async(span_exporter: InMemorySpanExporter):
-    @observe()
-    async def observed_foo():
-        return "foo"
-
-    with patch(
-        "lmnr.opentelemetry_lib.decorators.attach_context",
-        side_effect=RuntimeError("attach_context exploded"),
-    ):
-        result = await observed_foo()
-
-    assert result == "foo"
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    assert spans[0].name == "observed_foo"
-
-
-# =============================================================================
 # Context teardown failures — context_api.detach raises in finally block
 # The individual try/except around context_api.detach(ctx_token) catches it.
 # Result: 1 span, function returns correctly.
@@ -426,48 +384,6 @@ async def test_context_api_detach_failure_async(span_exporter: InMemorySpanExpor
         return "foo"
 
     with patch.object(otel_context, "detach", side_effect=RuntimeError("otel detach exploded")):
-        result = await observed_foo()
-
-    assert result == "foo"
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    assert spans[0].name == "observed_foo"
-
-
-# =============================================================================
-# Context teardown failures — lmnr detach_context raises in finally block
-# The individual try/except around detach_context(isolated_ctx_token) catches it.
-# Result: 1 span, function returns correctly.
-# =============================================================================
-
-
-def test_detach_context_failure_sync(span_exporter: InMemorySpanExporter):
-    @observe()
-    def observed_foo():
-        return "foo"
-
-    with patch(
-        "lmnr.opentelemetry_lib.decorators.detach_context",
-        side_effect=RuntimeError("detach_context exploded"),
-    ):
-        result = observed_foo()
-
-    assert result == "foo"
-    spans = span_exporter.get_finished_spans()
-    assert len(spans) == 1
-    assert spans[0].name == "observed_foo"
-
-
-@pytest.mark.asyncio
-async def test_detach_context_failure_async(span_exporter: InMemorySpanExporter):
-    @observe()
-    async def observed_foo():
-        return "foo"
-
-    with patch(
-        "lmnr.opentelemetry_lib.decorators.detach_context",
-        side_effect=RuntimeError("detach_context exploded"),
-    ):
         result = await observed_foo()
 
     assert result == "foo"

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -44,6 +44,48 @@ def test_start_as_current_span_exception(span_exporter: InMemorySpanExporter):
     assert events[0].attributes["exception.message"] == "error"
 
 
+# Counterpart of test_observe_exception_preserves_context in test_observe.py, using
+# Laminar.start_as_current_span() instead of @observe(). Not expected to fail, but
+# worth covering since it shares the context push/pop machinery with @observe().
+def test_start_as_current_span_exception_preserves_context(
+    span_exporter: InMemorySpanExporter,
+):
+    def err():
+        with Laminar.start_as_current_span("err"):
+            raise ValueError("test")
+
+    def success():
+        with Laminar.start_as_current_span("success"):
+            pass
+
+    with Laminar.start_as_current_span("parent"):
+        try:
+            err()
+        except Exception:
+            pass
+        success()
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 3
+    err_span = [span for span in spans if span.name == "err"][0]
+    success_span = [span for span in spans if span.name == "success"][0]
+    parent_span = [span for span in spans if span.name == "parent"][0]
+    assert getattr(err_span.get_span_context(), "trace_id") == getattr(
+        parent_span.get_span_context(), "trace_id"
+    )
+    assert getattr(success_span.get_span_context(), "trace_id") == getattr(
+        parent_span.get_span_context(), "trace_id"
+    )
+    assert getattr(err_span.parent, "span_id") == getattr(
+        parent_span.get_span_context(), "span_id"
+    )
+    assert getattr(success_span.parent, "span_id") == getattr(
+        parent_span.get_span_context(), "span_id"
+    )
+    assert err_span.attributes.get("lmnr.span.path") == ("parent", "err")
+    assert success_span.attributes.get("lmnr.span.path") == ("parent", "success")
+
+
 def test_start_as_current_span_span_type(span_exporter: InMemorySpanExporter):
     with Laminar.start_as_current_span("test", span_type="LLM"):
         pass


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core tracing context lifecycle for @observe and manual span APIs; wrong teardown could still mis-parent spans, though new tests cover the reported failure mode.
> 
> **Overview**
> Fixes a tracing bug where a **caught failure inside an `@observe` span** could leave OpenTelemetry context wrong, so **later sibling spans** no longer shared the same trace/parent as expected.
> 
> The change **stops double-managing Laminar’s isolated context** in `@observe`, `Laminar.use_span`, `Laminar.start_active_span`, and `LaminarSpan.end()`: it keeps **`context_api.attach` / `detach`** for the global OTEL context (so auto-instrumentation still parents correctly) and relies on **`push_span_context` / `pop_span_context`** for the isolated stack, removing the extra **`attach_context` / `detach_context`** pair that could detach twice on error paths.
> 
> Adds sync/async regression tests for **err → success** under the same parent (for `@observe` and `start_as_current_span`). Drops obsolete tests that mocked isolated attach/detach on observe. Dev deps: **vcrpy 8.3.0**, **pydantic-ai-slim 1.107.0**, and removes the **aiohttp pin** tied to the old vcrpy issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71aec228634965002a165c795f63a2d732251aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->