### PR TITLE
Chore/pyright fixes small wrappers

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_agent/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_agent/__init__.py
@@ -1,16 +1,22 @@
 """OpenTelemetry CUA instrumentation"""
 
 import logging
-from typing import Any, AsyncGenerator, Collection
+from importlib.metadata import version
+from typing import Any, AsyncGenerator, Collection, Sequence
 
 from lmnr import Laminar
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.sdk.utils import json_dumps
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
 
 from opentelemetry.trace import Span
 from opentelemetry.trace.status import Status, StatusCode
-from wrapt import wrap_function_wrapper
 
 logger = logging.getLogger(__name__)
 
@@ -18,12 +24,13 @@ _instruments = ("cua-agent >= 0.4.0",)
 
 
 def _wrap_run(
+    to_wrap: WrappedFunctionSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
-    parent_span = Laminar.start_span("ComputerAgent.run")
+    parent_span = Laminar.start_span(to_wrap.get("span_name") or "ComputerAgent.run")
     instance._lmnr_parent_span = parent_span
 
     try:
@@ -67,34 +74,41 @@ async def _abuild_from_streaming_response(
                 yield step
 
 
-class CuaAgentInstrumentor(BaseInstrumentor):
-    def __init__(self):
-        super().__init__()
+class CuaAgentInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        wrap_package = "agent.agent"
-        wrap_object = "ComputerAgent"
-        wrap_method = "run"
-        try:
-            wrap_function_wrapper(
-                wrap_package,
-                f"{wrap_object}.{wrap_method}",
-                _wrap_run,
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                cua_version = version("cua-agent")
+            except Exception as e:
+                logger.debug(f"Failed to get cua-agent version {e}")
+                cua_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="cua-agent",
+                version=cua_version,
             )
-        except ModuleNotFoundError:
-            pass  # that's ok, we don't want to fail if some methods do not exist
+        return self._scope
 
-    def _uninstrument(self, **kwargs):
-        wrap_package = "agent.agent"
-        wrap_object = "ComputerAgent"
-        wrap_method = "run"
-        try:
-            unwrap(
-                f"{wrap_package}.{wrap_object}",
-                wrap_method,
-            )
-        except ModuleNotFoundError:
-            pass  # that's ok, we don't want to fail if some methods do not exist
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                WrappedFunctionSpec(
+                    package_name="agent.agent",
+                    object_name="ComputerAgent",
+                    method_name="run",
+                    # `run` returns an async generator rather than a coroutine,
+                    # so the wrapper is a plain function that returns it.
+                    is_async=False,
+                    is_streaming=True,
+                    span_name="ComputerAgent.run",
+                    span_type="DEFAULT",
+                    instrumentation_scope=self.instrumentation_scope(),
+                    wrapper_function=_wrap_run,
+                ),
+            ]
+        )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_computer/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_computer/__init__.py
@@ -1,18 +1,24 @@
 """OpenTelemetry CUA instrumentation"""
 
 import logging
-from typing import Collection
+from importlib.metadata import version
+from typing import Any, Callable, Collection, Sequence
 
 from lmnr.sdk.utils import get_input_from_func_args, json_dumps
 from lmnr import Laminar
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.tracing.context import get_current_context
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
 
 from opentelemetry import trace
 from opentelemetry.trace import Span
 from opentelemetry.trace.status import Status, StatusCode
-from wrapt import wrap_function_wrapper
 
 from .utils import payload_to_placeholder
 
@@ -21,238 +27,18 @@ logger = logging.getLogger(__name__)
 _instruments = ("cua-computer >= 0.4.0",)
 
 
-WRAPPED_METHODS = [
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "close",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "force_close",
-    },
-]
-WRAPPED_AMETHODS = [
-    {
-        "package": "computer.computer",
-        "object": "Computer",
-        "method": "__aenter__",
-        "action": "start_parent_span",
-    },
-    {
-        "package": "computer.computer",
-        "object": "Computer",
-        "method": "__aexit__",
-        "action": "end_parent_span",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "mouse_down",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "mouse_up",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "left_click",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "right_click",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "double_click",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "move_cursor",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "drag_to",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "drag",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "key_down",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "key_up",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "type_text",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "press",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "hotkey",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "scroll",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "scroll_down",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "scroll_up",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "screenshot",
-        "output_formatter": payload_to_placeholder,
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "get_screen_size",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "get_cursor_position",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "copy_to_clipboard",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "set_clipboard",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "file_exists",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "directory_exists",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "list_dir",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "read_text",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "write_text",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "read_bytes",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "write_bytes",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "delete_file",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "create_dir",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "delete_dir",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "get_file_size",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "run_command",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "get_accessibility_tree",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "to_screen_coordinates",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "get_active_window_bounds",
-    },
-    {
-        "package": "computer.interface.generic",
-        "object": "GenericComputerInterface",
-        "method": "to_screenshot_coordinates",
-    },
-]
+class CuaComputerSpec(WrappedFunctionSpec, total=False):
+    """cua-computer's per-method extras.
+
+    `action` tags the two lifecycle methods that open/close the parent
+    `computer.run` span rather than tracing a call; `output_formatter` replaces
+    a large payload (e.g. a screenshot) with a placeholder before it is recorded.
+    """
+
+    action: str
+    output_formatter: Callable[[Any], Any]
 
 
-def _with_wrapper(func):
-    """Helper for providing tracer for wrapper functions. Includes metric collectors."""
-
-    def wrapper(
-        to_wrap,
-    ):
-        def wrapper(wrapped, instance, args, kwargs):
-            return func(
-                to_wrap,
-                wrapped,
-                instance,
-                args,
-                kwargs,
-            )
-
-        return wrapper
-
-    return wrapper
 
 
 def add_input_to_parent_span(span, instance):
@@ -301,13 +87,12 @@ def add_input_to_parent_span(span, instance):
     span.set_attribute("lmnr.span.input", json_dumps(params))
 
 
-@_with_wrapper
 def _wrap(
-    to_wrap,
+    to_wrap: CuaComputerSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
     if to_wrap.get("action") == "start_parent_span":
         parent_span = Laminar.start_span("computer.run")
@@ -339,7 +124,7 @@ def _wrap(
     with Laminar.use_span(parent_span):
         instance_name = "interface"
         with Laminar.start_as_current_span(
-            f"{instance_name}.{to_wrap.get('method')}", span_type="TOOL"
+            f"{instance_name}.{to_wrap['method_name']}", span_type="TOOL"
         ) as span:
             span.set_attribute(
                 "lmnr.span.input",
@@ -359,13 +144,12 @@ def _wrap(
             return result
 
 
-@_with_wrapper
 async def _wrap_async(
-    to_wrap,
+    to_wrap: CuaComputerSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
     if to_wrap.get("action") == "start_parent_span":
         parent_span = Laminar.start_span("computer.run")
@@ -396,7 +180,7 @@ async def _wrap_async(
     with Laminar.use_span(parent_span):
         instance_name = "interface"
         with Laminar.start_as_current_span(
-            f"{instance_name}.{to_wrap.get('method')}",
+            f"{instance_name}.{to_wrap['method_name']}",
             span_type="TOOL",
         ) as span:
             span.set_attribute(
@@ -417,60 +201,324 @@ async def _wrap_async(
             return result
 
 
-class CuaComputerInstrumentor(BaseInstrumentor):
-    def __init__(self):
-        super().__init__()
+WRAPPED_FUNCTIONS: list[CuaComputerSpec] = [
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="close",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="force_close",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    CuaComputerSpec(
+        package_name="computer.computer",
+        object_name="Computer",
+        method_name="__aenter__",
+        is_async=True,
+        action="start_parent_span",
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.computer",
+        object_name="Computer",
+        method_name="__aexit__",
+        is_async=True,
+        action="end_parent_span",
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="mouse_down",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="mouse_up",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="left_click",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="right_click",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="double_click",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="move_cursor",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="drag_to",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="drag",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="key_down",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="key_up",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="type_text",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="press",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="hotkey",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="scroll",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="scroll_down",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="scroll_up",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="screenshot",
+        is_async=True,
+        output_formatter=payload_to_placeholder,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="get_screen_size",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="get_cursor_position",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="copy_to_clipboard",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="set_clipboard",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="file_exists",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="directory_exists",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="list_dir",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="read_text",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="write_text",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="read_bytes",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="write_bytes",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="delete_file",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="create_dir",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="delete_dir",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="get_file_size",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="run_command",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="get_accessibility_tree",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="to_screen_coordinates",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="get_active_window_bounds",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+    CuaComputerSpec(
+        package_name="computer.interface.generic",
+        object_name="GenericComputerInterface",
+        method_name="to_screenshot_coordinates",
+        is_async=True,
+        wrapper_function=_wrap_async,
+    ),
+]
+
+
+class CuaComputerInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap(wrapped_method),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some methods do not exist
+                cua_version = version("cua-computer")
+            except Exception as e:
+                logger.debug(f"Failed to get cua-computer version {e}")
+                cua_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="cua-computer",
+                version=cua_version,
+            )
+        return self._scope
 
-        for wrapped_method in WRAPPED_AMETHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap_async(wrapped_method),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            try:
-                unwrap(
-                    f"{wrap_package}.{wrap_object}",
-                    wrapped_method.get("method"),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-        for wrapped_method in WRAPPED_AMETHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            try:
-                unwrap(
-                    f"{wrap_package}.{wrap_object}",
-                    wrapped_method.get("method"),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some methods do not exist
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/kernel/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/kernel/__init__.py
@@ -1,198 +1,56 @@
 """OpenTelemetry Kernel instrumentation"""
 
 import functools
-from typing import Collection
+import logging
+from importlib.metadata import version
+from typing import Any, Callable, Collection, Sequence
 
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.kernel.utils import (
     process_tool_output_formatter,
     screenshot_tool_output_formatter,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.sdk.decorators import observe
 from lmnr.sdk.utils import get_input_from_func_args, is_async, json_dumps
 from lmnr import Laminar
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
 
 from opentelemetry.trace.status import Status, StatusCode
-from wrapt import wrap_function_wrapper
+
+logger = logging.getLogger(__name__)
 
 _instruments = ("kernel >= 0.2.0",)
 
 
-WRAPPED_METHODS = [
-    {
-        "package": "kernel.resources.browsers",
-        "object": "BrowsersResource",
-        "method": "create",
-        "class_name": "Browser",
-    },
-    {
-        "package": "kernel.resources.browsers",
-        "object": "BrowsersResource",
-        "method": "retrieve",
-        "class_name": "Browser",
-    },
-    {
-        "package": "kernel.resources.browsers",
-        "object": "BrowsersResource",
-        "method": "list",
-        "class_name": "Browser",
-    },
-    {
-        "package": "kernel.resources.browsers",
-        "object": "BrowsersResource",
-        "method": "delete",
-        "class_name": "Browser",
-    },
-    {
-        "package": "kernel.resources.browsers",
-        "object": "BrowsersResource",
-        "method": "delete_by_id",
-        "class_name": "Browser",
-    },
-    {
-        "package": "kernel.resources.browsers",
-        "object": "BrowsersResource",
-        "method": "load_extensions",
-        "class_name": "Browser",
-    },
-    {
-        "package": "kernel.resources.browsers.computer",
-        "object": "ComputerResource",
-        "method": "capture_screenshot",
-        "class_name": "Computer",
-        "span_type": "TOOL",
-        "output_formatter": screenshot_tool_output_formatter,
-    },
-    {
-        "package": "kernel.resources.browsers.computer",
-        "object": "ComputerResource",
-        "method": "click_mouse",
-        "class_name": "Computer",
-        "span_type": "TOOL",
-    },
-    {
-        "package": "kernel.resources.browsers.computer",
-        "object": "ComputerResource",
-        "method": "drag_mouse",
-        "class_name": "Computer",
-        "span_type": "TOOL",
-    },
-    {
-        "package": "kernel.resources.browsers.computer",
-        "object": "ComputerResource",
-        "method": "move_mouse",
-        "class_name": "Computer",
-        "span_type": "TOOL",
-    },
-    {
-        "package": "kernel.resources.browsers.computer",
-        "object": "ComputerResource",
-        "method": "press_key",
-        "class_name": "Computer",
-        "span_type": "TOOL",
-    },
-    {
-        "package": "kernel.resources.browsers.computer",
-        "object": "ComputerResource",
-        "method": "scroll",
-        "class_name": "Computer",
-        "span_type": "TOOL",
-    },
-    {
-        "package": "kernel.resources.browsers.computer",
-        "object": "ComputerResource",
-        "method": "type_text",
-        "class_name": "Computer",
-        "span_type": "TOOL",
-    },
-    {
-        "package": "kernel.resources.browsers.playwright",
-        "object": "PlaywrightResource",
-        "method": "execute",
-        "class_name": "Playwright",
-    },
-    {
-        "package": "kernel.resources.browsers.process",
-        "object": "ProcessResource",
-        "method": "exec",
-        "class_name": "Process",
-        "span_type": "TOOL",
-        "output_formatter": process_tool_output_formatter,
-    },
-    {
-        "package": "kernel.resources.browsers.process",
-        "object": "ProcessResource",
-        "method": "kill",
-        "class_name": "Process",
-        "span_type": "TOOL",
-        "output_formatter": process_tool_output_formatter,
-    },
-    {
-        "package": "kernel.resources.browsers.process",
-        "object": "ProcessResource",
-        "method": "spawn",
-        "class_name": "Process",
-        "span_type": "TOOL",
-        "output_formatter": process_tool_output_formatter,
-    },
-    {
-        "package": "kernel.resources.browsers.process",
-        "object": "ProcessResource",
-        "method": "status",
-        "class_name": "Process",
-        "span_type": "TOOL",
-        "output_formatter": process_tool_output_formatter,
-    },
-    {
-        "package": "kernel.resources.browsers.process",
-        "object": "ProcessResource",
-        "method": "stdin",
-        "class_name": "Process",
-        "span_type": "TOOL",
-        "output_formatter": process_tool_output_formatter,
-    },
-    {
-        "package": "kernel.resources.browsers.process",
-        "object": "ProcessResource",
-        "method": "stdout_stream",
-        "class_name": "Process",
-        "span_type": "TOOL",
-        "output_formatter": process_tool_output_formatter,
-    },
-]
+class KernelSpec(WrappedFunctionSpec, total=False):
+    """kernel's per-method extras.
+
+    `class_name` names the span after the user-facing resource (e.g. "Browser")
+    rather than the SDK class; `output_formatter` condenses a large tool result
+    (a screenshot, a process payload) before it is recorded.
+    """
+
+    class_name: str
+    output_formatter: Callable[[Any], Any]
 
 
-def _with_wrapper(func):
-    """Helper for providing tracer for wrapper functions. Includes metric collectors."""
-
-    def wrapper(
-        to_wrap,
-    ):
-        def wrapper(wrapped, instance, args, kwargs):
-            return func(
-                to_wrap,
-                wrapped,
-                instance,
-                args,
-                kwargs,
-            )
-
-        return wrapper
-
-    return wrapper
 
 
-@_with_wrapper
 def _wrap(
-    to_wrap,
+    to_wrap: KernelSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
     with Laminar.start_as_current_span(
-        f"{to_wrap.get('class_name')}.{to_wrap.get('method')}",
+        f"{to_wrap.get('class_name')}.{to_wrap['method_name']}",
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
         input_kv = get_input_from_func_args(wrapped, True, args, kwargs)
@@ -214,16 +72,15 @@ def _wrap(
         return result
 
 
-@_with_wrapper
 async def _wrap_async(
-    to_wrap,
+    to_wrap: KernelSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
     with Laminar.start_as_current_span(
-        f"{to_wrap.get('class_name')}.{to_wrap.get('method')}",
+        f"{to_wrap.get('class_name')}.{to_wrap['method_name']}",
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
         input_kv = get_input_from_func_args(wrapped, True, args, kwargs)
@@ -245,13 +102,12 @@ async def _wrap_async(
         return result
 
 
-@_with_wrapper
 def _wrap_app_action(
-    to_wrap,
+    to_wrap: KernelSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
     """
     Wraps app.action() decorator factory to add tracing to action handlers.
@@ -308,74 +164,401 @@ def _wrap_app_action(
     return tracing_decorator
 
 
-class KernelInstrumentor(BaseInstrumentor):
-    def __init__(self):
-        super().__init__()
+WRAPPED_FUNCTIONS: list[KernelSpec] = [
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="BrowsersResource",
+        method_name="create",
+        is_async=False,
+        class_name="Browser",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="BrowsersResource",
+        method_name="retrieve",
+        is_async=False,
+        class_name="Browser",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="BrowsersResource",
+        method_name="list",
+        is_async=False,
+        class_name="Browser",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="BrowsersResource",
+        method_name="delete",
+        is_async=False,
+        class_name="Browser",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="BrowsersResource",
+        method_name="delete_by_id",
+        is_async=False,
+        class_name="Browser",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="BrowsersResource",
+        method_name="load_extensions",
+        is_async=False,
+        class_name="Browser",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="ComputerResource",
+        method_name="capture_screenshot",
+        is_async=False,
+        class_name="Computer",
+        span_type="TOOL",
+        output_formatter=screenshot_tool_output_formatter,
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="ComputerResource",
+        method_name="click_mouse",
+        is_async=False,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="ComputerResource",
+        method_name="drag_mouse",
+        is_async=False,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="ComputerResource",
+        method_name="move_mouse",
+        is_async=False,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="ComputerResource",
+        method_name="press_key",
+        is_async=False,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="ComputerResource",
+        method_name="scroll",
+        is_async=False,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="ComputerResource",
+        method_name="type_text",
+        is_async=False,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.playwright",
+        object_name="PlaywrightResource",
+        method_name="execute",
+        is_async=False,
+        class_name="Playwright",
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="ProcessResource",
+        method_name="exec",
+        is_async=False,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="ProcessResource",
+        method_name="kill",
+        is_async=False,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="ProcessResource",
+        method_name="spawn",
+        is_async=False,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="ProcessResource",
+        method_name="status",
+        is_async=False,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="ProcessResource",
+        method_name="stdin",
+        is_async=False,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="ProcessResource",
+        method_name="stdout_stream",
+        is_async=False,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="AsyncBrowsersResource",
+        method_name="create",
+        is_async=True,
+        class_name="Browser",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="AsyncBrowsersResource",
+        method_name="retrieve",
+        is_async=True,
+        class_name="Browser",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="AsyncBrowsersResource",
+        method_name="list",
+        is_async=True,
+        class_name="Browser",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="AsyncBrowsersResource",
+        method_name="delete",
+        is_async=True,
+        class_name="Browser",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="AsyncBrowsersResource",
+        method_name="delete_by_id",
+        is_async=True,
+        class_name="Browser",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers",
+        object_name="AsyncBrowsersResource",
+        method_name="load_extensions",
+        is_async=True,
+        class_name="Browser",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="AsyncComputerResource",
+        method_name="capture_screenshot",
+        is_async=True,
+        class_name="Computer",
+        span_type="TOOL",
+        output_formatter=screenshot_tool_output_formatter,
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="AsyncComputerResource",
+        method_name="click_mouse",
+        is_async=True,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="AsyncComputerResource",
+        method_name="drag_mouse",
+        is_async=True,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="AsyncComputerResource",
+        method_name="move_mouse",
+        is_async=True,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="AsyncComputerResource",
+        method_name="press_key",
+        is_async=True,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="AsyncComputerResource",
+        method_name="scroll",
+        is_async=True,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.computer",
+        object_name="AsyncComputerResource",
+        method_name="type_text",
+        is_async=True,
+        class_name="Computer",
+        span_type="TOOL",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.playwright",
+        object_name="AsyncPlaywrightResource",
+        method_name="execute",
+        is_async=True,
+        class_name="Playwright",
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="AsyncProcessResource",
+        method_name="exec",
+        is_async=True,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="AsyncProcessResource",
+        method_name="kill",
+        is_async=True,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="AsyncProcessResource",
+        method_name="spawn",
+        is_async=True,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="AsyncProcessResource",
+        method_name="status",
+        is_async=True,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="AsyncProcessResource",
+        method_name="stdin",
+        is_async=True,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.resources.browsers.process",
+        object_name="AsyncProcessResource",
+        method_name="stdout_stream",
+        is_async=True,
+        class_name="Process",
+        span_type="TOOL",
+        output_formatter=process_tool_output_formatter,
+        wrapper_function=_wrap_async,
+    ),
+    KernelSpec(
+        package_name="kernel.app_framework",
+        object_name="KernelApp",
+        method_name="action",
+        is_async=False,
+        wrapper_function=_wrap_app_action,
+    ),
+]
+
+
+class KernelInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap(wrapped_method),
-                )
-            except (ModuleNotFoundError, AttributeError):
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = f"Async{wrapped_method.get('object')}"
-            wrap_method = wrapped_method.get("method")
-            try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap_async(wrapped_method),
-                )
-            except (ModuleNotFoundError, AttributeError):
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-        try:
-            wrap_function_wrapper(
-                "kernel.app_framework",
-                "KernelApp.action",
-                _wrap_app_action({}),
+                kernel_version = version("kernel")
+            except Exception as e:
+                logger.debug(f"Failed to get kernel version {e}")
+                kernel_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="kernel",
+                version=kernel_version,
             )
-        except (ModuleNotFoundError, AttributeError):
-            pass
+        return self._scope
 
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            try:
-                unwrap(
-                    f"{wrap_package}.{wrap_object}",
-                    wrapped_method.get("method"),
-                )
-            except (ModuleNotFoundError, AttributeError):
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = f"Async{wrapped_method.get('object')}"
-            try:
-                unwrap(
-                    f"{wrap_package}.{wrap_object}",
-                    wrapped_method.get("method"),
-                )
-            except (ModuleNotFoundError, AttributeError):
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-        try:
-            unwrap("kernel.app_framework.KernelApp", "action")
-        except (ModuleNotFoundError, AttributeError):
-            pass
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/langgraph/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/langgraph/__init__.py
@@ -4,16 +4,20 @@ import json
 import logging
 from typing import Collection
 
+from importlib.metadata import version
+from typing import Any, Sequence
+
 from langchain_core.runnables.graph import Graph
-from opentelemetry.trace import Tracer
-from wrapt import wrap_function_wrapper
-from opentelemetry.trace import get_tracer
 from opentelemetry.context import get_value, attach, set_value
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
-
-from lmnr.sdk.utils import with_tracer_wrapper
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 
 
 logger = logging.getLogger(__name__)
@@ -21,8 +25,13 @@ logger = logging.getLogger(__name__)
 _instruments = ("langgraph >= 0.1.0",)
 
 
-@with_tracer_wrapper
-def wrap_pregel_stream(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
+def wrap_pregel_stream(
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     graph: Graph = instance.get_graph()
     nodes = [
         {
@@ -50,9 +59,12 @@ def wrap_pregel_stream(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs)
     return wrapped(*args, **kwargs)
 
 
-@with_tracer_wrapper
 async def async_wrap_pregel_stream(
-    tracer: Tracer, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
     graph: Graph = await instance.aget_graph()
     nodes = [
@@ -84,34 +96,55 @@ async def async_wrap_pregel_stream(
         yield item
 
 
-class LanggraphInstrumentor(BaseInstrumentor):
+class LanggraphInstrumentor(BaseLaminarInstrumentor):
     """An instrumentor for Langgraph."""
 
-    def __init__(self):
-        super().__init__()
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, "0.0.1a0", tracer_provider)
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                langgraph_version = version("langgraph")
+            except Exception as e:
+                logger.debug(f"Failed to get langgraph version {e}")
+                langgraph_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="langgraph",
+                version=langgraph_version,
+            )
+        return self._scope
 
-        wrap_function_wrapper(
-            "langgraph.pregel",
-            "Pregel.stream",
-            wrap_pregel_stream(tracer, "Pregel.stream"),
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                WrappedFunctionSpec(
+                    package_name="langgraph.pregel",
+                    object_name="Pregel",
+                    method_name="stream",
+                    is_async=False,
+                    is_streaming=True,
+                    # These wrappers only attach graph topology onto the OTel
+                    # context for downstream spans to pick up; they open no span
+                    # of their own, so there is no span_name/span_type to read.
+                    span_name=None,
+                    span_type=None,
+                    instrumentation_scope=self.instrumentation_scope(),
+                    wrapper_function=wrap_pregel_stream,
+                ),
+                WrappedFunctionSpec(
+                    package_name="langgraph.pregel",
+                    object_name="Pregel",
+                    method_name="astream",
+                    is_async=True,
+                    is_streaming=True,
+                    span_name=None,
+                    span_type=None,
+                    instrumentation_scope=self.instrumentation_scope(),
+                    wrapper_function=async_wrap_pregel_stream,
+                ),
+            ]
         )
-        wrap_function_wrapper(
-            "langgraph.pregel",
-            "Pregel.astream",
-            async_wrap_pregel_stream(tracer, "Pregel.astream"),
-        )
-
-    def _uninstrument(self, **kwargs):
-        # `unwrap` takes (holder, "attr") — NOT wrapt's (module, "Object.method")
-        # split used in `_instrument`. With the wrapt split it looks for an
-        # attribute literally named "Pregel.stream", finds nothing, and returns
-        # silently, leaving both methods wrapped forever.
-        unwrap("langgraph.pregel.Pregel", "stream")
-        unwrap("langgraph.pregel.Pregel", "astream")

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/opentelemetry/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/opentelemetry/__init__.py
@@ -1,12 +1,25 @@
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
+from importlib.metadata import version
+from typing import Any, Collection, Sequence
+
 from opentelemetry.trace import TraceFlags, SpanContext
-from typing import Collection
-from wrapt import wrap_function_wrapper
-import logging
+
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 
 
-def _wrap_span_context(fn, instance, args, kwargs):
+def _wrap_span_context(
+    to_wrap: WrappedFunctionSpec,
+    fn,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     """
     DataDog does something to the OpenTelemetry Contexts, so that when any code
     tries to access the current active span, it returns a non-recording span.
@@ -47,26 +60,41 @@ def _wrap_span_context(fn, instance, args, kwargs):
     return new_span_context
 
 
-class OpentelemetryInstrumentor(BaseInstrumentor):
-    def __init__(self):
-        super().__init__()
+class OpentelemetryInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return ("opentelemetry-api>=1.0.0",)
 
-    def _instrument(self, **kwargs):
-        try:
-            wrap_function_wrapper(
-                "opentelemetry.trace.span",
-                "NonRecordingSpan.get_span_context",
-                _wrap_span_context,
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                otel_version = version("opentelemetry-api")
+            except Exception:
+                otel_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="opentelemetry",
+                version=otel_version,
             )
+        return self._scope
 
-        except Exception as e:
-            logging.debug(f"Error wrapping SpanContext: {e}")
-
-    def _uninstrument(self, **kwargs):
-        # `unwrap` takes (holder, "attr"), not wrapt's (module, "Object.method")
-        # split used in `_instrument` — see the note in langgraph's
-        # `_uninstrument`. The wrapt split silently no-ops here.
-        unwrap("opentelemetry.trace.span.NonRecordingSpan", "get_span_context")
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                WrappedFunctionSpec(
+                    package_name="opentelemetry.trace.span",
+                    object_name="NonRecordingSpan",
+                    method_name="get_span_context",
+                    is_async=False,
+                    is_streaming=False,
+                    # This wrapper repairs a SpanContext rather than tracing
+                    # anything, so it creates no span and reads no span_name /
+                    # span_type off the spec.
+                    span_name=None,
+                    span_type=None,
+                    instrumentation_scope=self.instrumentation_scope(),
+                    wrapper_function=_wrap_span_context,
+                ),
+            ]
+        )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/skyvern/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/skyvern/__init__.py
@@ -1,16 +1,21 @@
+from importlib.metadata import version
+from typing import Any, Collection, Sequence
+
+import pydantic
+
+from lmnr import Laminar
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.sdk.log import get_default_logger
-from lmnr.sdk.utils import with_tracer_wrapper
 from lmnr.sdk.utils import get_input_from_func_args, json_dumps
-from lmnr.version import __version__
 
 logger = get_default_logger(__name__)
-
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import get_tracer, Tracer
-from typing import Collection
-from wrapt import wrap_function_wrapper
-import pydantic
 
 try:
     from skyvern import Skyvern
@@ -23,58 +28,15 @@ except ImportError as e:
 
 _instruments = ("skyvern >= 0.1.0",)
 
-WRAPPED_METHODS = [
-    {
-        "package": "skyvern.library.skyvern",
-        "object": "Skyvern",  # Class name
-        "method": "run_task",  # Method name
-        "span_name": "Skyvern.run_task",
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "skyvern.webeye.scraper.scraper",
-        # No "object" field for module-level functions
-        "method": "get_interactable_element_tree",  # Function name
-        "span_name": "get_interactable_element_tree",
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "skyvern.forge.agent",
-        "object": "ForgeAgent",
-        "method": "execute_step",
-        "span_name": "ForgeAgent.execute_step",
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "skyvern.services.task_v2_service",
-        "method": "initialize_task_v2",
-        "span_name": "initialize_task_v2",
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "skyvern.services.task_v2_service",
-        "method": "run_task_v2_helper",
-        "span_name": "run_task_v2_helper",
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "skyvern.forge.sdk.workflow.models.block",
-        "object": "Block",
-        "method": "_generate_workflow_run_block_description",
-        "span_name": "Block._generate_workflow_run_block_description",
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "skyvern.webeye.actions.handler",
-        "method": "extract_information_for_navigation_goal",
-        "span_name": "extract_information_for_navigation_goal",
-        "span_type": "DEFAULT",
-    },
-]
 
 
-@with_tracer_wrapper
-async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
+async def _wrap(
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     span_name = to_wrap.get("span_name")
     attributes = {
         "lmnr.span.type": to_wrap.get("span_type"),
@@ -84,7 +46,10 @@ async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         get_input_from_func_args(wrapped, True, args, kwargs)
     )
 
-    with tracer.start_as_current_span(span_name, attributes=attributes) as span:
+    # `Laminar.start_as_current_span` rather than a per-library tracer: this
+    # instrumentor no longer receives one. The attributes are passed through
+    # verbatim so the emitted span is unchanged.
+    with Laminar.start_as_current_span(span_name, attributes=attributes) as span:
         try:
             result = await wrapped(*args, **kwargs)
 
@@ -102,7 +67,7 @@ async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
             raise
 
 
-def instrument_llm_handler(tracer: Tracer):
+def instrument_llm_handler():
     """Wrap skyvern's global LLM handler, returning the original for restoration.
 
     Reading `app.LLM_API_HANDLER` raises `RuntimeError` until skyvern's forge app
@@ -127,7 +92,7 @@ def instrument_llm_handler(tracer: Tracer):
             "lmnr.span.type": "DEFAULT",
         }
 
-        with tracer.start_as_current_span(span_name, attributes=attributes) as span:
+        with Laminar.start_as_current_span(span_name, attributes=attributes) as span:
             try:
                 result = await original_handler(*args, **kwargs)
 
@@ -148,58 +113,119 @@ def instrument_llm_handler(tracer: Tracer):
     return original_handler
 
 
-class SkyvernInstrumentor(BaseInstrumentor):
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="skyvern.library.skyvern",
+        object_name="Skyvern",
+        method_name="run_task",
+        is_async=True,
+        span_name="Skyvern.run_task",
+        span_type="DEFAULT",
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="skyvern.webeye.scraper.scraper",
+        object_name=None,
+        method_name="get_interactable_element_tree",
+        is_async=True,
+        span_name="get_interactable_element_tree",
+        span_type="DEFAULT",
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="skyvern.forge.agent",
+        object_name="ForgeAgent",
+        method_name="execute_step",
+        is_async=True,
+        span_name="ForgeAgent.execute_step",
+        span_type="DEFAULT",
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="skyvern.services.task_v2_service",
+        object_name=None,
+        method_name="initialize_task_v2",
+        is_async=True,
+        span_name="initialize_task_v2",
+        span_type="DEFAULT",
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="skyvern.services.task_v2_service",
+        object_name=None,
+        method_name="run_task_v2_helper",
+        is_async=True,
+        span_name="run_task_v2_helper",
+        span_type="DEFAULT",
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="skyvern.forge.sdk.workflow.models.block",
+        object_name="Block",
+        method_name="_generate_workflow_run_block_description",
+        is_async=True,
+        span_name="Block._generate_workflow_run_block_description",
+        span_type="DEFAULT",
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="skyvern.webeye.actions.handler",
+        object_name=None,
+        method_name="extract_information_for_navigation_goal",
+        is_async=True,
+        span_name="extract_information_for_navigation_goal",
+        span_type="DEFAULT",
+        wrapper_function=_wrap,
+    ),
+]
+
+
+class SkyvernInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
+
     def __init__(self):
         super().__init__()
         self._original_llm_handler = None
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                skyvern_version = version("skyvern")
+            except Exception as e:
+                logger.debug(f"Failed to get skyvern version {e}")
+                skyvern_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="skyvern",
+                version=skyvern_version,
+            )
+        return self._scope
+
     def _instrument(self, **kwargs):
-
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        # Guarded, and deliberately BEFORE nothing: `app.LLM_API_HANDLER` raises
-        # RuntimeError until skyvern's forge app is started, which is the normal
-        # state during `Laminar.initialize()`. Unguarded, that exception
-        # propagated out of `_instrument` before the loop below ran, so a single
-        # uninitialized global left ALL seven methods unwrapped — i.e. skyvern
-        # tracing silently did nothing.
+        # Guarded: `app.LLM_API_HANDLER` raises RuntimeError until skyvern's
+        # forge app is started, which is the normal state during
+        # `Laminar.initialize()`. Unguarded, that exception propagated out of
+        # `_instrument` before any method was wrapped, so a single uninitialized
+        # global left ALL seven unwrapped — skyvern tracing silently did nothing.
         try:
-            self._original_llm_handler = instrument_llm_handler(tracer)
+            self._original_llm_handler = instrument_llm_handler()
         except Exception as e:
             logger.debug(f"Failed to instrument skyvern LLM_API_HANDLER: {e}")
 
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
-            # For class methods: "Class.method", for module functions: just "function_name"
-            if wrap_object:
-                target = f"{wrap_object}.{wrap_method}"
-            else:
-                target = wrap_method
-
-            try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    target,
-                    _wrap(
-                        tracer,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we're not instrumenting everything
+        super()._instrument(**kwargs)
 
     def _uninstrument(self, **kwargs):
-
         # `instrument_llm_handler` swaps a module-level global, which `unwrap`
-        # below cannot undo — without this the handler stayed wrapped forever
-        # and each instrument/uninstrument cycle layered another wrapper on it.
+        # cannot undo — without this the handler stayed wrapped forever and each
+        # instrument/uninstrument cycle layered another wrapper on it.
         if self._original_llm_handler is not None:
             try:
                 from skyvern.forge import app
@@ -209,24 +235,4 @@ class SkyvernInstrumentor(BaseInstrumentor):
                 logger.debug(f"Failed to restore skyvern LLM_API_HANDLER: {e}")
             self._original_llm_handler = None
 
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
-            # For class methods: "package.Class", for module functions: just "package"
-            if wrap_object:
-                module_path = f"{wrap_package}.{wrap_object}"
-            else:
-                module_path = wrap_package
-
-            try:
-                unwrap(module_path, wrap_method)
-            except (ImportError, AttributeError, ModuleNotFoundError) as e:
-                # Mirrors the per-wrap tolerance in `_instrument`. Several of
-                # these targets live behind skyvern's own optional extras (the
-                # scraper needs PIL, task_v2_service needs sqlalchemy), and
-                # `unwrap` RAISES ImportError when it cannot resolve the holder
-                # — so without this an install missing any one of them made
-                # `uninstrument()` blow up rather than skip that target.
-                logger.debug(f"Failed to uninstrument {module_path}.{wrap_method}: {e}")
+        super()._uninstrument(**kwargs)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/skyvern/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/skyvern/__init__.py
@@ -1,6 +1,9 @@
+from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.utils import with_tracer_wrapper
 from lmnr.sdk.utils import get_input_from_func_args, json_dumps
 from lmnr.version import __version__
+
+logger = get_default_logger(__name__)
 
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
@@ -100,6 +103,12 @@ async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
 
 
 def instrument_llm_handler(tracer: Tracer):
+    """Wrap skyvern's global LLM handler, returning the original for restoration.
+
+    Reading `app.LLM_API_HANDLER` raises `RuntimeError` until skyvern's forge app
+    has been started, which is the normal state at `Laminar.initialize()` time —
+    hence the guard at the call site.
+    """
     from skyvern.forge import app
 
     # Store the original handler
@@ -136,11 +145,13 @@ def instrument_llm_handler(tracer: Tracer):
 
     # Replace the global handler
     app.LLM_API_HANDLER = wrapped_llm_handler
+    return original_handler
 
 
 class SkyvernInstrumentor(BaseInstrumentor):
     def __init__(self):
         super().__init__()
+        self._original_llm_handler = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
@@ -150,7 +161,16 @@ class SkyvernInstrumentor(BaseInstrumentor):
         tracer_provider = kwargs.get("tracer_provider")
         tracer = get_tracer(__name__, __version__, tracer_provider)
 
-        instrument_llm_handler(tracer)
+        # Guarded, and deliberately BEFORE nothing: `app.LLM_API_HANDLER` raises
+        # RuntimeError until skyvern's forge app is started, which is the normal
+        # state during `Laminar.initialize()`. Unguarded, that exception
+        # propagated out of `_instrument` before the loop below ran, so a single
+        # uninitialized global left ALL seven methods unwrapped — i.e. skyvern
+        # tracing silently did nothing.
+        try:
+            self._original_llm_handler = instrument_llm_handler(tracer)
+        except Exception as e:
+            logger.debug(f"Failed to instrument skyvern LLM_API_HANDLER: {e}")
 
         for wrapped_method in WRAPPED_METHODS:
             wrap_package = wrapped_method.get("package")
@@ -177,6 +197,18 @@ class SkyvernInstrumentor(BaseInstrumentor):
 
     def _uninstrument(self, **kwargs):
 
+        # `instrument_llm_handler` swaps a module-level global, which `unwrap`
+        # below cannot undo — without this the handler stayed wrapped forever
+        # and each instrument/uninstrument cycle layered another wrapper on it.
+        if self._original_llm_handler is not None:
+            try:
+                from skyvern.forge import app
+
+                app.LLM_API_HANDLER = self._original_llm_handler
+            except Exception as e:
+                logger.debug(f"Failed to restore skyvern LLM_API_HANDLER: {e}")
+            self._original_llm_handler = None
+
         for wrapped_method in WRAPPED_METHODS:
             wrap_package = wrapped_method.get("package")
             wrap_object = wrapped_method.get("object")
@@ -188,4 +220,13 @@ class SkyvernInstrumentor(BaseInstrumentor):
             else:
                 module_path = wrap_package
 
-            unwrap(module_path, wrap_method)
+            try:
+                unwrap(module_path, wrap_method)
+            except (ImportError, AttributeError, ModuleNotFoundError) as e:
+                # Mirrors the per-wrap tolerance in `_instrument`. Several of
+                # these targets live behind skyvern's own optional extras (the
+                # scraper needs PIL, task_v2_service needs sqlalchemy), and
+                # `unwrap` RAISES ImportError when it cannot resolve the holder
+                # — so without this an install missing any one of them made
+                # `uninstrument()` blow up rather than skip that target.
+                logger.debug(f"Failed to uninstrument {module_path}.{wrap_method}: {e}")

--- a/tests/test_instrumentor_targets.py
+++ b/tests/test_instrumentor_targets.py
@@ -34,6 +34,10 @@ INSTRUMENTOR_TARGETS: dict[str, tuple[str, str, set[tuple[str, str]]]] = {
             ("langgraph.pregel", "Pregel.astream"),
         },
     ),
+    # NOTE: skyvern is deliberately absent. It is also migrated, but its
+    # instrumentor module hard-imports `skyvern` at module level, and skyvern
+    # requires Python 3.11+ while this SDK supports 3.10 — so it cannot be a dev
+    # dependency and none of its targets are importable here.
 }
 
 
@@ -50,6 +54,24 @@ def _resolve(module_name: str, target: str):
 def _is_wrapped(module_name: str, target: str) -> bool:
     holder, attr = _resolve(module_name, target)
     return hasattr(getattr(holder, attr), "__wrapped__")
+
+
+def _reachable(targets: set[tuple[str, str]]) -> set[tuple[str, str]]:
+    """Drop targets whose module cannot be imported in this environment.
+
+    Every `_instrument` here swallows ModuleNotFoundError per wrap, so an
+    unreachable target is legitimately left unwrapped rather than being a
+    failure. Asserting on them anyway would make the suite depend on the target
+    library's own optional extras.
+    """
+    ok = set()
+    for module_name, target in targets:
+        try:
+            _resolve(module_name, target)
+        except (ImportError, AttributeError):
+            continue
+        ok.add((module_name, target))
+    return ok
 
 
 def _instrumentor(key: str):
@@ -69,11 +91,17 @@ def reinstrumented(request):
     session loses its spans.
     """
     instrumentor, targets = _instrumentor(request.param)
+    was_instrumented = instrumentor.is_instrumented_by_opentelemetry
     try:
         yield instrumentor, targets
     finally:
-        if not instrumentor.is_instrumented_by_opentelemetry:
+        # Restore whatever we found, not a fixed state: some of these are
+        # auto-enabled by the conftest session fixture and some are not, and
+        # leaving either one flipped would leak into the rest of the session.
+        if was_instrumented and not instrumentor.is_instrumented_by_opentelemetry:
             instrumentor.instrument()
+        elif not was_instrumented and instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
 
 
 @pytest.mark.parametrize(
@@ -81,6 +109,9 @@ def reinstrumented(request):
 )
 def test_instrument_wraps_exactly_the_declared_targets(reinstrumented):
     instrumentor, targets = reinstrumented
+    targets = _reachable(targets)
+    if not targets:
+        pytest.skip("no declared target is importable in this environment")
 
     instrumentor.uninstrument()
     for module_name, target in targets:
@@ -102,6 +133,9 @@ def test_uninstrument_restores_the_original_attribute(reinstrumented):
     """A migration that wraps correctly but leaks on teardown would still break
     any host that re-initializes Laminar (test suites, notebooks)."""
     instrumentor, targets = reinstrumented
+    targets = _reachable(targets)
+    if not targets:
+        pytest.skip("no declared target is importable in this environment")
 
     instrumentor.uninstrument()
     originals = {}
@@ -117,6 +151,7 @@ def test_uninstrument_restores_the_original_attribute(reinstrumented):
         assert getattr(holder, attr) is original, (
             f"did not restore {module_name}.{target} to the original function"
         )
+
 
 
 # ---------------------------------------------------------------------------
@@ -182,43 +217,90 @@ def test_unwrap_silently_no_ops_on_the_wrapt_argument_split():
 # ---------------------------------------------------------------------------
 
 
-def _target_set(rows) -> set[tuple[str, str, str]]:
-    return {
-        (r["package"], r.get("object") or "", r["method"]) for r in rows
-    }
-
-
-def test_kernel_declares_its_full_target_set():
-    """kernel iterates its table twice, synthesizing `Async{object}` on the
-    second pass, and wraps `KernelApp.action` outside the table entirely. The
-    migration turns all three into explicit rows, so the union must match."""
+def test_kernel_table_covers_the_sync_async_and_app_action_wraps():
+    """kernel used to iterate its 20-row table twice — synthesizing
+    `Async{object}` on the second pass — and wrap `KernelApp.action` outside the
+    table entirely. All three are now explicit rows; the totals must still match.
+    """
     from lmnr.opentelemetry_lib.opentelemetry.instrumentation.kernel import (
-        WRAPPED_METHODS,
+        WRAPPED_FUNCTIONS,
     )
 
-    sync = _target_set(WRAPPED_METHODS)
+    assert len(WRAPPED_FUNCTIONS) == 41
+
+    sync = [
+        r
+        for r in WRAPPED_FUNCTIONS
+        if not r["is_async"] and r["object_name"] != "KernelApp"
+    ]
+    async_ = [r for r in WRAPPED_FUNCTIONS if r["is_async"]]
     assert len(sync) == 20
+    assert len(async_) == 20
 
-    # every sync row has an async twin synthesized at instrument time
-    expected_async = {(pkg, f"Async{obj}", meth) for pkg, obj, meth in sync}
-    assert len(expected_async) == 20
+    # each async row is the `Async`-prefixed twin of a sync row, on the same
+    # package and method — that is exactly what the second pass used to build.
+    assert {
+        (r["package_name"], f"Async{r['object_name']}", r["method_name"])
+        for r in sync
+    } == {(r["package_name"], r["object_name"], r["method_name"]) for r in async_}
 
-    # ...plus the one out-of-table wrap
-    full = sync | expected_async | {("kernel.app_framework", "KernelApp", "action")}
-    assert len(full) == 41
+    app_action = [r for r in WRAPPED_FUNCTIONS if r["object_name"] == "KernelApp"]
+    assert [r["method_name"] for r in app_action] == ["action"]
 
 
-def test_cua_computer_declares_both_sync_and_async_tables():
-    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.cua_computer import (
-        WRAPPED_METHODS,
-        WRAPPED_AMETHODS,
+def test_kernel_wraps_and_restores_a_real_target():
+    """kernel is actually installed here, so unlike the other tables this one can
+    be verified end to end rather than only declaratively."""
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.kernel import (
+        KernelInstrumentor,
     )
 
-    sync = _target_set(WRAPPED_METHODS)
-    async_ = _target_set(WRAPPED_AMETHODS)
+    target = ("kernel.resources.browsers", "BrowsersResource.create")
+    instrumentor = KernelInstrumentor()
+    was_instrumented = instrumentor.is_instrumented_by_opentelemetry
+    try:
+        if was_instrumented:
+            instrumentor.uninstrument()
+        original = getattr(*_resolve(*target)[:1], _resolve(*target)[1])
 
-    assert sync, "sync table must not be empty"
-    assert async_, "async table must not be empty"
-    # The two tables target distinct methods; a migration collapsing them into
-    # one list with an `is_async` column must not lose or merge any row.
-    assert len(sync | async_) == len(sync) + len(async_)
+        instrumentor.instrument()
+        assert _is_wrapped(*target)
+
+        instrumentor.uninstrument()
+        holder, attr = _resolve(*target)
+        assert getattr(holder, attr) is original
+    finally:
+        if instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
+        if was_instrumented:
+            instrumentor.instrument()
+
+
+def test_cua_computer_merged_table_preserves_every_row():
+    """cua_computer's two tables (sync + async) were collapsed into one list with
+    an `is_async` column. Pin the resulting counts and the per-method extras, so
+    a row cannot be dropped or silently flipped to the wrong wrapper.
+    """
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.cua_computer import (
+        WRAPPED_FUNCTIONS,
+    )
+
+    assert len(WRAPPED_FUNCTIONS) == 41
+    assert sum(1 for r in WRAPPED_FUNCTIONS if not r["is_async"]) == 2
+    assert sum(1 for r in WRAPPED_FUNCTIONS if r["is_async"]) == 39
+
+    # every row targets a distinct (package, object, method)
+    targets = {
+        (r["package_name"], r["object_name"], r["method_name"])
+        for r in WRAPPED_FUNCTIONS
+    }
+    assert len(targets) == len(WRAPPED_FUNCTIONS)
+
+    # the two lifecycle rows that open/close the parent `computer.run` span
+    assert {r.get("action") for r in WRAPPED_FUNCTIONS if r.get("action")} == {
+        "start_parent_span",
+        "end_parent_span",
+    }
+    # screenshot is the one row whose payload is swapped for a placeholder
+    formatters = [r for r in WRAPPED_FUNCTIONS if r.get("output_formatter")]
+    assert [r["method_name"] for r in formatters] == ["screenshot"]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large refactor of tracing hooks across six integrations; behavior should be equivalent but regressions could silently drop spans or leak wrappers (especially Skyvern’s global LLM handler).
> 
> **Overview**
> Migrates **cua-agent**, **cua-computer**, **kernel**, **langgraph**, **opentelemetry**, and **skyvern** off hand-rolled `wrap_function_wrapper` / `unwrap` loops onto **`BaseLaminarInstrumentor`** with declarative **`WrappedFunctionSpec`** / **`LaminarInstrumentorConfig`** tables. Each instrumentor now declares wrapped targets in one list (with `is_async`, optional `span_name` / `span_type`, and per-library extras like kernel `class_name` or cua-computer `action` / `output_formatter`) and reports **`instrumentation_scope`** using the installed package version.
> 
> **Kernel** replaces the old “iterate sync table twice and synthesize `Async{object}`” pattern with **41 explicit rows**, including **`KernelApp.action`**. **Cua-computer** merges its former sync/async dict tables into a single **`WRAPPED_FUNCTIONS`** list keyed by **`method_name`**. Wrappers drop `_with_wrapper` / `with_tracer_wrapper` currying in favor of a consistent `(to_wrap, wrapped, instance, args, kwargs)` signature.
> 
> **Skyvern** switches span creation to **`Laminar.start_as_current_span`**, **guards** `LLM_API_HANDLER` patching so initialize-time failures no longer skip all method wraps, and **restores** the original global handler on uninstrument. **Langgraph** and the OTel compatibility patch no longer ship custom `_uninstrument` bodies that used the wrong `unwrap` calling convention—teardown goes through the shared base.
> 
> Tests in **`test_instrumentor_targets.py`** add reachable-target filtering, session-safe reinstrument fixtures, kernel/cua-computer table characterization, and an end-to-end kernel wrap/restore check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b3a09808b88309d54629bb39708fa4575afd9ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->