### PR TITLE
move CAS instrumetnation to the new format

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/__init__.py
@@ -1,13 +1,16 @@
-import importlib
-import sys
+from importlib.metadata import version
+from typing import Collection
 
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+)
 from lmnr.sdk.log import get_default_logger
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
-from typing import Any, Collection
-from wrapt import FunctionWrapper, wrap_function_wrapper
-
+from .types import ClaudeAgentSpec
 from .wrappers import (
     wrap_sync,
     wrap_async,
@@ -22,186 +25,134 @@ logger = get_default_logger(__name__)
 
 _instruments = ("claude-agent-sdk >= 0.1.0",)
 
-WRAPPED_METHODS = [
-    {
-        "package": "claude_agent_sdk._internal.transport.subprocess_cli",
-        "object": "SubprocessCLITransport",
-        "method": "connect",
-        "class_name": "SubprocessCLITransport",
-        "wrapper": wrap_transport_connect,
-    },
-    {
-        "package": "claude_agent_sdk._internal.transport.subprocess_cli",
-        "object": "SubprocessCLITransport",
-        "method": "close",
-        "class_name": "SubprocessCLITransport",
-        "wrapper": wrap_transport_close,
-    },
-    {
-        "package": "claude_agent_sdk.client",
-        "object": "ClaudeSDKClient",
-        "method": "__init__",
-        "class_name": "ClaudeSDKClient",
-        "wrapper": wrap_client_init,
-    },
-    {
-        "package": "claude_agent_sdk.client",
-        "object": "ClaudeSDKClient",
-        "method": "connect",
-        "class_name": "ClaudeSDKClient",
-        "should_publish_span_context": True,
-        "wrapper": wrap_async,
-    },
-    {
-        "package": "claude_agent_sdk.client",
-        "object": "ClaudeSDKClient",
-        "method": "query",
-        "class_name": "ClaudeSDKClient",
-        "should_publish_span_context": True,
-        "wrapper": wrap_async,
-    },
-    {
-        "package": "claude_agent_sdk.client",
-        "object": "ClaudeSDKClient",
-        "method": "receive_messages",
-        "class_name": "ClaudeSDKClient",
-        "wrapper": wrap_async_gen,
-    },
-    {
-        "package": "claude_agent_sdk.client",
-        "object": "ClaudeSDKClient",
-        "method": "receive_response",
-        "class_name": "ClaudeSDKClient",
-        "wrapper": wrap_async_gen,
-    },
-    {
-        "package": "claude_agent_sdk.client",
-        "object": "ClaudeSDKClient",
-        "method": "interrupt",
-        "class_name": "ClaudeSDKClient",
-        "wrapper": wrap_async,
-    },
-    {
-        "package": "claude_agent_sdk.client",
-        "object": "ClaudeSDKClient",
-        "method": "disconnect",
-        "class_name": "ClaudeSDKClient",
-        "wrapper": wrap_async,
-    },
-    {
-        # Module-level query function (streaming)
-        "package": "claude_agent_sdk",
-        "method": "query",
-        "should_publish_span_context": True,
-        "wrapper": wrap_query,
-    },
-    {
-        # Module-level create_sdk_mcp_server function (sync)
-        "package": "claude_agent_sdk",
-        "method": "create_sdk_mcp_server",
-        "wrapper": wrap_sync,
-    },
+WRAPPED_FUNCTIONS: list[ClaudeAgentSpec] = [
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk._internal.transport.subprocess_cli",
+        object_name="SubprocessCLITransport",
+        method_name="connect",
+        is_async=True,
+        class_name="SubprocessCLITransport",
+        wrapper_function=wrap_transport_connect,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk._internal.transport.subprocess_cli",
+        object_name="SubprocessCLITransport",
+        method_name="close",
+        is_async=True,
+        class_name="SubprocessCLITransport",
+        wrapper_function=wrap_transport_close,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk.client",
+        object_name="ClaudeSDKClient",
+        method_name="__init__",
+        is_async=False,
+        class_name="ClaudeSDKClient",
+        wrapper_function=wrap_client_init,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk.client",
+        object_name="ClaudeSDKClient",
+        method_name="connect",
+        is_async=True,
+        class_name="ClaudeSDKClient",
+        should_publish_span_context=True,
+        wrapper_function=wrap_async,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk.client",
+        object_name="ClaudeSDKClient",
+        method_name="query",
+        is_async=True,
+        class_name="ClaudeSDKClient",
+        should_publish_span_context=True,
+        wrapper_function=wrap_async,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk.client",
+        object_name="ClaudeSDKClient",
+        method_name="receive_messages",
+        # the wrapper is a plain function returning an async generator
+        is_async=False,
+        is_streaming=True,
+        class_name="ClaudeSDKClient",
+        wrapper_function=wrap_async_gen,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk.client",
+        object_name="ClaudeSDKClient",
+        method_name="receive_response",
+        is_async=False,
+        is_streaming=True,
+        class_name="ClaudeSDKClient",
+        wrapper_function=wrap_async_gen,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk.client",
+        object_name="ClaudeSDKClient",
+        method_name="interrupt",
+        is_async=True,
+        class_name="ClaudeSDKClient",
+        wrapper_function=wrap_async,
+    ),
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk.client",
+        object_name="ClaudeSDKClient",
+        method_name="disconnect",
+        is_async=True,
+        class_name="ClaudeSDKClient",
+        wrapper_function=wrap_async,
+    ),
+    # Module-level query function (streaming). `replace_aliases` is what makes
+    # `from claude_agent_sdk import query` pick up the wrapper regardless of
+    # import order -- previously this package carried its own private copy of
+    # that machinery; it now comes from BaseLaminarInstrumentor.
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk",
+        object_name=None,
+        method_name="query",
+        is_async=False,
+        is_streaming=True,
+        replace_aliases=True,
+        should_publish_span_context=True,
+        wrapper_function=wrap_query,
+    ),
+    # Module-level create_sdk_mcp_server function (sync)
+    ClaudeAgentSpec(
+        package_name="claude_agent_sdk",
+        object_name=None,
+        method_name="create_sdk_mcp_server",
+        is_async=False,
+        replace_aliases=True,
+        wrapper_function=wrap_sync,
+    ),
 ]
 
-_MODULE_FUNCTION_ORIGINALS: dict[tuple[str, str], Any] = {}
 
-
-def _replace_function_aliases(original, wrapped):
-    for module in list(sys.modules.values()):
-        module_dict = getattr(module, "__dict__", None)
-        if not module_dict:
-            continue
-        for attr, value in list(module_dict.items()):
-            if value is original:
-                setattr(module, attr, wrapped)
-
-
-def _wrap_module_function(module_name: str, function_name: str, wrapper):
-    try:
-        module = sys.modules.get(module_name) or importlib.import_module(module_name)
-    except ModuleNotFoundError:
-        return
-
-    try:
-        original = getattr(module, function_name)
-    except AttributeError:
-        return
-
-    key = (module_name, function_name)
-    if key not in _MODULE_FUNCTION_ORIGINALS:
-        _MODULE_FUNCTION_ORIGINALS[key] = original
-
-    wrapped_function = FunctionWrapper(original, wrapper)
-    setattr(module, function_name, wrapped_function)
-    _replace_function_aliases(original, wrapped_function)
-
-
-def _unwrap_module_function(module_name: str, function_name: str):
-    key = (module_name, function_name)
-    original = _MODULE_FUNCTION_ORIGINALS.get(key)
-    if not original:
-        return
-
-    module = sys.modules.get(module_name)
-    if not module:
-        return
-
-    current = getattr(module, function_name, None)
-    setattr(module, function_name, original)
-    if current is not None:
-        _replace_function_aliases(current, original)
-    del _MODULE_FUNCTION_ORIGINALS[key]
-
-
-class ClaudeAgentInstrumentor(BaseInstrumentor):
-    def __init__(self):
-        super().__init__()
+class ClaudeAgentInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        # Wrap methods
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            wrapper_func = wrapped_method.get("wrapper")
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                sdk_version = version("claude-agent-sdk")
+            except Exception as e:
+                logger.debug(f"Failed to get claude-agent-sdk version {e}")
+                sdk_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="claude-agent-sdk",
+                version=sdk_version,
+            )
+        return self._scope
 
-            # Create wrapper instance with metadata
-            wrapper = wrapper_func(wrapped_method)
-
-            if wrap_object:
-                target = f"{wrap_object}.{wrap_method}"
-                try:
-                    wrap_function_wrapper(
-                        wrap_package,
-                        target,
-                        wrapper,
-                    )
-                except (ModuleNotFoundError, AttributeError):
-                    pass  # that's ok, we don't want to fail if some methods do not exist
-            else:
-                try:
-                    _wrap_module_function(
-                        wrap_package,
-                        wrap_method,
-                        wrapper,
-                    )
-                except (ModuleNotFoundError, AttributeError):
-                    pass  # that's ok
-
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
-            if wrap_object:
-                module_path = f"{wrap_package}.{wrap_object}"
-                try:
-                    unwrap(module_path, wrap_method)
-                except (ModuleNotFoundError, AttributeError):
-                    pass  # that's ok, we don't want to fail if some methods do not exist
-            else:
-                _unwrap_module_function(wrap_package, wrap_method)
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/span_utils.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/span_utils.py
@@ -1,6 +1,6 @@
 """Span utilities for Claude Agent instrumentation."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lmnr import Laminar
 from lmnr.opentelemetry_lib.tracing import get_current_context
@@ -11,13 +11,16 @@ from lmnr.sdk.utils import get_input_from_func_args, is_method, json_dumps
 from opentelemetry import trace
 from opentelemetry.sdk.trace import ReadableSpan
 
+if TYPE_CHECKING:
+    from .types import ClaudeAgentSpec
+
 logger = get_default_logger(__name__)
 
 
-def span_name(to_wrap: dict[str, str]) -> str:
+def span_name(to_wrap: "ClaudeAgentSpec") -> str:
     """Generate span name from method metadata."""
     class_name = to_wrap.get("class_name")
-    method = to_wrap.get("method")
+    method = to_wrap["method_name"]
     return f"{class_name}.{method}" if class_name else method
 
 

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/types.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/types.py
@@ -1,0 +1,17 @@
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    WrappedFunctionSpec,
+)
+
+
+class ClaudeAgentSpec(WrappedFunctionSpec, total=False):
+    """claude-agent-sdk's per-method extras.
+
+    `class_name` is what the span is named after (`"{class_name}.{method_name}"`),
+    which is not always the same as `object_name` — the module-level `query` and
+    `create_sdk_mcp_server` rows have no class at all and fall back to the bare
+    method name. `should_publish_span_context` marks the calls that must hand the
+    current span context to the CLI subprocess so its spans nest under ours.
+    """
+
+    class_name: str
+    should_publish_span_context: bool

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -2,14 +2,18 @@
 
 import asyncio
 import os
-from typing import Any
+from typing import Any, Sequence
 
 from lmnr import Laminar
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    add_spec_wrapper,
+)
 from lmnr.sdk.log import get_default_logger
 
 from opentelemetry.trace import Status, StatusCode
 
 from .proxy import create_proxy_for_transport, start_proxy, stop_proxy, _release_port
+from .types import ClaudeAgentSpec
 from .span_utils import (
     span_name,
     record_input,
@@ -40,116 +44,125 @@ logger = get_default_logger(__name__)
 DEFAULT_CLEANUP_TIMEOUT = 4.0
 
 
-def wrap_sync(to_wrap: dict[str, Any]):
+def wrap_sync(
+    to_wrap: ClaudeAgentSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     """Wrapper for synchronous methods."""
 
-    def wrapper(wrapped, instance, args, kwargs):
-        with Laminar.start_as_current_span(
-            span_name(to_wrap),
-            span_type=to_wrap.get("span_type", "DEFAULT"),
-        ) as span:
-            record_input(span, wrapped, args, kwargs)
+    with Laminar.start_as_current_span(
+        span_name(to_wrap),
+        span_type=to_wrap.get("span_type", "DEFAULT"),
+    ) as span:
+        record_input(span, wrapped, args, kwargs)
 
-            try:
-                result = wrapped(*args, **kwargs)
-            except Exception as e:  # pylint: disable=broad-except
-                span.set_status(Status(StatusCode.ERROR))
-                span.record_exception(e)
-                raise
+        try:
+            result = wrapped(*args, **kwargs)
+        except Exception as e:  # pylint: disable=broad-except
+            span.set_status(Status(StatusCode.ERROR))
+            span.record_exception(e)
+            raise
 
-            record_output(span, to_wrap, result)
-            return result
-
-    return wrapper
+        record_output(span, to_wrap, result)
+        return result
 
 
-def wrap_async(to_wrap: dict[str, Any]):
+async def wrap_async(
+    to_wrap: ClaudeAgentSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     """Wrapper for async methods."""
 
-    async def wrapper(wrapped, instance, args, kwargs):
-        with Laminar.start_as_current_span(
+    with Laminar.start_as_current_span(
+        span_name(to_wrap),
+        span_type=to_wrap.get("span_type", "DEFAULT"),
+    ) as span:
+        record_input(span, wrapped, args, kwargs)
+
+        if to_wrap.get("should_publish_span_context"):
+            # Get transport from instance (ClaudeSDKClient._transport)
+            if hasattr(instance, "_transport"):
+                publish_span_context_for_transport(instance._transport)
+
+        try:
+            result = await wrapped(*args, **kwargs)
+        except Exception as e:  # pylint: disable=broad-except
+            span.set_status(Status(StatusCode.ERROR))
+            span.record_exception(e)
+            raise
+
+        record_output(span, to_wrap, result)
+
+        return result
+
+
+def wrap_async_gen(
+    to_wrap: ClaudeAgentSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
+    """Wrapper for async generator methods (streaming)."""
+
+    async def generator():
+        span = Laminar.start_span(
             span_name(to_wrap),
             span_type=to_wrap.get("span_type", "DEFAULT"),
-        ) as span:
-            record_input(span, wrapped, args, kwargs)
+        )
+        collected = []
+        async_iter = None
 
-            if to_wrap.get("should_publish_span_context"):
-                # Get transport from instance (ClaudeSDKClient._transport)
+        if to_wrap.get("should_publish_span_context"):
+            with Laminar.use_span(span):
                 if hasattr(instance, "_transport"):
                     publish_span_context_for_transport(instance._transport)
 
-            try:
-                result = await wrapped(*args, **kwargs)
-            except Exception as e:  # pylint: disable=broad-except
+        try:
+            with Laminar.use_span(span):
+                record_input(span, wrapped, args, kwargs)
+                async_source = wrapped(*args, **kwargs)
+                async_iter = (
+                    async_source.__aiter__()
+                    if hasattr(async_source, "__aiter__")
+                    else async_source
+                )
+
+            while True:
+                try:
+                    with Laminar.use_span(
+                        span, record_exception=False, set_status_on_exception=False
+                    ):
+                        item = await async_iter.__anext__()
+                        collected.append(item)
+                except StopAsyncIteration:
+                    break
+                yield item
+        except GeneratorExit:
+            # User broke out of the loop - this is normal, don't record as error
+            raise
+        except asyncio.CancelledError:
+            # Request was cancelled (e.g., FastAPI client disconnect)
+            # Don't record as error, just propagate
+            raise
+        except Exception as e:  # pylint: disable=broad-except
+            with Laminar.use_span(span):
                 span.set_status(Status(StatusCode.ERROR))
                 span.record_exception(e)
-                raise
+            raise
+        finally:
+            await _cleanup_async_iter(async_iter, span)
+            with Laminar.use_span(span):
+                record_output(span, to_wrap, collected)
+            span.end()
 
-            record_output(span, to_wrap, result)
-
-            return result
-
-    return wrapper
-
-
-def wrap_async_gen(to_wrap: dict[str, Any]):
-    """Wrapper for async generator methods (streaming)."""
-
-    def wrapper(wrapped, instance, args, kwargs):
-        async def generator():
-            span = Laminar.start_span(
-                span_name(to_wrap),
-                span_type=to_wrap.get("span_type", "DEFAULT"),
-            )
-            collected = []
-            async_iter = None
-
-            if to_wrap.get("should_publish_span_context"):
-                with Laminar.use_span(span):
-                    if hasattr(instance, "_transport"):
-                        publish_span_context_for_transport(instance._transport)
-
-            try:
-                with Laminar.use_span(span):
-                    record_input(span, wrapped, args, kwargs)
-                    async_source = wrapped(*args, **kwargs)
-                    async_iter = (
-                        async_source.__aiter__()
-                        if hasattr(async_source, "__aiter__")
-                        else async_source
-                    )
-
-                while True:
-                    try:
-                        with Laminar.use_span(
-                            span, record_exception=False, set_status_on_exception=False
-                        ):
-                            item = await async_iter.__anext__()
-                            collected.append(item)
-                    except StopAsyncIteration:
-                        break
-                    yield item
-            except GeneratorExit:
-                # User broke out of the loop - this is normal, don't record as error
-                raise
-            except asyncio.CancelledError:
-                # Request was cancelled (e.g., FastAPI client disconnect)
-                # Don't record as error, just propagate
-                raise
-            except Exception as e:  # pylint: disable=broad-except
-                with Laminar.use_span(span):
-                    span.set_status(Status(StatusCode.ERROR))
-                    span.record_exception(e)
-                raise
-            finally:
-                await _cleanup_async_iter(async_iter, span)
-                with Laminar.use_span(span):
-                    record_output(span, to_wrap, collected)
-                span.end()
-
-        return generator()
-
-    return wrapper
+    return generator()
 
 
 async def _cleanup_async_iter(async_iter, span) -> None:
@@ -177,128 +190,132 @@ async def _cleanup_async_iter(async_iter, span) -> None:
         pass
 
 
-def wrap_transport_connect(to_wrap: dict[str, Any]):
+async def wrap_transport_connect(
+    to_wrap: ClaudeAgentSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     """Wrap Transport.connect to start proxy before connecting."""
-
-    async def wrapper(wrapped, instance, args, kwargs):
-        try:
-            from claude_agent_sdk._internal.transport.subprocess_cli import (
-                SubprocessCLITransport,
-            )
-        except (ImportError, ModuleNotFoundError):
-            logger.warning(
-                "Failed to import SubprocessCLITransport, skipping proxy setup"
-            )
-            return await wrapped(*args, **kwargs)
-
-        # Read options.env BEFORE modifying to avoid circular proxy config
-        options = getattr(instance, "_options", None)
-        env_dict = options.env if options is not None else {}
-        session_cwd = getattr(options, "cwd", None)
-        # Read the DOCUMENTED options.setting_sources only. Do not try to infer
-        # the SDK's private skills-based default (_apply_skills_defaults narrows
-        # this to user,project) — that is an internal we must not track. Reading
-        # a layer the CLI ignored is a safe over-read for upstream resolution:
-        # the flag layer still forces every base URL to the proxy.
-        setting_sources = getattr(options, "setting_sources", None)
-        target_url = resolve_target_url_from_env(
-            env_dict,
-            cwd=session_cwd,
-            setting_sources=setting_sources,
-            # options.settings is the highest layer the CLI reads and
-            # apply_settings_proxy_override rewrites its base URLs to the proxy.
-            settings=getattr(options, "settings", None),
+    try:
+        from claude_agent_sdk._internal.transport.subprocess_cli import (
+            SubprocessCLITransport,
         )
+    except (ImportError, ModuleNotFoundError):
+        logger.warning(
+            "Failed to import SubprocessCLITransport, skipping proxy setup"
+        )
+        return await wrapped(*args, **kwargs)
 
-        if target_url is None:
-            raise RuntimeError("Invalid provider configuration")
+    # Read options.env BEFORE modifying to avoid circular proxy config
+    options = getattr(instance, "_options", None)
+    env_dict = options.env if options is not None else {}
+    session_cwd = getattr(options, "cwd", None)
+    # Read the DOCUMENTED options.setting_sources only. Do not try to infer
+    # the SDK's private skills-based default (_apply_skills_defaults narrows
+    # this to user,project) — that is an internal we must not track. Reading
+    # a layer the CLI ignored is a safe over-read for upstream resolution:
+    # the flag layer still forces every base URL to the proxy.
+    setting_sources = getattr(options, "setting_sources", None)
+    target_url = resolve_target_url_from_env(
+        env_dict,
+        cwd=session_cwd,
+        setting_sources=setting_sources,
+        # options.settings is the highest layer the CLI reads and
+        # apply_settings_proxy_override rewrites its base URLs to the proxy.
+        settings=getattr(options, "settings", None),
+    )
 
-        proxy = create_proxy_for_transport()
-        proxy_url = start_proxy(proxy, target_url=target_url)
+    if target_url is None:
+        raise RuntimeError("Invalid provider configuration")
 
-        # Custom transports use global env, SubprocessCLITransport uses options.env
-        is_custom = not isinstance(instance, SubprocessCLITransport)
+    proxy = create_proxy_for_transport()
+    proxy_url = start_proxy(proxy, target_url=target_url)
 
-        options_env_snapshot = {}
-        original_settings: Any = None
-        settings_overridden = False
-        if is_custom:
-            original_env = setup_proxy_env(proxy_url, session_cwd)
-            env_set_keys = {k for k, v in original_env.items() if v is not None}
-        else:
-            if options is not None:
-                options_env_snapshot = snapshot_options_env_for_proxy(options)
-                update_options_env_for_proxy(options, proxy_url, target_url)
-                original_settings = getattr(options, "settings", None)
-                settings_overridden = apply_settings_proxy_override(
-                    options, proxy_url
-                )
+    # Custom transports use global env, SubprocessCLITransport uses options.env
+    is_custom = not isinstance(instance, SubprocessCLITransport)
 
-            original_env = {}
-            env_set_keys = set()
+    options_env_snapshot = {}
+    original_settings: Any = None
+    settings_overridden = False
+    if is_custom:
+        original_env = setup_proxy_env(proxy_url, session_cwd)
+        env_set_keys = {k for k, v in original_env.items() if v is not None}
+    else:
+        if options is not None:
+            options_env_snapshot = snapshot_options_env_for_proxy(options)
+            update_options_env_for_proxy(options, proxy_url, target_url)
+            original_settings = getattr(options, "settings", None)
+            settings_overridden = apply_settings_proxy_override(
+                options, proxy_url
+            )
 
-            # Remove from os.environ (mutually exclusive with ANTHROPIC_BASE_URL)
-            if FOUNDRY_RESOURCE_ENV in os.environ:
-                original_env[FOUNDRY_RESOURCE_ENV] = os.environ[FOUNDRY_RESOURCE_ENV]
-                env_set_keys.add(FOUNDRY_RESOURCE_ENV)
-                os.environ.pop(FOUNDRY_RESOURCE_ENV)
+        original_env = {}
+        env_set_keys = set()
 
-            # Prevent subprocess from routing through corporate proxy
-            for proxy_var in PROXY_ENV_KEYS:
-                if proxy_var in os.environ:
-                    original_env[proxy_var] = os.environ[proxy_var]
-                    env_set_keys.add(proxy_var)
-                    os.environ.pop(proxy_var)
+        # Remove from os.environ (mutually exclusive with ANTHROPIC_BASE_URL)
+        if FOUNDRY_RESOURCE_ENV in os.environ:
+            original_env[FOUNDRY_RESOURCE_ENV] = os.environ[FOUNDRY_RESOURCE_ENV]
+            env_set_keys.add(FOUNDRY_RESOURCE_ENV)
+            os.environ.pop(FOUNDRY_RESOURCE_ENV)
 
-        context: dict[str, Any] = {
-            "proxy": proxy,
-            "proxy_url": proxy_url,
-            "is_custom_transport": is_custom,
-            "original_env": original_env,
-            "env_set_keys": env_set_keys,
-            "options_env_snapshot": options_env_snapshot,
-            "original_settings": original_settings,
-            "settings_overridden": settings_overridden,
-        }
+        # Prevent subprocess from routing through corporate proxy
+        for proxy_var in PROXY_ENV_KEYS:
+            if proxy_var in os.environ:
+                original_env[proxy_var] = os.environ[proxy_var]
+                env_set_keys.add(proxy_var)
+                os.environ.pop(proxy_var)
 
-        instance.__lmnr_context = context
-        instance.__lmnr_wrapped = True
+    context: dict[str, Any] = {
+        "proxy": proxy,
+        "proxy_url": proxy_url,
+        "is_custom_transport": is_custom,
+        "original_env": original_env,
+        "env_set_keys": env_set_keys,
+        "options_env_snapshot": options_env_snapshot,
+        "original_settings": original_settings,
+        "settings_overridden": settings_overridden,
+    }
+
+    instance.__lmnr_context = context
+    instance.__lmnr_wrapped = True
+
+    try:
+        result = await wrapped(*args, **kwargs)
+        publish_span_context_for_transport(instance)
+        return result
+    except Exception:
+        stop_proxy(proxy)
+
+        if original_env:
+            restore_env(original_env, env_set_keys or set())
+
+        if options_env_snapshot and options is not None:
+            restore_options_env_from_snapshot(options, options_env_snapshot)
+
+        if settings_overridden and options is not None:
+            options.settings = original_settings
 
         try:
-            result = await wrapped(*args, **kwargs)
-            publish_span_context_for_transport(instance)
-            return result
+            delattr(instance, "__lmnr_context")
         except Exception:
-            stop_proxy(proxy)
-
-            if original_env:
-                restore_env(original_env, env_set_keys or set())
-
-            if options_env_snapshot and options is not None:
-                restore_options_env_from_snapshot(options, options_env_snapshot)
-
-            if settings_overridden and options is not None:
-                options.settings = original_settings
-
-            try:
-                delattr(instance, "__lmnr_context")
-            except Exception:
-                pass
-            raise
-
-    return wrapper
+            pass
+        raise
 
 
-def wrap_transport_close(to_wrap: dict[str, Any]):
+async def wrap_transport_close(
+    to_wrap: ClaudeAgentSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     """Wrap Transport.close to stop proxy after closing."""
-
-    async def wrapper(wrapped, instance, args, kwargs):
-        try:
-            return await wrapped(*args, **kwargs)
-        finally:
-            await _cleanup_transport_context(instance)
-
-    return wrapper
+    try:
+        return await wrapped(*args, **kwargs)
+    finally:
+        await _cleanup_transport_context(instance)
 
 
 async def _cleanup_transport_context(instance) -> None:
@@ -524,87 +541,91 @@ def update_options_env_for_proxy(options, proxy_url: str, target_url: str) -> No
         options.env[VERTEX_BASE_URL_ENV] = proxy_url
 
 
-def wrap_query(to_wrap: dict[str, Any]):
+def wrap_query(
+    to_wrap: ClaudeAgentSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     """Wrap query() function - handles custom transport wrapping."""
+    transport = kwargs.get("transport")
 
-    def wrapper(wrapped, instance, args, kwargs):
-        transport = kwargs.get("transport")
-
-        if transport:
-            try:
-                from claude_agent_sdk._internal.transport.subprocess_cli import (
-                    SubprocessCLITransport,
-                )
-
-                if not isinstance(transport, SubprocessCLITransport):
-                    wrap_custom_transport_if_needed(transport)
-            except (ImportError, ModuleNotFoundError):
-                wrap_custom_transport_if_needed(transport)
-
-        async def generator():
-            with Laminar.start_as_current_span(
-                span_name(to_wrap),
-                span_type=to_wrap.get("span_type", "DEFAULT"),
-            ) as span:
-                record_input(span, wrapped, args, kwargs)
-
-                collected = []
-                async_iter = None
-                try:
-                    async_iter = wrapped(*args, **kwargs)
-
-                    async for item in async_iter:
-                        collected.append(item)
-                        yield item
-                except GeneratorExit:
-                    raise
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    span.set_status(Status(StatusCode.ERROR))
-                    span.record_exception(e)
-                    raise
-                finally:
-                    await _cleanup_async_iter(async_iter, span)
-                    record_output(span, to_wrap, collected)
-
-        return generator()
-
-    return wrapper
-
-
-def wrap_client_init(to_wrap: dict[str, Any]):
-    """Wrap ClaudeSDKClient.__init__ to handle custom transport wrapping."""
-
-    def wrapper(wrapped, instance, args, kwargs):
+    if transport:
         try:
             from claude_agent_sdk._internal.transport.subprocess_cli import (
                 SubprocessCLITransport,
             )
+
+            if not isinstance(transport, SubprocessCLITransport):
+                wrap_custom_transport_if_needed(transport)
         except (ImportError, ModuleNotFoundError):
-            logger.warning(
-                "Failed to import SubprocessCLITransport, skipping proxy setup"
-            )
-            return wrapped(*args, **kwargs)
-
-        transport = None
-        if args and len(args) > 1:
-            transport = args[1]
-        if "transport" in kwargs:
-            transport = kwargs["transport"]
-
-        # If user provided a custom transport, wrap it for proxy lifecycle
-        # SubprocessCLITransport is already wrapped globally
-        if transport and not isinstance(transport, SubprocessCLITransport):
             wrap_custom_transport_if_needed(transport)
 
-        # Note: We don't pre-configure proxy URL here because we don't know the port
-        # until the proxy is actually created in wrap_transport_connect
+    async def generator():
+        with Laminar.start_as_current_span(
+            span_name(to_wrap),
+            span_type=to_wrap.get("span_type", "DEFAULT"),
+        ) as span:
+            record_input(span, wrapped, args, kwargs)
 
-        # Call original init
+            collected = []
+            async_iter = None
+            try:
+                async_iter = wrapped(*args, **kwargs)
+
+                async for item in async_iter:
+                    collected.append(item)
+                    yield item
+            except GeneratorExit:
+                raise
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                span.set_status(Status(StatusCode.ERROR))
+                span.record_exception(e)
+                raise
+            finally:
+                await _cleanup_async_iter(async_iter, span)
+                record_output(span, to_wrap, collected)
+
+    return generator()
+
+
+def wrap_client_init(
+    to_wrap: ClaudeAgentSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
+    """Wrap ClaudeSDKClient.__init__ to handle custom transport wrapping."""
+    try:
+        from claude_agent_sdk._internal.transport.subprocess_cli import (
+            SubprocessCLITransport,
+        )
+    except (ImportError, ModuleNotFoundError):
+        logger.warning(
+            "Failed to import SubprocessCLITransport, skipping proxy setup"
+        )
         return wrapped(*args, **kwargs)
 
-    return wrapper
+    transport = None
+    if args and len(args) > 1:
+        transport = args[1]
+    if "transport" in kwargs:
+        transport = kwargs["transport"]
+
+    # If user provided a custom transport, wrap it for proxy lifecycle
+    # SubprocessCLITransport is already wrapped globally
+    if transport and not isinstance(transport, SubprocessCLITransport):
+        wrap_custom_transport_if_needed(transport)
+
+    # Note: We don't pre-configure proxy URL here because we don't know the port
+    # until the proxy is actually created in wrap_transport_connect
+
+    # Call original init
+    return wrapped(*args, **kwargs)
 
 
 def wrap_custom_transport_if_needed(transport):
@@ -620,8 +641,28 @@ def wrap_custom_transport_if_needed(transport):
 
     transport.__lmnr_wrapped = True
 
-    connect_wrapper = wrap_transport_connect({"is_transport_connect": True})
-    close_wrapper = wrap_transport_close({"is_transport_close": True})
+    # A custom transport is wrapped per-instance at runtime, so it has no row in
+    # WRAPPED_FUNCTIONS. `add_spec_wrapper` is the same adapter the instrumentor
+    # uses, binding a spec so the handler still gets the wrapt-shaped call.
+    # Neither transport handler reads the spec, so a minimal one is enough.
+    connect_wrapper = add_spec_wrapper(
+        wrap_transport_connect,
+        ClaudeAgentSpec(
+            package_name="",
+            method_name="connect",
+            is_async=True,
+            wrapper_function=wrap_transport_connect,
+        ),
+    )
+    close_wrapper = add_spec_wrapper(
+        wrap_transport_close,
+        ClaudeAgentSpec(
+            package_name="",
+            method_name="close",
+            is_async=True,
+            wrapper_function=wrap_transport_close,
+        ),
+    )
 
     original_connect = transport.connect
     original_close = transport.close

--- a/tests/test_instrumentations/test_claude_agent/test_proxy_env.py
+++ b/tests/test_instrumentations/test_claude_agent/test_proxy_env.py
@@ -3,6 +3,9 @@
 import os
 from unittest.mock import patch
 
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    add_spec_wrapper,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (
     proxy as claude_proxy,
     utils as claude_utils,
@@ -293,8 +296,8 @@ def test_subprocess_transport_removes_proxy_vars_from_os_environ(monkeypatch):
     original_connect = AsyncMock(side_effect=mock_connect)
 
     # Create wrapper
-    to_wrap = {"original": original_connect}
-    wrapper = wrap_transport_connect(to_wrap)
+    to_wrap = {"method_name": "connect", "original": original_connect}
+    wrapper = add_spec_wrapper(wrap_transport_connect, to_wrap)
 
     # Mock proxy functions
     from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (

--- a/tests/test_instrumentations/test_claude_agent/test_proxy_unit.py
+++ b/tests/test_instrumentations/test_claude_agent/test_proxy_unit.py
@@ -9,6 +9,9 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 import pytest
 
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    add_spec_wrapper,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (
     proxy as claude_proxy,
     utils as claude_utils,
@@ -516,8 +519,13 @@ def test_wrap_query_does_not_double_wrap_subprocess_transport():
 
     wrapped_query = AsyncMock(side_effect=mock_query)
 
-    # Create the wrapper
-    wrapper = wrappers_module.wrap_query({"method": "query", "span_type": "DEFAULT"})
+    # Create the wrapper. The wrappers are no longer closure factories; they are
+    # spec-first handlers adapted by `add_spec_wrapper`, exactly as the
+    # instrumentor does it.
+    wrapper = add_spec_wrapper(
+        wrappers_module.wrap_query,
+        {"method_name": "query", "span_type": "DEFAULT"},
+    )
 
     # Call the wrapper with a SubprocessCLITransport
     kwargs = {"prompt": "test", "transport": mock_transport}
@@ -563,7 +571,10 @@ def test_wrap_client_init_does_not_double_wrap_subprocess_transport():
     mock_init = MagicMock()
 
     # Create the wrapper
-    wrapper = wrap_client_init({"method": "__init__", "class_name": "ClaudeSDKClient"})
+    wrapper = add_spec_wrapper(
+        wrap_client_init,
+        {"method_name": "__init__", "class_name": "ClaudeSDKClient"},
+    )
 
     # Call the wrapper with a SubprocessCLITransport
     kwargs = {"transport": mock_transport}

--- a/tests/test_instrumentor_targets.py
+++ b/tests/test_instrumentor_targets.py
@@ -11,6 +11,7 @@ the migration actually moves.
 """
 
 import importlib
+import sys
 
 import pytest
 
@@ -32,6 +33,30 @@ INSTRUMENTOR_TARGETS: dict[str, tuple[str, str, set[tuple[str, str]]]] = {
         {
             ("langgraph.pregel", "Pregel.stream"),
             ("langgraph.pregel", "Pregel.astream"),
+        },
+    ),
+    "claude_agent": (
+        "lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent",
+        "ClaudeAgentInstrumentor",
+        {
+            (
+                "claude_agent_sdk._internal.transport.subprocess_cli",
+                "SubprocessCLITransport.connect",
+            ),
+            (
+                "claude_agent_sdk._internal.transport.subprocess_cli",
+                "SubprocessCLITransport.close",
+            ),
+            ("claude_agent_sdk.client", "ClaudeSDKClient.__init__"),
+            ("claude_agent_sdk.client", "ClaudeSDKClient.connect"),
+            ("claude_agent_sdk.client", "ClaudeSDKClient.query"),
+            ("claude_agent_sdk.client", "ClaudeSDKClient.receive_messages"),
+            ("claude_agent_sdk.client", "ClaudeSDKClient.receive_response"),
+            ("claude_agent_sdk.client", "ClaudeSDKClient.interrupt"),
+            ("claude_agent_sdk.client", "ClaudeSDKClient.disconnect"),
+            # the two module-level functions, wrapped via alias replacement
+            ("claude_agent_sdk", "query"),
+            ("claude_agent_sdk", "create_sdk_mcp_server"),
         },
     ),
     # NOTE: skyvern is deliberately absent. It is also migrated, but its
@@ -152,6 +177,51 @@ def test_uninstrument_restores_the_original_attribute(reinstrumented):
             f"did not restore {module_name}.{target} to the original function"
         )
 
+
+
+def test_claude_agent_alias_replacement_reaches_prior_from_imports():
+    """claude_agent carried its own private copy of the alias-replacement
+    machinery; it now uses `BaseLaminarInstrumentor`'s. The behaviour that copy
+    existed for: a caller who did `from claude_agent_sdk import query` BEFORE
+    instrumentation still ends up with the wrapped function, and gets the
+    original back on uninstrument.
+    """
+    import claude_agent_sdk
+
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.claude_agent import (
+        ClaudeAgentInstrumentor,
+    )
+
+    instrumentor = ClaudeAgentInstrumentor()
+    was_instrumented = instrumentor.is_instrumented_by_opentelemetry
+    try:
+        if was_instrumented:
+            instrumentor.uninstrument()
+
+        # a module that grabbed its own reference before we instrumented
+        import types
+
+        consumer = types.ModuleType("_lmnr_claude_consumer")
+        consumer.query = claude_agent_sdk.query
+        sys.modules["_lmnr_claude_consumer"] = consumer
+        original = consumer.query
+
+        instrumentor.instrument()
+        assert consumer.query is not original, (
+            "alias replacement did not reach a pre-existing `from ... import query`"
+        )
+        assert hasattr(consumer.query, "__wrapped__")
+
+        instrumentor.uninstrument()
+        assert consumer.query is original, (
+            "alias replacement did not restore the pre-existing reference"
+        )
+    finally:
+        sys.modules.pop("_lmnr_claude_consumer", None)
+        if instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
+        if was_instrumented:
+            instrumentor.instrument()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Refactors how SDK methods and module-level functions are patched (including proxy/env lifecycle), but behavior is pinned by instrumentor target and alias-replacement tests; regressions would mainly show up as missed wraps or broken uninstrument/restore.
> 
> **Overview**
> **Migrates Claude Agent SDK instrumentation** from a custom `BaseInstrumentor` with hand-rolled wrap/unwrap loops to the shared **`BaseLaminarInstrumentor`** + declarative **`WRAPPED_FUNCTIONS`** table.
> 
> The old dict-based `WRAPPED_METHODS` list becomes typed **`ClaudeAgentSpec`** rows (with `is_async`, `is_streaming`, `replace_aliases`, and `should_publish_span_context`). Module-level `query` and `create_sdk_mcp_server` now rely on **`replace_aliases=True`** on the base instrumentor instead of local `_wrap_module_function` / alias-replacement helpers that were deleted from `__init__.py`.
> 
> **Wrapper functions** are no longer closure factories that return wrapt callbacks; they are spec-first handlers `(spec, wrapped, instance, args, kwargs)` wired through **`add_spec_wrapper`**, matching other migrated instrumentors. Dynamic custom-transport wrapping uses the same adapter.
> 
> Adds **`instrumentation_scope()`** (claude-agent-sdk name/version) and extends **characterization tests** (`INSTRUMENTOR_TARGETS` for claude_agent, alias-replacement test for pre-imported `query` references). Unit tests now build wrappers via `add_spec_wrapper` like production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 038f6a2a7a947a981e5dd882390258cfbed9a677. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->