### PR TITLE
attempt at fixing race in test

### DIFF
--- a/tests/test_litellm.py
+++ b/tests/test_litellm.py
@@ -223,16 +223,22 @@ def test_litellm_completion_activates_span_for_otel_callbacks(
     `@observe` root) happens to be current, which would mis-mark that span as an
     LLM call and suppress litellm's own request span.
     """
+    import threading
+
     from litellm.integrations.custom_logger import CustomLogger
     from opentelemetry import trace
 
     captured: dict[str, object] = {}
+    called = threading.Event()
 
     class _SpanCapturingCallback(CustomLogger):
         def log_success_event(self, kwargs, response_obj, start_time, end_time):
+            # litellm dispatches success callbacks on a background thread, so
+            # the main thread must wait for this to run before asserting.
             captured["span_id"] = (
                 trace.get_current_span().get_span_context().span_id
             )
+            called.set()
 
     litellm.callbacks = [_SpanCapturingCallback()]
     try:
@@ -241,6 +247,7 @@ def test_litellm_completion_activates_span_for_otel_callbacks(
             messages=[{"role": "user", "content": "say hi"}],
             mock_response="Hello there!",
         )
+        assert called.wait(timeout=5), "litellm callback did not fire in time"
     finally:
         litellm.callbacks = []
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Test-only synchronization change; no production or instrumentation behavior modified.
> 
> **Overview**
> Fixes a flaky race in **`test_litellm_completion_activates_span_for_otel_callbacks`**, which checks that OTel-based LiteLLM success callbacks see the wrapper’s `litellm.completion` span as the active span (LAM-1784).
> 
> LiteLLM runs **`log_success_event`** on a **background thread**, so the test could assert on `captured["span_id"]` before the callback ran. The change adds a **`threading.Event`**, sets it from the callback after recording the span id, and **`called.wait(timeout=5)`** after `litellm.completion` so assertions run only after the callback has fired.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53210129142174d8d9cc9a4422f60ce5df03864. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->