### PR TITLE
allow for v2 pydantic_ai too (no breaking changes to core paths)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.55"
+version = "0.7.56"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }
@@ -133,7 +133,7 @@ dev = [
   "openai-agents==0.14.1",
   "patchright==1.58.2",
   "playwright==1.58.0",
-  "pydantic-ai-slim==1.107.0",
+  "pydantic-ai-slim==2.5.1",
   "pytest==9.0.3",
   "pytest-asyncio==1.3.0",
   "pytest-recording==0.13.4",

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/pydantic_ai/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/pydantic_ai/__init__.py
@@ -76,7 +76,7 @@ class PydanticAIInstrumentor(BaseInstrumentor):
         # breakage from a 2.x release that could change `InstrumentationSettings`
         # (which we instantiate eagerly during `_instrument`); when 2.x ships,
         # validate compatibility and bump the cap.
-        return ("pydantic-ai-slim >= 1.0.0, < 2.0.0",)
+        return ("pydantic-ai-slim >= 1.0.0, < 3.0.0",)
 
     def _instrument(self, **kwargs: Any):
         from pydantic_ai import Agent

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import sys
 import httpx
 from packaging import version
 
-__version__ = "0.7.55"
+__version__ = "0.7.56"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Small version-range and release bump with no logic changes in the diff; main risk is untested breakage if pydantic-ai 2.x changes instrumented APIs beyond what existing fallbacks cover.
> 
> **Overview**
> **Enables `pydantic-ai-slim` 2.x** alongside 1.x by relaxing the OpenTelemetry instrumentor’s declared dependency from `< 2.0.0` to `< 3.0.0`, so installs on pydantic-ai 2 are no longer blocked at dependency check time.
> 
> Dev tests are pinned to **`pydantic-ai-slim==2.5.1`** (was 1.107.0). Instrumentation behavior is unchanged in this diff—existing wrappers and the `pydantic_ai.capabilities` fallback remain as-is.
> 
> Release **0.7.56** bumps `pyproject.toml` and `version.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9a40a50acf625230008e5fcb3f25dbe8f07ac5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->