### PR TITLE
relax otel deps to allow older otel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
   "opentelemetry-exporter-otlp-proto-grpc (>=1.39.0, <2.0.0)",
   "opentelemetry-instrumentation (>=0.54b0, <1.0.0)",
   "opentelemetry-instrumentation-threading (>=0.54b0, <1.0.0)",
-  "opentelemetry-semantic-conventions (==0.65b0)",
+  "opentelemetry-semantic-conventions (>=0.62b1, <1.0.0)",
   "opentelemetry-semantic-conventions-ai (==0.4.13)",
   "orjson (>=3.0.0,<4.0.0)",
   "packaging (>=22.0,<27.0)",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Dependency constraint change only; low runtime risk, with the usual caveat that very different semconv versions could affect attribute constants used via `opentelemetry.semconv`.
> 
> **Overview**
> **Relaxes the pinned `opentelemetry-semantic-conventions` dependency** from `==0.65b0` to `>=0.62b1, <1.0.0`, so `lmnr` can be installed alongside environments that already use slightly older OpenTelemetry semantic-conventions packages instead of forcing a single exact version.
> 
> No application code changes; this is packaging-only and aligns with the goal of allowing older OTEL stacks while still bounding supported versions below 1.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc9488511e44bb21aa57d890c975fefa75e0978. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->