### PR TITLE
fix(claude-agent): intercept traffic when ANTHROPIC_BASE_URL is set in Claude settings.json

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
@@ -1,9 +1,12 @@
 """Shared utilities for Claude Agent instrumentation."""
 
+import json
 import os
 import re
 import socket
 import time
+from pathlib import Path
+from typing import Any
 
 from lmnr.sdk.log import get_default_logger
 
@@ -21,10 +24,62 @@ BEDROCK_AWS_REGION_ENV = "AWS_REGION"
 VERTEX_BASE_URL_ENV = "ANTHROPIC_VERTEX_BASE_URL"
 VERTEX_USE_ENV = "CLAUDE_CODE_USE_VERTEX"
 
+# Provider base-URL env keys that Claude Code may load from settings.json `env`
+# and that must be rewritten to the local proxy for auto-instrumentation.
+PROXY_BASE_URL_ENV_KEYS = (
+    "ANTHROPIC_BASE_URL",
+    FOUNDRY_BASE_URL_ENV,
+    BEDROCK_BASE_URL_ENV,
+    VERTEX_BASE_URL_ENV,
+)
+
 
 def is_truthy_env(value: str | None) -> bool:
     """Check if environment variable value is truthy (equals '1')."""
     return value == "1"
+
+
+def get_claude_config_dir() -> Path:
+    """Resolve Claude Code config directory (respects CLAUDE_CONFIG_DIR)."""
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude"
+
+
+def read_claude_user_settings() -> dict[str, Any]:
+    """
+    Load user-level Claude Code settings.json if present.
+
+    Returns an empty dict when the file is missing or invalid.
+    """
+    settings_path = get_claude_config_dir() / "settings.json"
+    try:
+        with settings_path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def read_claude_user_settings_env() -> dict[str, str]:
+    """
+    Read the `env` block from ~/.claude/settings.json (or CLAUDE_CONFIG_DIR).
+
+    Claude Code applies this block to the CLI session. For some versions /
+    paths it effectively overrides subprocess process.env for keys like
+    ANTHROPIC_BASE_URL, which causes Laminar's injected proxy URL to be ignored.
+    """
+    data = read_claude_user_settings()
+    env = data.get("env")
+    if not isinstance(env, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key, value in env.items():
+        if value is None:
+            continue
+        result[str(key)] = str(value)
+    return result
 
 
 def snapshot_env(keys: list[str]) -> tuple[dict[str, str | None], set[str]]:
@@ -142,7 +197,10 @@ def resolve_target_url_from_env(
     4. ANTHROPIC_BASE_URL - standard Anthropic API base URL
     5. Fall back to default (https://api.anthropic.com)
 
-    For each environment variable, checks env_dict first, then os.environ as fallback.
+    For each environment variable, checks env_dict first, then os.environ,
+    then the `env` block from Claude Code user settings.json (CLAUDE_CONFIG_DIR
+    or ~/.claude/settings.json). Settings are a common place for custom
+    ANTHROPIC_BASE_URL when using non-default Anthropic-compatible endpoints.
 
     Args:
         env_dict: Dictionary of environment variables (e.g., from options.env)
@@ -151,10 +209,11 @@ def resolve_target_url_from_env(
     Returns:
         Resolved target URL, or None if provider is misconfigured
     """
+    settings_env = read_claude_user_settings_env()
 
-    # Helper to get value from env_dict first, then os.environ
+    # Helper: options.env > process env > Claude user settings env
     def get_env_value(key: str) -> str | None:
-        return env_dict.get(key) or os.environ.get(key)
+        return env_dict.get(key) or os.environ.get(key) or settings_env.get(key)
 
     # 1. Check for HTTPS_PROXY (highest priority)
     https_proxy = get_env_value("HTTPS_PROXY")

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/utils.py
@@ -47,19 +47,43 @@ def get_claude_config_dir() -> Path:
     return Path.home() / ".claude"
 
 
+def _resolve_session_cwd(cwd: str | Path | None = None) -> Path:
+    """Project/session root for Claude project and local settings files."""
+    if cwd is None:
+        return Path.cwd()
+    return Path(cwd).expanduser()
+
+
+def _read_settings_json_file(path: Path) -> dict[str, Any]:
+    """Load a Claude settings.json file; empty dict if missing/invalid."""
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _extract_settings_env(data: dict[str, Any]) -> dict[str, str]:
+    """Normalize a settings object ``env`` block to str->str."""
+    env = data.get("env")
+    if not isinstance(env, dict):
+        return {}
+    result: dict[str, str] = {}
+    for key, value in env.items():
+        if value is None:
+            continue
+        result[str(key)] = str(value)
+    return result
+
+
 def read_claude_user_settings() -> dict[str, Any]:
     """
     Load user-level Claude Code settings.json if present.
 
     Returns an empty dict when the file is missing or invalid.
     """
-    settings_path = get_claude_config_dir() / "settings.json"
-    try:
-        with settings_path.open(encoding="utf-8") as f:
-            data = json.load(f)
-    except (OSError, json.JSONDecodeError, TypeError):
-        return {}
-    return data if isinstance(data, dict) else {}
+    return _read_settings_json_file(get_claude_config_dir() / "settings.json")
 
 
 def read_claude_user_settings_env() -> dict[str, str]:
@@ -70,16 +94,52 @@ def read_claude_user_settings_env() -> dict[str, str]:
     paths it effectively overrides subprocess process.env for keys like
     ANTHROPIC_BASE_URL, which causes Laminar's injected proxy URL to be ignored.
     """
-    data = read_claude_user_settings()
-    env = data.get("env")
-    if not isinstance(env, dict):
-        return {}
-    result: dict[str, str] = {}
-    for key, value in env.items():
-        if value is None:
-            continue
-        result[str(key)] = str(value)
-    return result
+    return _extract_settings_env(read_claude_user_settings())
+
+
+def read_claude_project_settings(cwd: str | Path | None = None) -> dict[str, Any]:
+    """
+    Load shared project settings from ``{cwd}/.claude/settings.json``.
+
+    ``cwd`` defaults to the process working directory (Claude Agent SDK uses
+    ``options.cwd`` when set).
+    """
+    return _read_settings_json_file(
+        _resolve_session_cwd(cwd) / ".claude" / "settings.json"
+    )
+
+
+def read_claude_local_settings(cwd: str | Path | None = None) -> dict[str, Any]:
+    """
+    Load local project settings from ``{cwd}/.claude/settings.local.json``.
+
+    Higher priority than shared project settings; typically gitignored.
+    """
+    return _read_settings_json_file(
+        _resolve_session_cwd(cwd) / ".claude" / "settings.local.json"
+    )
+
+
+def read_claude_settings_env(cwd: str | Path | None = None) -> dict[str, str]:
+    """
+    Merge ``env`` from Claude settings layers using Claude Code priority.
+
+    Priority (highest wins per key):
+    1. Local project: ``{cwd}/.claude/settings.local.json``
+    2. Shared project: ``{cwd}/.claude/settings.json``
+    3. User: ``~/.claude/settings.json`` (or ``CLAUDE_CONFIG_DIR``)
+
+    ``cwd`` is the session/project root (``ClaudeAgentOptions.cwd`` when set;
+    otherwise process cwd). Project/local base URLs must be visible here so the
+    auto-instrumentation proxy forwards to the team's gateway instead of the
+    default Anthropic endpoint when flag-level settings rewrite ``ANTHROPIC_BASE_URL``.
+    """
+    merged: dict[str, str] = {}
+    # Lowest priority first so higher layers overwrite.
+    merged.update(read_claude_user_settings_env())
+    merged.update(_extract_settings_env(read_claude_project_settings(cwd)))
+    merged.update(_extract_settings_env(read_claude_local_settings(cwd)))
+    return merged
 
 
 def snapshot_env(keys: list[str]) -> tuple[dict[str, str | None], set[str]]:
@@ -173,7 +233,10 @@ def _get_region_from_aws_config(profile: str) -> str | None:
 
 
 def resolve_target_url_from_env(
-    env_dict: dict[str, str], fallback: str = DEFAULT_ANTHROPIC_BASE_URL
+    env_dict: dict[str, str],
+    fallback: str = DEFAULT_ANTHROPIC_BASE_URL,
+    *,
+    cwd: str | Path | None = None,
 ) -> str | None:
     """
     Resolve target URL from environment dictionary with os.environ fallback.
@@ -198,20 +261,22 @@ def resolve_target_url_from_env(
     5. Fall back to default (https://api.anthropic.com)
 
     For each environment variable, checks env_dict first, then os.environ,
-    then the `env` block from Claude Code user settings.json (CLAUDE_CONFIG_DIR
-    or ~/.claude/settings.json). Settings are a common place for custom
+    then the merged ``env`` block from Claude Code settings layers (local
+    project > shared project > user). Settings are a common place for custom
     ANTHROPIC_BASE_URL when using non-default Anthropic-compatible endpoints.
 
     Args:
         env_dict: Dictionary of environment variables (e.g., from options.env)
         fallback: Fallback URL if no other source found (default: DEFAULT_ANTHROPIC_BASE_URL)
+        cwd: Session/project root for project and local settings
+            (``ClaudeAgentOptions.cwd``); defaults to process cwd.
 
     Returns:
         Resolved target URL, or None if provider is misconfigured
     """
-    settings_env = read_claude_user_settings_env()
+    settings_env = read_claude_settings_env(cwd)
 
-    # Helper: options.env > process env > Claude user settings env
+    # Helper: options.env > process env > Claude settings env (local>project>user)
     def get_env_value(key: str) -> str | None:
         return env_dict.get(key) or os.environ.get(key) or settings_env.get(key)
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -1,7 +1,9 @@
 """Wrapper functions for Claude Agent instrumentation."""
 
 import asyncio
+import json
 import os
+from pathlib import Path
 from typing import Any
 
 from lmnr import Laminar
@@ -21,6 +23,8 @@ from .utils import (
     restore_env,
     resolve_target_url_from_env,
     is_truthy_env,
+    read_claude_user_settings_env,
+    PROXY_BASE_URL_ENV_KEYS,
     FOUNDRY_BASE_URL_ENV,
     FOUNDRY_RESOURCE_ENV,
     FOUNDRY_USE_ENV,
@@ -201,13 +205,21 @@ def wrap_transport_connect(to_wrap: dict[str, Any]):
         is_custom = not isinstance(instance, SubprocessCLITransport)
 
         options_env_snapshot = {}
+        options_settings_snapshot = None
         if is_custom:
             original_env = setup_proxy_env(proxy_url)
             env_set_keys = {k for k, v in original_env.items() if v is not None}
         else:
             if hasattr(instance, "_options"):
                 options_env_snapshot = snapshot_options_env_for_proxy(instance._options)
+                options_settings_snapshot = getattr(
+                    instance._options, "settings", None
+                )
                 update_options_env_for_proxy(instance._options, proxy_url, target_url)
+                # Claude Code may prefer settings.json env over process.env for
+                # ANTHROPIC_BASE_URL. Inject flag-level settings so the CLI hits
+                # our proxy (highest user-controlled settings layer).
+                apply_settings_env_proxy_override(instance._options, proxy_url)
 
             original_env = {}
             env_set_keys = set()
@@ -232,6 +244,7 @@ def wrap_transport_connect(to_wrap: dict[str, Any]):
             "original_env": original_env,
             "env_set_keys": env_set_keys,
             "options_env_snapshot": options_env_snapshot,
+            "options_settings_snapshot": options_settings_snapshot,
         }
 
         instance.__lmnr_context = context
@@ -250,6 +263,10 @@ def wrap_transport_connect(to_wrap: dict[str, Any]):
             if options_env_snapshot and hasattr(instance, "_options"):
                 restore_options_env_from_snapshot(
                     instance._options, options_env_snapshot
+                )
+            if hasattr(instance, "_options"):
+                restore_options_settings(
+                    instance._options, options_settings_snapshot
                 )
 
             try:
@@ -290,6 +307,15 @@ async def _cleanup_transport_context(instance) -> None:
                 restore_env(
                     context.get("original_env", {}),
                     context.get("env_set_keys", set()),
+                )
+
+            if context.get("options_env_snapshot") and hasattr(instance, "_options"):
+                restore_options_env_from_snapshot(
+                    instance._options, context["options_env_snapshot"]
+                )
+            if hasattr(instance, "_options") and "options_settings_snapshot" in context:
+                restore_options_settings(
+                    instance._options, context.get("options_settings_snapshot")
                 )
 
             # Release port immediately to prevent leaks
@@ -377,6 +403,93 @@ def restore_options_env_from_snapshot(options, snapshot: dict[str, str | None]) 
             options.env[key] = value
 
 
+def _load_settings_object(settings_value: str | None) -> dict[str, Any]:
+    """Parse ClaudeAgentOptions.settings (JSON string or file path) into a dict."""
+    if not settings_value:
+        return {}
+
+    settings_str = settings_value.strip()
+    if settings_str.startswith("{") and settings_str.endswith("}"):
+        try:
+            parsed = json.loads(settings_str)
+            return parsed if isinstance(parsed, dict) else {}
+        except json.JSONDecodeError:
+            return {}
+
+    path = Path(settings_str).expanduser()
+    if not path.is_file():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as f:
+            parsed = json.load(f)
+        return parsed if isinstance(parsed, dict) else {}
+    except (OSError, json.JSONDecodeError, TypeError):
+        return {}
+
+
+def apply_settings_env_proxy_override(options, proxy_url: str) -> None:
+    """
+    Inject flag-level settings so Claude Code CLI routes API traffic via proxy.
+
+    Claude Code loads ``env`` from ``~/.claude/settings.json`` (and project
+    settings). That layer can take precedence over the subprocess process.env
+    values we set in ``options.env``, so rewriting ``options.env`` alone is not
+    enough when ``ANTHROPIC_BASE_URL`` is configured in settings.
+
+    Claude Agent SDK maps ``options.settings`` to ``--settings``, the highest
+    user-controlled settings layer. We merge proxy base-URL overrides into that
+    layer so the CLI uses the local proxy while the proxy forwards to the
+    original upstream (already configured via ``start_proxy(target_url=...)``).
+
+    Does not mutate the on-disk settings file.
+    """
+    if not hasattr(options, "settings"):
+        logger.debug(
+            "ClaudeAgentOptions has no settings field; cannot override settings.json env"
+        )
+        return
+
+    settings_obj = _load_settings_object(getattr(options, "settings", None))
+    env = settings_obj.get("env")
+    env_dict: dict[str, str] = dict(env) if isinstance(env, dict) else {}
+
+    # Mirror proxy base URLs from options.env into flag settings env.
+    options_env = getattr(options, "env", None) or {}
+    for key in PROXY_BASE_URL_ENV_KEYS:
+        if key in options_env:
+            env_dict[key] = options_env[key]
+    env_dict["ANTHROPIC_BASE_URL"] = proxy_url
+    env_dict.pop(FOUNDRY_RESOURCE_ENV, None)
+
+    settings_obj["env"] = env_dict
+    options.settings = json.dumps(settings_obj)
+
+    settings_env = read_claude_user_settings_env()
+    conflicting = [
+        key
+        for key in PROXY_BASE_URL_ENV_KEYS
+        if key in settings_env and settings_env[key] not in ("", proxy_url)
+    ]
+    if conflicting:
+        logger.info(
+            "Claude Code user settings define %s; injected flag settings so "
+            "auto-instrumentation proxy at %s intercepts API traffic. "
+            "Original settings file was not modified.",
+            ", ".join(conflicting),
+            proxy_url,
+        )
+
+
+def restore_options_settings(options, snapshot: str | None) -> None:
+    """Restore options.settings after proxy setup (or clear if it was unset)."""
+    if not hasattr(options, "settings"):
+        return
+    if snapshot is None:
+        options.settings = None
+    else:
+        options.settings = snapshot
+
+
 def update_options_env_for_proxy(options, proxy_url: str, target_url: str) -> None:
     """
     Update options.env to point subprocess to proxy.
@@ -396,14 +509,18 @@ def update_options_env_for_proxy(options, proxy_url: str, target_url: str) -> No
     from os.environ are handled separately in wrap_transport_connect by temporarily removing
     them before subprocess starts (since subprocess inherits os.environ).
 
+    Also see :func:`apply_settings_env_proxy_override` — settings.json ``env`` can
+    override process.env for ANTHROPIC_BASE_URL; flag settings must rewrite it too.
+
     Args:
         options: ClaudeAgentOptions instance with .env dict
         proxy_url: Proxy URL (e.g., "http://127.0.0.1:45667")
         target_url: Original target URL to forward to (e.g., "https://api.anthropic.com")
     """
+    settings_env = read_claude_user_settings_env()
 
     def get_env_value(key: str) -> str | None:
-        return options.env.get(key) or os.environ.get(key)
+        return options.env.get(key) or os.environ.get(key) or settings_env.get(key)
 
     foundry_enabled = is_truthy_env(get_env_value("CLAUDE_CODE_USE_FOUNDRY"))
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -23,7 +23,7 @@ from .utils import (
     restore_env,
     resolve_target_url_from_env,
     is_truthy_env,
-    read_claude_user_settings_env,
+    read_claude_settings_env,
     PROXY_BASE_URL_ENV_KEYS,
     FOUNDRY_BASE_URL_ENV,
     FOUNDRY_RESOURCE_ENV,
@@ -192,8 +192,10 @@ def wrap_transport_connect(to_wrap: dict[str, Any]):
             return await wrapped(*args, **kwargs)
 
         # Read options.env BEFORE modifying to avoid circular proxy config
-        env_dict = instance._options.env if hasattr(instance, "_options") else {}
-        target_url = resolve_target_url_from_env(env_dict)
+        options = getattr(instance, "_options", None)
+        env_dict = options.env if options is not None and hasattr(options, "env") else {}
+        session_cwd = getattr(options, "cwd", None) if options is not None else None
+        target_url = resolve_target_url_from_env(env_dict, cwd=session_cwd)
 
         if target_url is None:
             raise RuntimeError("Invalid provider configuration")
@@ -403,45 +405,88 @@ def restore_options_env_from_snapshot(options, snapshot: dict[str, str | None]) 
             options.env[key] = value
 
 
-def _load_settings_object(settings_value: str | None) -> dict[str, Any]:
-    """Parse ClaudeAgentOptions.settings (JSON string or file path) into a dict."""
+def _load_settings_object(
+    settings_value: str | None,
+    *,
+    cwd: str | Path | None = None,
+) -> tuple[dict[str, Any], bool]:
+    """
+    Parse ClaudeAgentOptions.settings (JSON string or file path) into a dict.
+
+    Relative file paths are resolved against ``cwd`` (``options.cwd``) first,
+    then against the process working directory if still missing.
+
+    Returns:
+        (settings_dict, unresolved_path). ``unresolved_path`` is True when
+        ``settings_value`` looked like a file path that could not be loaded.
+        Callers must not replace such paths with a proxy-only JSON blob.
+    """
     if not settings_value:
-        return {}
+        return {}, False
 
     settings_str = settings_value.strip()
     if settings_str.startswith("{") and settings_str.endswith("}"):
         try:
             parsed = json.loads(settings_str)
-            return parsed if isinstance(parsed, dict) else {}
+            return (parsed if isinstance(parsed, dict) else {}), False
         except json.JSONDecodeError:
-            return {}
+            # Treat unparseable brace-wrapped strings as non-path content.
+            return {}, False
 
     path = Path(settings_str).expanduser()
-    if not path.is_file():
-        return {}
-    try:
-        with path.open(encoding="utf-8") as f:
-            parsed = json.load(f)
-        return parsed if isinstance(parsed, dict) else {}
-    except (OSError, json.JSONDecodeError, TypeError):
-        return {}
+    candidates: list[Path] = []
+    if path.is_absolute():
+        candidates.append(path)
+    else:
+        if cwd is not None:
+            candidates.append(Path(cwd).expanduser() / path)
+        candidates.append(Path.cwd() / path)
+        # Also try as-is relative to process cwd (Path default).
+        candidates.append(path)
+
+    seen: set[Path] = set()
+    for candidate in candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            resolved = candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if not candidate.is_file():
+            continue
+        try:
+            with candidate.open(encoding="utf-8") as f:
+                parsed = json.load(f)
+            if isinstance(parsed, dict):
+                return parsed, False
+            return {}, False
+        except (OSError, json.JSONDecodeError, TypeError):
+            return {}, True
+
+    return {}, True
 
 
 def apply_settings_env_proxy_override(options, proxy_url: str) -> None:
     """
     Inject flag-level settings so Claude Code CLI routes API traffic via proxy.
 
-    Claude Code loads ``env`` from ``~/.claude/settings.json`` (and project
-    settings). That layer can take precedence over the subprocess process.env
-    values we set in ``options.env``, so rewriting ``options.env`` alone is not
-    enough when ``ANTHROPIC_BASE_URL`` is configured in settings.
+    Claude Code loads ``env`` from user, project, and local settings layers.
+    Those layers can take precedence over the subprocess process.env values we
+    set in ``options.env``, so rewriting ``options.env`` alone is not enough
+    when ``ANTHROPIC_BASE_URL`` is configured in settings.
 
     Claude Agent SDK maps ``options.settings`` to ``--settings``, the highest
     user-controlled settings layer. We merge proxy base-URL overrides into that
     layer so the CLI uses the local proxy while the proxy forwards to the
     original upstream (already configured via ``start_proxy(target_url=...)``).
 
-    Does not mutate the on-disk settings file.
+    Relative ``options.settings`` paths are resolved against ``options.cwd``.
+    If a path cannot be loaded, the original path string is left unchanged
+    (never replaced with an empty proxy-only JSON blob that would drop the
+    user's real settings for that CLI run).
+
+    Does not mutate on-disk settings files.
     """
     if not hasattr(options, "settings"):
         logger.debug(
@@ -449,7 +494,21 @@ def apply_settings_env_proxy_override(options, proxy_url: str) -> None:
         )
         return
 
-    settings_obj = _load_settings_object(getattr(options, "settings", None))
+    original_settings = getattr(options, "settings", None)
+    session_cwd = getattr(options, "cwd", None)
+    settings_obj, unresolved_path = _load_settings_object(
+        original_settings, cwd=session_cwd
+    )
+    if unresolved_path:
+        # Keep the original path so the CLI can still resolve it with its own
+        # cwd. Proxy routing continues via options.env.
+        logger.debug(
+            "options.settings path %r not found (cwd=%r); leaving path unchanged",
+            original_settings,
+            session_cwd,
+        )
+        return
+
     env = settings_obj.get("env")
     env_dict: dict[str, str] = dict(env) if isinstance(env, dict) else {}
 
@@ -464,7 +523,7 @@ def apply_settings_env_proxy_override(options, proxy_url: str) -> None:
     settings_obj["env"] = env_dict
     options.settings = json.dumps(settings_obj)
 
-    settings_env = read_claude_user_settings_env()
+    settings_env = read_claude_settings_env(session_cwd)
     conflicting = [
         key
         for key in PROXY_BASE_URL_ENV_KEYS
@@ -472,13 +531,12 @@ def apply_settings_env_proxy_override(options, proxy_url: str) -> None:
     ]
     if conflicting:
         logger.info(
-            "Claude Code user settings define %s; injected flag settings so "
+            "Claude Code settings define %s; injected flag settings so "
             "auto-instrumentation proxy at %s intercepts API traffic. "
             "Original settings file was not modified.",
             ", ".join(conflicting),
             proxy_url,
         )
-
 
 def restore_options_settings(options, snapshot: str | None) -> None:
     """Restore options.settings after proxy setup (or clear if it was unset)."""
@@ -517,7 +575,8 @@ def update_options_env_for_proxy(options, proxy_url: str, target_url: str) -> No
         proxy_url: Proxy URL (e.g., "http://127.0.0.1:45667")
         target_url: Original target URL to forward to (e.g., "https://api.anthropic.com")
     """
-    settings_env = read_claude_user_settings_env()
+    session_cwd = getattr(options, "cwd", None)
+    settings_env = read_claude_settings_env(session_cwd)
 
     def get_env_value(key: str) -> str | None:
         return options.env.get(key) or os.environ.get(key) or settings_env.get(key)

--- a/tests/test_instrumentations/test_claude_agent/test_claude_settings_env.py
+++ b/tests/test_instrumentations/test_claude_agent/test_claude_settings_env.py
@@ -1,0 +1,266 @@
+"""Tests for Claude Code settings.json env handling with the auto-instrumentation proxy."""
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (
+    proxy as claude_proxy,
+    utils as claude_utils,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent.utils import (
+    read_claude_user_settings_env,
+    resolve_target_url_from_env,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent.wrappers import (
+    apply_settings_env_proxy_override,
+    restore_options_settings,
+    update_options_env_for_proxy,
+    wrap_transport_connect,
+)
+from lmnr_claude_code_proxy import ProxyServer
+
+
+class MockOptions:
+    def __init__(self, env=None, settings=None):
+        self.env = env or {}
+        self.settings = settings
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    monkeypatch.delenv("ANTHROPIC_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_ORIGINAL_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_FOUNDRY_BASE_URL", raising=False)
+    monkeypatch.delenv("ANTHROPIC_FOUNDRY_RESOURCE", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_USE_FOUNDRY", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_USE_BEDROCK", raising=False)
+    monkeypatch.delenv("CLAUDE_CODE_USE_VERTEX", raising=False)
+    monkeypatch.delenv("HTTP_PROXY", raising=False)
+    monkeypatch.delenv("HTTPS_PROXY", raising=False)
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+
+
+def test_read_claude_user_settings_env(tmp_path, monkeypatch, clean_env):
+    """settings.json env block is loaded from CLAUDE_CONFIG_DIR."""
+    config_dir = tmp_path / "claude"
+    config_dir.mkdir()
+    settings = {
+        "env": {
+            "ANTHROPIC_BASE_URL": "http://127.0.0.1:30233",
+            "ANTHROPIC_API_KEY": "test-key",
+        },
+        "model": "claude-sonnet-4-5",
+    }
+    (config_dir / "settings.json").write_text(json.dumps(settings), encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+    env = read_claude_user_settings_env()
+    assert env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:30233"
+    assert env["ANTHROPIC_API_KEY"] == "test-key"
+
+
+def test_read_claude_user_settings_env_missing_file(tmp_path, monkeypatch, clean_env):
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(tmp_path / "missing"))
+    assert read_claude_user_settings_env() == {}
+
+
+def test_resolve_target_url_from_settings_when_not_in_process_env(
+    tmp_path, monkeypatch, clean_env
+):
+    """Upstream from settings.json is used when process env has no base URL."""
+    config_dir = tmp_path / "claude"
+    config_dir.mkdir()
+    (config_dir / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:30233"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+    assert resolve_target_url_from_env({}) == "http://127.0.0.1:30233"
+
+
+def test_options_env_beats_settings_for_target_url(tmp_path, monkeypatch, clean_env):
+    config_dir = tmp_path / "claude"
+    config_dir.mkdir()
+    (config_dir / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "http://settings.example"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+    assert (
+        resolve_target_url_from_env({"ANTHROPIC_BASE_URL": "http://options.example"})
+        == "http://options.example"
+    )
+
+
+def test_apply_settings_env_proxy_override_injects_flag_settings(clean_env):
+    options = MockOptions()
+    update_options_env_for_proxy(
+        options, "http://127.0.0.1:45667", "http://127.0.0.1:30233"
+    )
+    apply_settings_env_proxy_override(options, "http://127.0.0.1:45667")
+
+    assert options.settings is not None
+    parsed = json.loads(options.settings)
+    assert parsed["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"
+
+
+def test_apply_settings_env_proxy_override_merges_existing_json_settings(clean_env):
+    options = MockOptions(
+        settings=json.dumps(
+            {
+                "permissions": {"defaultMode": "acceptEdits"},
+                "env": {"ANTHROPIC_MODEL": "claude-opus-4-5"},
+            }
+        )
+    )
+    update_options_env_for_proxy(
+        options, "http://127.0.0.1:45667", "https://api.anthropic.com"
+    )
+    apply_settings_env_proxy_override(options, "http://127.0.0.1:45667")
+
+    parsed = json.loads(options.settings)
+    assert parsed["permissions"]["defaultMode"] == "acceptEdits"
+    assert parsed["env"]["ANTHROPIC_MODEL"] == "claude-opus-4-5"
+    assert parsed["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"
+
+
+def test_apply_settings_env_proxy_override_merges_settings_file(
+    tmp_path, monkeypatch, clean_env
+):
+    settings_path = tmp_path / "extra-settings.json"
+    settings_path.write_text(
+        json.dumps({"env": {"FOO": "bar"}, "model": "claude-sonnet-4-5"}),
+        encoding="utf-8",
+    )
+    options = MockOptions(settings=str(settings_path))
+    update_options_env_for_proxy(
+        options, "http://127.0.0.1:45667", "https://api.anthropic.com"
+    )
+    apply_settings_env_proxy_override(options, "http://127.0.0.1:45667")
+
+    parsed = json.loads(options.settings)
+    assert parsed["model"] == "claude-sonnet-4-5"
+    assert parsed["env"]["FOO"] == "bar"
+    assert parsed["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"
+
+
+def test_restore_options_settings(clean_env):
+    options = MockOptions(settings=None)
+    apply_settings_env_proxy_override(options, "http://127.0.0.1:45667")
+    assert options.settings is not None
+    restore_options_settings(options, None)
+    assert options.settings is None
+
+    options.settings = '{"env":{}}'
+    restore_options_settings(options, "/tmp/original.json")
+    assert options.settings == "/tmp/original.json"
+
+
+def test_wrap_transport_connect_overrides_settings_base_url(
+    tmp_path, monkeypatch, clean_env
+):
+    """
+    Repro for lmnr-ai/lmnr#2167: ANTHROPIC_BASE_URL in settings.json must not
+    prevent the CLI from using the local auto-instrumentation proxy.
+    """
+    from claude_agent_sdk._internal.transport.subprocess_cli import (
+        SubprocessCLITransport,
+    )
+
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (
+        wrappers as claude_wrappers,
+        span_utils,
+    )
+
+    config_dir = tmp_path / "claude"
+    config_dir.mkdir()
+    (config_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "env": {
+                    "ANTHROPIC_BASE_URL": "http://127.0.0.1:30233",
+                    "ANTHROPIC_API_KEY": "test-key",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+    # Process env may also have the custom URL (as in the issue repro).
+    monkeypatch.setenv("ANTHROPIC_BASE_URL", "http://127.0.0.1:30233")
+
+    transport = MagicMock(spec=SubprocessCLITransport)
+    transport._options = MockOptions(env={})
+
+    captured = {}
+
+    async def mock_connect(*args, **kwargs):
+        captured["env"] = dict(transport._options.env)
+        captured["settings"] = transport._options.settings
+        return None
+
+    original_connect = AsyncMock(side_effect=mock_connect)
+    wrapper = wrap_transport_connect({"original": original_connect})
+
+    # Patch names bound in wrappers (from .proxy import ...).
+    with (
+        patch.object(claude_wrappers, "create_proxy_for_transport") as mock_create,
+        patch.object(claude_wrappers, "start_proxy") as mock_start,
+        patch.object(span_utils, "publish_span_context_for_transport"),
+    ):
+        mock_proxy = MagicMock(spec=ProxyServer)
+        mock_create.return_value = mock_proxy
+        mock_start.return_value = "http://127.0.0.1:45667"
+
+        asyncio.run(wrapper(original_connect, transport, (), {}))
+
+        # Proxy must forward to the settings/custom upstream, not default Anthropic.
+        mock_start.assert_called_once_with(
+            mock_proxy, target_url="http://127.0.0.1:30233"
+        )
+
+    assert captured["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"
+    assert captured["env"]["ANTHROPIC_ORIGINAL_BASE_URL"] == "http://127.0.0.1:30233"
+
+    settings = json.loads(captured["settings"])
+    assert settings["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"
+
+    # Disk settings remain unchanged (no mutation of user config).
+    on_disk = json.loads((config_dir / "settings.json").read_text(encoding="utf-8"))
+    assert on_disk["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:30233"
+
+
+def test_foundry_from_settings_enables_proxy_base_url(
+    tmp_path, monkeypatch, clean_env
+):
+    config_dir = tmp_path / "claude"
+    config_dir.mkdir()
+    (config_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "env": {
+                    "CLAUDE_CODE_USE_FOUNDRY": "1",
+                    "ANTHROPIC_FOUNDRY_BASE_URL": "https://foundry.example.com",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(config_dir))
+
+    assert resolve_target_url_from_env({}) == "https://foundry.example.com"
+
+    options = MockOptions()
+    update_options_env_for_proxy(
+        options, "http://127.0.0.1:45667", "https://foundry.example.com"
+    )
+    apply_settings_env_proxy_override(options, "http://127.0.0.1:45667")
+
+    assert options.env[claude_utils.FOUNDRY_BASE_URL_ENV] == "http://127.0.0.1:45667"
+    parsed = json.loads(options.settings)
+    assert parsed["env"][claude_utils.FOUNDRY_BASE_URL_ENV] == "http://127.0.0.1:45667"

--- a/tests/test_instrumentations/test_claude_agent/test_claude_settings_env.py
+++ b/tests/test_instrumentations/test_claude_agent/test_claude_settings_env.py
@@ -11,6 +11,7 @@ from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (
     utils as claude_utils,
 )
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent.utils import (
+    read_claude_settings_env,
     read_claude_user_settings_env,
     resolve_target_url_from_env,
 )
@@ -24,9 +25,10 @@ from lmnr_claude_code_proxy import ProxyServer
 
 
 class MockOptions:
-    def __init__(self, env=None, settings=None):
+    def __init__(self, env=None, settings=None, cwd=None):
         self.env = env or {}
         self.settings = settings
+        self.cwd = cwd
 
 
 @pytest.fixture
@@ -264,3 +266,172 @@ def test_foundry_from_settings_enables_proxy_base_url(
     assert options.env[claude_utils.FOUNDRY_BASE_URL_ENV] == "http://127.0.0.1:45667"
     parsed = json.loads(options.settings)
     assert parsed["env"][claude_utils.FOUNDRY_BASE_URL_ENV] == "http://127.0.0.1:45667"
+
+
+def test_resolve_target_url_from_project_settings(tmp_path, monkeypatch, clean_env):
+    """Project .claude/settings.json base URL is used before default Anthropic."""
+    # Isolate user settings so only project layer applies.
+    user_dir = tmp_path / "user-claude"
+    user_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+
+    project = tmp_path / "project"
+    claude_dir = project / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://team-gateway.example/v1"}}),
+        encoding="utf-8",
+    )
+
+    assert (
+        resolve_target_url_from_env({}, cwd=project)
+        == "https://team-gateway.example/v1"
+    )
+
+
+def test_local_settings_override_project_and_user(tmp_path, monkeypatch, clean_env):
+    """Claude priority: local > project > user for settings env keys."""
+    user_dir = tmp_path / "user-claude"
+    user_dir.mkdir()
+    (user_dir / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://user.example"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+
+    project = tmp_path / "project"
+    claude_dir = project / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://project.example"}}),
+        encoding="utf-8",
+    )
+    (claude_dir / "settings.local.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://local.example"}}),
+        encoding="utf-8",
+    )
+
+    env = read_claude_settings_env(project)
+    assert env["ANTHROPIC_BASE_URL"] == "https://local.example"
+    assert resolve_target_url_from_env({}, cwd=project) == "https://local.example"
+
+    # Without local file, project wins over user.
+    (claude_dir / "settings.local.json").unlink()
+    assert resolve_target_url_from_env({}, cwd=project) == "https://project.example"
+
+
+def test_project_settings_used_as_proxy_upstream(tmp_path, monkeypatch, clean_env):
+    """
+    Flag-level proxy injection must still forward to project settings base URL.
+
+    Regression for Bugbot: resolve only from user settings while always injecting
+    flag ANTHROPIC_BASE_URL caused team gateways in project settings to misroute
+    to default Anthropic.
+    """
+    from claude_agent_sdk._internal.transport.subprocess_cli import (
+        SubprocessCLITransport,
+    )
+
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (
+        wrappers as claude_wrappers,
+        span_utils,
+    )
+
+    user_dir = tmp_path / "user-claude"
+    user_dir.mkdir()
+    monkeypatch.setenv("CLAUDE_CONFIG_DIR", str(user_dir))
+
+    project = tmp_path / "project"
+    claude_dir = project / ".claude"
+    claude_dir.mkdir(parents=True)
+    (claude_dir / "settings.json").write_text(
+        json.dumps({"env": {"ANTHROPIC_BASE_URL": "https://team-gateway.example/v1"}}),
+        encoding="utf-8",
+    )
+
+    transport = MagicMock(spec=SubprocessCLITransport)
+    transport._options = MockOptions(env={}, cwd=str(project))
+
+    captured = {}
+
+    async def mock_connect(*args, **kwargs):
+        captured["env"] = dict(transport._options.env)
+        captured["settings"] = transport._options.settings
+        return None
+
+    original_connect = AsyncMock(side_effect=mock_connect)
+    wrapper = wrap_transport_connect({"original": original_connect})
+
+    with (
+        patch.object(claude_wrappers, "create_proxy_for_transport") as mock_create,
+        patch.object(claude_wrappers, "start_proxy") as mock_start,
+        patch.object(span_utils, "publish_span_context_for_transport"),
+    ):
+        mock_proxy = MagicMock(spec=ProxyServer)
+        mock_create.return_value = mock_proxy
+        mock_start.return_value = "http://127.0.0.1:45667"
+
+        asyncio.run(wrapper(original_connect, transport, (), {}))
+
+        mock_start.assert_called_once_with(
+            mock_proxy, target_url="https://team-gateway.example/v1"
+        )
+
+    assert captured["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"
+    assert (
+        captured["env"]["ANTHROPIC_ORIGINAL_BASE_URL"]
+        == "https://team-gateway.example/v1"
+    )
+
+
+def test_relative_settings_path_resolves_against_options_cwd(
+    tmp_path, monkeypatch, clean_env
+):
+    """Relative options.settings path is resolved vs options.cwd, not process cwd."""
+    project = tmp_path / "project"
+    project.mkdir()
+    settings_path = project / "agent-settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "permissions": {"defaultMode": "acceptEdits"},
+                "env": {"ANTHROPIC_MODEL": "claude-opus-4-5", "FOO": "from-file"},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    # Process cwd is elsewhere; path is relative to options.cwd.
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+
+    options = MockOptions(settings="agent-settings.json", cwd=str(project))
+    update_options_env_for_proxy(
+        options, "http://127.0.0.1:45667", "https://api.anthropic.com"
+    )
+    apply_settings_env_proxy_override(options, "http://127.0.0.1:45667")
+
+    parsed = json.loads(options.settings)
+    assert parsed["permissions"]["defaultMode"] == "acceptEdits"
+    assert parsed["env"]["FOO"] == "from-file"
+    assert parsed["env"]["ANTHROPIC_MODEL"] == "claude-opus-4-5"
+    assert parsed["env"]["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"
+
+
+def test_missing_settings_path_preserves_original_path(tmp_path, monkeypatch, clean_env):
+    """Missing settings file path must not be clobbered with proxy-only JSON."""
+    other = tmp_path / "other"
+    other.mkdir()
+    monkeypatch.chdir(other)
+
+    original_path = "missing-settings.json"
+    options = MockOptions(settings=original_path, cwd=str(tmp_path / "no-such-project"))
+    update_options_env_for_proxy(
+        options, "http://127.0.0.1:45667", "https://api.anthropic.com"
+    )
+    apply_settings_env_proxy_override(options, "http://127.0.0.1:45667")
+
+    assert options.settings == original_path
+    # options.env still points at the proxy.
+    assert options.env["ANTHROPIC_BASE_URL"] == "http://127.0.0.1:45667"


### PR DESCRIPTION
## Summary

Fixes silent Claude Agent SDK auto-instrumentation failure when `ANTHROPIC_BASE_URL` lives in `~/.claude/settings.json` `env` (reported as [lmnr-ai/lmnr#2167](https://github.com/lmnr-ai/lmnr/issues/2167)).

**Problem:** Laminar rewrites subprocess `options.env.ANTHROPIC_BASE_URL` to the local Rust proxy (`127.0.0.1:45667`), but Claude Code can still take the base URL from user settings. The CLI then bypasses the proxy → traces only have `DEFAULT` spans (no `anthropic.messages` / LLM spans), with no warning.

**Fix:**
1. Resolve proxy **upstream** from Claude user settings `env` when not present in `options.env` / process env (so custom endpoints in settings still forward correctly).
2. Inject **flag-level** `options.settings` (`--settings`) with `env.ANTHROPIC_BASE_URL` (and provider base URLs) pointing at the local proxy. Flag settings are the highest user-controlled settings layer, so they override `~/.claude/settings.json` without mutating the on-disk file.
3. Snapshot/restore `options.settings` on transport cleanup/error.

## Test plan

- [x] `pytest tests/test_instrumentations/test_claude_agent/test_claude_settings_env.py tests/test_instrumentations/test_claude_agent/test_update_options_env.py tests/test_instrumentations/test_claude_agent/test_proxy_env.py` → **44 passed**
- [x] Unit coverage for settings env read, target URL resolution, flag settings merge (JSON + file path), wrap_transport_connect repro for #2167, on-disk settings left unchanged

## Related

- Issue: https://github.com/lmnr-ai/lmnr/issues/2167
- Does not modify `~/.claude/settings.json` on disk (isolated via SDK `options.settings`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how API traffic is routed for all subprocess Claude Agent sessions when settings define base URLs; mistakes could misroute requests or break tracing, but behavior is scoped to instrumentation and is heavily tested with snapshot/restore.
> 
> **Overview**
> Fixes Claude Agent auto-instrumentation silently missing LLM spans when **`ANTHROPIC_BASE_URL`** (or provider base URLs) live in Claude Code **`settings.json`** `env` instead of only in `options.env` / process env.
> 
> **Upstream resolution** now merges Claude settings layers (local project → shared project → user, keyed by **`options.cwd`**) into `resolve_target_url_from_env` and `update_options_env_for_proxy`, so the local proxy still forwards to team gateways and custom endpoints defined on disk.
> 
> **CLI routing** adds **`apply_settings_env_proxy_override`**, which merges proxy base URLs into **`options.settings`** (`--settings`, highest user-controlled layer) without editing on-disk files; snapshots restore **`options.settings`** on transport error/close. Relative settings file paths resolve against **`options.cwd`**; missing paths are left unchanged.
> 
> New unit tests cover settings layering, Foundry-from-settings, and the #2167 repro.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41c9055b06a6dd197ece985d5a7c3d78f61e0c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->