### PR TITLE
Fix LiteLLM streaming usage and reasoning telemetry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@
 
 [project]
 name = "lmnr"
-version = "0.7.59"
+version = "0.7.60"
 description = "Python SDK for Laminar"
 authors = [
   { name = "lmnr.ai", email = "founders@lmnr.ai" }

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/litellm/wrappers/completions/streaming.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/litellm/wrappers/completions/streaming.py
@@ -1,14 +1,19 @@
 from collections import defaultdict
-from typing import Any, AsyncGenerator, Generator
+from collections.abc import AsyncGenerator, Generator
+from typing import Any
 
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
 from opentelemetry.trace import Span, Status, StatusCode
 
-from lmnr.sdk.utils import json_dumps
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     dont_throw,
     set_span_attribute,
     to_dict,
 )
+from lmnr.sdk.utils import json_dumps
 
 
 @dont_throw
@@ -18,6 +23,8 @@ def _accumulate_chunk(accumulated: dict, chunk: dict):
         accumulated["id"] = chunk_dict.get("id")
     if accumulated["model"] is None and chunk_dict.get("model"):
         accumulated["model"] = chunk_dict.get("model")
+    if chunk_dict.get("usage") is not None:
+        accumulated["usage"] = to_dict(chunk_dict["usage"])
     for i, choice in enumerate(chunk_dict.get("choices", [])):
         idx = choice.get("index", i)
         accumulated["choices"][idx]["content"] += choice.get("content", "")
@@ -84,6 +91,33 @@ def _set_accumulated_attributes(
             span, "gen_ai.output.messages", json_dumps(formatted_choices)
         )
 
+        if usage := accumulated.get("usage"):
+            input_tokens = usage.get("prompt_tokens", usage.get("input_tokens", 0))
+            output_tokens = usage.get(
+                "completion_tokens", usage.get("output_tokens", 0)
+            )
+            total_tokens = usage.get("total_tokens", input_tokens + output_tokens)
+            set_span_attribute(span, GEN_AI_USAGE_INPUT_TOKENS, input_tokens)
+            set_span_attribute(span, GEN_AI_USAGE_OUTPUT_TOKENS, output_tokens)
+            set_span_attribute(span, "llm.usage.total_tokens", total_tokens)
+
+            input_details = to_dict(usage.get("prompt_tokens_details", {}))
+            cache_read_tokens = input_details.get(
+                "cached_tokens", usage.get("cache_read_input_tokens", 0)
+            )
+            cache_creation_tokens = input_details.get(
+                "cache_creation_tokens",
+                usage.get("cache_creation_input_tokens", 0),
+            )
+            set_span_attribute(
+                span, "gen_ai.usage.cache_read_input_tokens", cache_read_tokens
+            )
+            set_span_attribute(
+                span,
+                "gen_ai.usage.cache_creation_input_tokens",
+                cache_creation_tokens,
+            )
+
         # Record raw response in rollout mode
         if record_raw_response:
             # Reconstruct full response from accumulated data
@@ -92,6 +126,7 @@ def _set_accumulated_attributes(
                 "model": accumulated["model"],
                 "object": "chat.completion",
                 "choices": [],
+                "usage": accumulated.get("usage"),
             }
             for choice in accumulated["choices"].values():
                 raw_response["choices"].append(
@@ -128,14 +163,15 @@ def process_completion_streaming_response(
     accumulated = {
         "id": None,
         "model": None,
+        "usage": None,
         "choices": defaultdict(
             lambda: {
                 "index": None,
                 "content": "",
                 "role": "assistant",
-                    "finish_reason": None,
-                    "tool_calls": {},
-                }
+                "finish_reason": None,
+                "tool_calls": {},
+            }
         ),
     }
     try:
@@ -158,6 +194,7 @@ async def process_completion_async_streaming_response(
     accumulated = {
         "id": None,
         "model": None,
+        "usage": None,
         "choices": defaultdict(
             lambda: {
                 "index": None,

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/litellm/wrappers/completions/streaming.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/litellm/wrappers/completions/streaming.py
@@ -36,6 +36,16 @@ def _accumulate_chunk(accumulated: dict, chunk: dict):
             accumulated["choices"][idx]["role"] = delta.get("role")
         if delta.get("content"):
             accumulated["choices"][idx]["content"] += delta.get("content")
+        reasoning = next(
+            (
+                delta.get(key)
+                for key in ("reasoning_content", "reasoning", "thinking")
+                if delta.get(key)
+            ),
+            None,
+        )
+        if reasoning:
+            accumulated["choices"][idx]["reasoning_content"] += reasoning
         if delta.get("tool_calls"):
             tool_calls_acc = accumulated["choices"][idx]["tool_calls"]
             for tc_chunk in delta.get("tool_calls"):
@@ -76,6 +86,7 @@ def _set_accumulated_attributes(
                         choice["content"] if len(choice["content"]) > 0 else None
                     ),
                     "role": choice["role"],
+                    "reasoning_content": choice["reasoning_content"] or None,
                     "finish_reason": (
                         choice["finish_reason"] if choice["finish_reason"] else None
                     ),
@@ -102,21 +113,30 @@ def _set_accumulated_attributes(
             set_span_attribute(span, "llm.usage.total_tokens", total_tokens)
 
             input_details = to_dict(usage.get("prompt_tokens_details", {}))
-            cache_read_tokens = input_details.get(
-                "cached_tokens", usage.get("cache_read_input_tokens", 0)
-            )
-            cache_creation_tokens = input_details.get(
-                "cache_creation_tokens",
-                usage.get("cache_creation_input_tokens", 0),
-            )
-            set_span_attribute(
-                span, "gen_ai.usage.cache_read_input_tokens", cache_read_tokens
-            )
-            set_span_attribute(
-                span,
-                "gen_ai.usage.cache_creation_input_tokens",
-                cache_creation_tokens,
-            )
+            if "cached_tokens" in input_details:
+                set_span_attribute(
+                    span,
+                    "gen_ai.usage.cache_read_input_tokens",
+                    input_details["cached_tokens"],
+                )
+            elif "cache_read_input_tokens" in usage:
+                set_span_attribute(
+                    span,
+                    "gen_ai.usage.cache_read_input_tokens",
+                    usage["cache_read_input_tokens"],
+                )
+            if "cache_creation_tokens" in input_details:
+                set_span_attribute(
+                    span,
+                    "gen_ai.usage.cache_creation_input_tokens",
+                    input_details["cache_creation_tokens"],
+                )
+            elif "cache_creation_input_tokens" in usage:
+                set_span_attribute(
+                    span,
+                    "gen_ai.usage.cache_creation_input_tokens",
+                    usage["cache_creation_input_tokens"],
+                )
 
         # Record raw response in rollout mode
         if record_raw_response:
@@ -139,6 +159,7 @@ def _set_accumulated_attributes(
                                 if len(choice["content"]) > 0
                                 else None
                             ),
+                            "reasoning_content": (choice["reasoning_content"] or None),
                             "tool_calls": (
                                 list(choice["tool_calls"].values())
                                 if choice["tool_calls"]
@@ -169,6 +190,7 @@ def process_completion_streaming_response(
                 "index": None,
                 "content": "",
                 "role": "assistant",
+                "reasoning_content": "",
                 "finish_reason": None,
                 "tool_calls": {},
             }
@@ -200,6 +222,7 @@ async def process_completion_async_streaming_response(
                 "index": None,
                 "content": "",
                 "role": "assistant",
+                "reasoning_content": "",
                 "finish_reason": None,
                 "tool_calls": {},
             }

--- a/src/lmnr/version.py
+++ b/src/lmnr/version.py
@@ -3,7 +3,7 @@ import sys
 import httpx
 from packaging import version
 
-__version__ = "0.7.59"
+__version__ = "0.7.60"
 PYTHON_VERSION = f"{sys.version_info.major}.{sys.version_info.minor}"
 
 

--- a/tests/test_litellm.py
+++ b/tests/test_litellm.py
@@ -369,6 +369,75 @@ def test_litellm_completion_streaming_records_usage_only_chunk(
     assert attributes["gen_ai.usage.cache_read_input_tokens"] == 4000
 
 
+def test_litellm_completion_streaming_preserves_reasoning_deltas(
+    span_exporter: InMemorySpanExporter,
+):
+    """Reasoning deltas must be accumulated into the output message."""
+    span = Laminar.start_span("litellm.completion", span_type="LLM")
+    chunks = [
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "role": "assistant",
+                        "reasoning_content": "I should inspect ",
+                    },
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {
+                        "reasoning_content": "the repository.",
+                        "content": "I'll inspect it.",
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+    ]
+
+    assert list(process_completion_streaming_response(span, iter(chunks))) == chunks
+
+    output = json.loads(
+        span_exporter.get_finished_spans()[0].attributes["gen_ai.output.messages"]
+    )
+    assert output[0]["reasoning_content"] == "I should inspect the repository."
+    assert output[0]["content"] == "I'll inspect it."
+
+
+def test_litellm_completion_streaming_omits_unknown_cache_usage(
+    span_exporter: InMemorySpanExporter,
+):
+    """Missing cache details must not be reported as confirmed zero usage."""
+    span = Laminar.start_span("litellm.completion", span_type="LLM")
+    chunks = [
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 5000,
+                "completion_tokens": 100,
+                "total_tokens": 5100,
+            },
+        }
+    ]
+
+    list(process_completion_streaming_response(span, iter(chunks)))
+
+    attributes = span_exporter.get_finished_spans()[0].attributes
+    assert "gen_ai.usage.cache_read_input_tokens" not in attributes
+    assert "gen_ai.usage.cache_creation_input_tokens" not in attributes
+
+
 @pytest.mark.asyncio
 async def test_litellm_completion_async_streaming_records_usage_only_chunk(
     span_exporter: InMemorySpanExporter,
@@ -411,6 +480,52 @@ async def test_litellm_completion_async_streaming_records_usage_only_chunk(
     assert attributes["gen_ai.usage.output_tokens"] == 100
     assert attributes["llm.usage.total_tokens"] == 5100
     assert attributes["gen_ai.usage.cache_read_input_tokens"] == 4000
+
+
+@pytest.mark.asyncio
+async def test_litellm_completion_async_streaming_preserves_reasoning_deltas(
+    span_exporter: InMemorySpanExporter,
+):
+    """The async stream wrapper must accumulate reasoning deltas."""
+    span = Laminar.start_span("litellm.completion", span_type="LLM")
+    chunks = [
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"reasoning_content": "Think ", "content": ""},
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"reasoning_content": "carefully.", "content": "Done"},
+                    "finish_reason": "stop",
+                }
+            ],
+        },
+    ]
+
+    async def stream():
+        for chunk in chunks:
+            yield chunk
+
+    received = [
+        chunk
+        async for chunk in process_completion_async_streaming_response(span, stream())
+    ]
+    assert received == chunks
+    output = json.loads(
+        span_exporter.get_finished_spans()[0].attributes["gen_ai.output.messages"]
+    )
+    assert output[0]["reasoning_content"] == "Think carefully."
+    assert output[0]["content"] == "Done"
 
 
 @pytest.mark.vcr(record_mode="once")

--- a/tests/test_litellm.py
+++ b/tests/test_litellm.py
@@ -311,6 +311,7 @@ def test_litellm_completion_streaming(span_exporter: InMemorySpanExporter):
             "role": "assistant",
             "content": "The capital of France is **Paris**.",
             "tool_calls": None,
+            "reasoning_content": None,
             "finish_reason": "stop",
             "index": 0,
         }
@@ -559,6 +560,7 @@ def test_litellm_completion_streaming_openai(span_exporter: InMemorySpanExporter
             "content": "The capital of France is Paris.",
             "tool_calls": None,
             "finish_reason": "stop",
+            "reasoning_content": None,
             "index": 0,
         }
     ]
@@ -963,6 +965,7 @@ def test_litellm_completion_streaming_with_tool_call(
             "role": "assistant",
             "content": None,
             "finish_reason": "tool_calls",
+            "reasoning_content": None,
             "index": 0,
             "tool_calls": [
                 {
@@ -1032,6 +1035,7 @@ def test_litellm_completion_streaming_with_tool_call_openai(
             "content": None,
             "finish_reason": "tool_calls",
             "index": 0,
+            "reasoning_content": None,
             "tool_calls": [
                 {
                     "id": tool_call_id,
@@ -1131,6 +1135,7 @@ async def test_litellm_completion_streaming_async(span_exporter: InMemorySpanExp
             "role": "assistant",
             "content": "The capital of France is **Paris**.",
             "tool_calls": None,
+            "reasoning_content": None,
             "finish_reason": "stop",
             "index": 0,
         }
@@ -1182,6 +1187,7 @@ async def test_litellm_completion_streaming_async_openai(
             "role": "assistant",
             "content": "The capital of France is Paris.",
             "tool_calls": None,
+            "reasoning_content": None,
             "finish_reason": "stop",
             "index": 0,
         }
@@ -1487,6 +1493,7 @@ async def test_litellm_completion_streaming_with_tool_call_async(
             "content": None,
             "finish_reason": "tool_calls",
             "index": 0,
+            "reasoning_content": None,
             "tool_calls": [
                 {
                     "id": tool_call_id,

--- a/tests/test_litellm.py
+++ b/tests/test_litellm.py
@@ -11,7 +11,11 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from pydantic import BaseModel
 
-from lmnr import LaminarLiteLLMCallback
+from lmnr import Laminar, LaminarLiteLLMCallback
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.litellm.wrappers.completions.streaming import (
+    process_completion_async_streaming_response,
+    process_completion_streaming_response,
+)
 from lmnr.version import __version__
 
 
@@ -235,9 +239,7 @@ def test_litellm_completion_activates_span_for_otel_callbacks(
         def log_success_event(self, kwargs, response_obj, start_time, end_time):
             # litellm dispatches success callbacks on a background thread, so
             # the main thread must wait for this to run before asserting.
-            captured["span_id"] = (
-                trace.get_current_span().get_span_context().span_id
-            )
+            captured["span_id"] = trace.get_current_span().get_span_context().span_id
             called.set()
 
     litellm.callbacks = [_SpanCapturingCallback()]
@@ -324,6 +326,91 @@ def test_litellm_completion_streaming(span_exporter: InMemorySpanExporter):
         str(uuid.UUID(int=spans[0].get_span_context().span_id)),
     )
     check_span_has_basic_attributes(spans[0])
+
+
+def test_litellm_completion_streaming_records_usage_only_chunk(
+    span_exporter: InMemorySpanExporter,
+):
+    """Usage from the final empty-choice stream chunk must reach the span."""
+    span = Laminar.start_span("litellm.completion", span_type="LLM")
+    chunks = [
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hello"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 5000,
+                "completion_tokens": 100,
+                "total_tokens": 5100,
+                "prompt_tokens_details": {"cached_tokens": 4000},
+            },
+        },
+    ]
+
+    assert list(process_completion_streaming_response(span, iter(chunks))) == chunks
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert attributes["gen_ai.usage.input_tokens"] == 5000
+    assert attributes["gen_ai.usage.output_tokens"] == 100
+    assert attributes["llm.usage.total_tokens"] == 5100
+    assert attributes["gen_ai.usage.cache_read_input_tokens"] == 4000
+
+
+@pytest.mark.asyncio
+async def test_litellm_completion_async_streaming_records_usage_only_chunk(
+    span_exporter: InMemorySpanExporter,
+):
+    """The async stream wrapper must preserve a final usage-only chunk."""
+    span = Laminar.start_span("litellm.completion", span_type="LLM")
+    chunks = [
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [{"index": 0, "delta": {"content": "Hello"}}],
+        },
+        {
+            "id": "chatcmpl-test",
+            "model": "kimi-k3",
+            "choices": [],
+            "usage": {
+                "prompt_tokens": 5000,
+                "completion_tokens": 100,
+                "total_tokens": 5100,
+                "prompt_tokens_details": {"cached_tokens": 4000},
+            },
+        },
+    ]
+
+    async def stream():
+        for chunk in chunks:
+            yield chunk
+
+    received = [
+        chunk
+        async for chunk in process_completion_async_streaming_response(span, stream())
+    ]
+    assert received == chunks
+
+    spans = span_exporter.get_finished_spans()
+    assert len(spans) == 1
+    attributes = spans[0].attributes
+    assert attributes["gen_ai.usage.input_tokens"] == 5000
+    assert attributes["gen_ai.usage.output_tokens"] == 100
+    assert attributes["llm.usage.total_tokens"] == 5100
+    assert attributes["gen_ai.usage.cache_read_input_tokens"] == 4000
 
 
 @pytest.mark.vcr(record_mode="once")


### PR DESCRIPTION
## Summary

- retain the last non-null `usage` object while consuming LiteLLM completion streams
- write input, output, total, cache-read, and cache-creation token attributes when reported
- accumulate streamed reasoning deltas (`reasoning_content`, with normalized `reasoning`/`thinking` fallbacks) into reconstructed output messages
- include usage and reasoning in reconstructed raw rollout responses
- avoid reporting unknown cache usage as confirmed zero
- add synchronous and asynchronous regression tests for usage-only chunks and multi-chunk reasoning

Fixes #324.

## Testing

```text
uv run pytest tests/test_litellm.py \
  -k 'streaming_records_usage_only_chunk or streaming_preserves_reasoning_deltas or streaming_omits_unknown_cache_usage' \
  -q

5 passed, 26 deselected
```

```text
uv tool run ruff check \
  src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/litellm/wrappers/completions/streaming.py

All checks passed!
```

_This pull request was created and updated by an AI agent on behalf of Graham Neubig._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Instrumentation-only change to LiteLLM stream span attributes; no auth, data-store, or request-path behavior changes.
> 
> **Overview**
> LiteLLM streaming spans now keep token usage and reasoning text that previously dropped off the reconstructed completion.
> 
> The stream accumulator retains the last non-null `usage` object (including usage-only final chunks) and writes input, output, total, cache-read, and cache-creation attributes when those fields are present. Missing cache details are left unset instead of recorded as zero.
> 
> Streamed reasoning deltas (`reasoning_content`, with `reasoning`/`thinking` fallbacks) are concatenated into output messages and raw rollout responses. Sync and async tests cover usage-only chunks, reasoning accumulation, and omitted cache attributes. Bumps the SDK to `0.7.60`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 781134a1cd4c76751fc4f5625d52fdbee7bf9124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->