### PR TITLE
move browser wrappers to new shape

### DIFF
--- a/src/lmnr/sdk/browser/browser_use_cdp_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_cdp_otel.py
@@ -1,19 +1,36 @@
 import asyncio
 import uuid
+from importlib.metadata import version
+from typing import Any, Sequence
 
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-from lmnr.sdk.utils import with_tracer_and_client_wrapper
-from lmnr.version import __version__
+from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.browser.cdp_utils import (
     start_recording_events,
     take_full_snapshot,
 )
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import get_tracer, Tracer
 from typing import Collection
-from wrapt import wrap_function_wrapper
+
+logger = get_default_logger(__name__)
+
+
+class BrowserUseCdpSpec(WrappedFunctionSpec, total=False):
+    """browser-use CDP's per-method extra.
+
+    `action` selects what `process_wrapped_result` does with the return value —
+    these wrappers open no spans, they bootstrap session recording.
+    """
+
+    action: str
 
 # Stable versions, e.g. 0.6.0, satisfy this condition too
 _instruments = ("browser-use >= 0.6.0rc1",)
@@ -23,20 +40,6 @@ _instruments = ("browser-use >= 0.6.0rc1",)
 # so this must be a fast O(1) lookup instead of a CDP evaluate call.
 _initialized_sessions: set[str] = set()
 
-WRAPPED_METHODS = [
-    {
-        "package": "browser_use.browser.session",
-        "object": "BrowserSession",
-        "method": "get_or_create_cdp_session",
-        "action": "inject_session_recorder",
-    },
-    {
-        "package": "browser_use.browser.session",
-        "object": "BrowserSession",
-        "method": "on_SwitchTabEvent",
-        "action": "take_full_snapshot",
-    },
-]
 
 
 async def process_wrapped_result(result, instance, client, to_wrap):
@@ -62,9 +65,14 @@ async def process_wrapped_result(result, instance, client, to_wrap):
             await take_full_snapshot(cdp_session)
 
 
-@with_tracer_and_client_wrapper
 async def _wrap(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: BrowserUseCdpSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     result = await wrapped(*args, **kwargs)
     asyncio.create_task(process_wrapped_result(result, instance, client, to_wrap))
@@ -72,43 +80,62 @@ async def _wrap(
     return result
 
 
-class BrowserUseInstrumentor(BaseInstrumentor):
+WRAPPED_FUNCTIONS: list[BrowserUseCdpSpec] = [
+    BrowserUseCdpSpec(
+        package_name="browser_use.browser.session",
+        object_name="BrowserSession",
+        method_name="get_or_create_cdp_session",
+        is_async=True,
+        action="inject_session_recorder",
+        wrapper_function=_wrap,
+    ),
+    BrowserUseCdpSpec(
+        package_name="browser_use.browser.session",
+        object_name="BrowserSession",
+        method_name="on_SwitchTabEvent",
+        is_async=True,
+        action="take_full_snapshot",
+        wrapper_function=_wrap,
+    ),
+]
+
+
+class BrowserUseInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
+
     def __init__(self, async_client: AsyncLaminarClient):
         super().__init__()
         self.async_client = async_client
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap(
-                        tracer,
-                        self.async_client,
-                        wrapped_method,
-                    ),
-                )
-            except (ModuleNotFoundError, ImportError):
-                pass  # that's ok, we're not instrumenting everything
+                bu_version = version("browser-use")
+            except Exception as e:
+                logger.debug(f"Failed to get browser-use version {e}")
+                bu_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="browser-use",
+                version=bu_version,
+            )
+        return self._scope
+
+    def wrapper_kwargs(self) -> dict[str, Any]:
+        # The client is instrumentor-level, not per-method, so it rides the
+        # base's handler-kwargs channel rather than being stuffed into each spec.
+        return {"client": self.async_client}
 
     def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
-            unwrap(
-                f"{wrap_package}.{wrap_object}" if wrap_object else wrap_package,
-                wrap_method,
-            )
+        super()._uninstrument(**kwargs)
+        # Session ids must not outlive the instrumentation: a stale entry would
+        # make a later run skip recorder injection for a reused session id.
+        _initialized_sessions.clear()

--- a/src/lmnr/sdk/browser/browser_use_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_otel.py
@@ -1,14 +1,34 @@
-from lmnr import Laminar
-from lmnr.sdk.utils import with_tracer_wrapper
-from lmnr.sdk.utils import get_input_from_func_args, json_dumps
-from lmnr.version import __version__
+from importlib.metadata import version
+from typing import Any, Collection, Sequence
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import get_tracer, Tracer
-from typing import Collection
-from wrapt import wrap_function_wrapper
 import pydantic
+
+from lmnr import Laminar
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
+from lmnr.sdk.log import get_default_logger
+from lmnr.sdk.utils import get_input_from_func_args, json_dumps
+
+logger = get_default_logger(__name__)
+
+
+class BrowserUseSpec(WrappedFunctionSpec, total=False):
+    """browser-use's per-method extras.
+
+    Both flags are True on every current row, so the input/output recording
+    below is effectively disabled — the wrapper reconstructs what it needs from
+    the call arguments instead. They are kept because they are read per-row and
+    a future row may want the default behaviour.
+    """
+
+    ignore_input: bool
+    ignore_output: bool
 
 try:
     from browser_use import AgentHistoryList
@@ -21,52 +41,20 @@ except ImportError as e:
 
 _instruments = ("browser-use < 0.5.0",)
 
-WRAPPED_METHODS = [
-    {
-        "package": "browser_use.agent.service",
-        "object": "Agent",
-        "method": "run",
-        "span_name": "agent.run",
-        "ignore_input": True,
-        "ignore_output": True,
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "browser_use.agent.service",
-        "object": "Agent",
-        "method": "step",
-        "span_name": "agent.step",
-        "ignore_input": True,
-        "ignore_output": True,
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "browser_use.controller.service",
-        "object": "Controller",
-        "method": "act",
-        "span_name": "controller.act",
-        "ignore_input": True,
-        "ignore_output": True,
-        "span_type": "DEFAULT",
-    },
-    {
-        "package": "browser_use.controller.registry.service",
-        "object": "Registry",
-        "method": "execute_action",
-        "ignore_input": True,
-        "ignore_output": True,
-        "span_type": "TOOL",
-    },
-]
 
 
-@with_tracer_wrapper
-async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
+async def _wrap(
+    to_wrap: BrowserUseSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     span_name = to_wrap.get("span_name")
     attributes = {
         "lmnr.span.type": to_wrap.get("span_type"),
     }
-    if to_wrap.get("method") == "execute_action":
+    if to_wrap["method_name"] == "execute_action":
         span_name = args[0] if len(args) > 0 else kwargs.get("action_name", "action")
         attributes["lmnr.span.input"] = json_dumps(
             {
@@ -78,10 +66,10 @@ async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         if not to_wrap.get("ignore_input"):
             inp_dict = get_input_from_func_args(wrapped, True, args, kwargs)
             # Add task to the `agent.run` span input
-            if to_wrap.get("method") == "run" and hasattr(instance, "task"):
+            if to_wrap["method_name"] == "run" and hasattr(instance, "task"):
                 inp_dict["task"] = instance.task
             attributes["lmnr.span.input"] = json_dumps(inp_dict)
-    if to_wrap.get("method") == "step" and to_wrap.get("object") == "Agent":
+    if to_wrap["method_name"] == "step" and to_wrap.get("object_name") == "Agent":
         # Add step number to the `agent.step` span name
         step_info = kwargs.get("step_info", args[0] if len(args) > 0 else None)
         if step_info and hasattr(step_info, "step_number"):
@@ -102,41 +90,77 @@ async def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         return result
 
 
-class BrowserUseLegacyInstrumentor(BaseInstrumentor):
-    def __init__(self):
-        super().__init__()
+WRAPPED_FUNCTIONS: list[BrowserUseSpec] = [
+    BrowserUseSpec(
+        package_name="browser_use.agent.service",
+        object_name="Agent",
+        method_name="run",
+        is_async=True,
+        span_name="agent.run",
+        span_type="DEFAULT",
+        ignore_input=True,
+        ignore_output=True,
+        wrapper_function=_wrap,
+    ),
+    BrowserUseSpec(
+        package_name="browser_use.agent.service",
+        object_name="Agent",
+        method_name="step",
+        is_async=True,
+        span_name="agent.step",
+        span_type="DEFAULT",
+        ignore_input=True,
+        ignore_output=True,
+        wrapper_function=_wrap,
+    ),
+    BrowserUseSpec(
+        package_name="browser_use.controller.service",
+        object_name="Controller",
+        method_name="act",
+        is_async=True,
+        span_name="controller.act",
+        span_type="DEFAULT",
+        ignore_input=True,
+        ignore_output=True,
+        wrapper_function=_wrap,
+    ),
+    BrowserUseSpec(
+        package_name="browser_use.controller.registry.service",
+        object_name="Registry",
+        method_name="execute_action",
+        is_async=True,
+        span_type="TOOL",
+        ignore_input=True,
+        ignore_output=True,
+        wrapper_function=_wrap,
+    ),
+]
+
+
+class BrowserUseLegacyInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap(
-                        tracer,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we're not instrumenting everything
-
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
-            unwrap(
-                f"{wrap_package}.{wrap_object}" if wrap_object else wrap_package,
-                wrap_method,
+                bu_version = version("browser-use")
+            except Exception as e:
+                logger.debug(f"Failed to get browser-use version {e}")
+                bu_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="browser-use",
+                version=bu_version,
             )
+        return self._scope
+
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )

--- a/src/lmnr/sdk/browser/bubus_otel.py
+++ b/src/lmnr/sdk/browser/bubus_otel.py
@@ -1,11 +1,17 @@
-from typing import Collection
+from importlib.metadata import version
+from typing import Any, Collection, Sequence
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
 from opentelemetry.trace import NonRecordingSpan, get_current_span
-from wrapt import wrap_function_wrapper
 
 from lmnr import Laminar
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.tracing.context import get_current_context
 from lmnr.sdk.log import get_default_logger
 
@@ -14,7 +20,13 @@ event_id_to_span_context = {}
 logger = get_default_logger(__name__)
 
 
-def wrap_dispatch(wrapped, instance, args, kwargs):
+def wrap_dispatch(
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     event = args[0] if args and len(args) > 0 else kwargs.get("event", None)
     if event and hasattr(event, "event_id"):
         event_id = event.event_id
@@ -24,7 +36,13 @@ def wrap_dispatch(wrapped, instance, args, kwargs):
     return wrapped(*args, **kwargs)
 
 
-async def wrap_process_event(wrapped, instance, args, kwargs):
+async def wrap_process_event(
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     event = args[0] if args and len(args) > 0 else kwargs.get("event", None)
     span_context = None
     if event and hasattr(event, "event_id"):
@@ -39,32 +57,62 @@ async def wrap_process_event(wrapped, instance, args, kwargs):
         return await wrapped(*args, **kwargs)
 
 
-class BubusInstrumentor(BaseInstrumentor):
-    def __init__(self):
-        super().__init__()
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="bubus.service",
+        object_name="EventBus",
+        method_name="dispatch",
+        is_async=False,
+        wrapper_function=wrap_dispatch,
+    ),
+    WrappedFunctionSpec(
+        package_name="bubus.service",
+        object_name="EventBus",
+        method_name="process_event",
+        is_async=True,
+        wrapper_function=wrap_process_event,
+    ),
+]
+
+
+class BubusInstrumentor(BaseLaminarInstrumentor):
+    """Context-propagation shim, not telemetry.
+
+    These wrappers open no spans: `dispatch` stashes the current span context
+    against the event id, and `process_event` re-attaches it so work done on the
+    bus's own task still nests under the dispatching trace.
+    """
+
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        try:
-            wrap_function_wrapper("bubus.service", "EventBus.dispatch", wrap_dispatch)
-        except (ModuleNotFoundError, ImportError):
-            pass
-        try:
-            wrap_function_wrapper(
-                "bubus.service", "EventBus.process_event", wrap_process_event
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                bubus_version = version("bubus")
+            except Exception as e:
+                logger.debug(f"Failed to get bubus version {e}")
+                bubus_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="bubus",
+                version=bubus_version,
             )
-        except (ModuleNotFoundError, ImportError):
-            pass
+        return self._scope
+
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def _uninstrument(self, **kwargs):
-        try:
-            unwrap("bubus.service.EventBus", "dispatch")
-        except (ModuleNotFoundError, ImportError):
-            pass
-        try:
-            unwrap("bubus.service.EventBus", "process_event")
-        except (ModuleNotFoundError, ImportError):
-            pass
+        super()._uninstrument(**kwargs)
+        # This map is the whole point of the instrumentation, so it must not
+        # outlive it — a stale entry would re-parent a later event onto a span
+        # from a previous run.
         event_id_to_span_context.clear()

--- a/src/lmnr/sdk/browser/patchright_otel.py
+++ b/src/lmnr/sdk/browser/patchright_otel.py
@@ -1,155 +1,72 @@
-from lmnr.sdk.browser.playwright_otel import (
-    _wrap_bring_to_front_async,
-    _wrap_bring_to_front_sync,
-    _wrap_new_browser_sync,
-    _wrap_new_browser_async,
-    _wrap_new_context_sync,
-    _wrap_new_context_async,
+from importlib.metadata import version
+from typing import Any, Collection
+
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
+from lmnr.sdk.browser.playwright_otel import WRAPPED_FUNCTIONS as PLAYWRIGHT_FUNCTIONS
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import get_tracer
-from lmnr.version import __version__
-from typing import Collection
-from wrapt import wrap_function_wrapper
+from lmnr.sdk.log import get_default_logger
+
+logger = get_default_logger(__name__)
 
 _instruments = ("patchright >= 1.9.0",)
 
-WRAPPED_METHODS = [
-    {
-        "package": "patchright.sync_api",
-        "object": "BrowserType",
-        "method": "launch",
-        "wrapper": _wrap_new_browser_sync,
-    },
-    {
-        "package": "patchright.sync_api",
-        "object": "BrowserType",
-        "method": "connect",
-        "wrapper": _wrap_new_browser_sync,
-    },
-    {
-        "package": "patchright.sync_api",
-        "object": "BrowserType",
-        "method": "connect_over_cdp",
-        "wrapper": _wrap_new_browser_sync,
-    },
-    {
-        "package": "patchright.sync_api",
-        "object": "Browser",
-        "method": "new_context",
-        "wrapper": _wrap_new_context_sync,
-    },
-    {
-        "package": "patchright.sync_api",
-        "object": "BrowserType",
-        "method": "launch_persistent_context",
-        "wrapper": _wrap_new_context_sync,
-    },
-    {
-        "package": "patchright.sync_api",
-        "object": "Page",
-        "method": "bring_to_front",
-        "wrapper": _wrap_bring_to_front_sync,
-    },
-]
 
-WRAPPED_METHODS_ASYNC = [
-    {
-        "package": "patchright.async_api",
-        "object": "BrowserType",
-        "method": "launch",
-        "wrapper": _wrap_new_browser_async,
-    },
-    {
-        "package": "patchright.async_api",
-        "object": "BrowserType",
-        "method": "connect",
-        "wrapper": _wrap_new_browser_async,
-    },
-    {
-        "package": "patchright.async_api",
-        "object": "BrowserType",
-        "method": "connect_over_cdp",
-        "wrapper": _wrap_new_browser_async,
-    },
-    {
-        "package": "patchright.async_api",
-        "object": "Browser",
-        "method": "new_context",
-        "wrapper": _wrap_new_context_async,
-    },
-    {
-        "package": "patchright.async_api",
-        "object": "BrowserType",
-        "method": "launch_persistent_context",
-        "wrapper": _wrap_new_context_async,
-    },
-    {
-        "package": "patchright.async_api",
-        "object": "Page",
-        "method": "bring_to_front",
-        "wrapper": _wrap_bring_to_front_async,
-    },
+def _to_patchright(spec: WrappedFunctionSpec) -> WrappedFunctionSpec:
+    """Retarget a playwright spec at the patchright package.
+
+    patchright is a drop-in fork, so the two tables differ only in the package
+    name. They used to be maintained as two hand-written copies, which drifted:
+    patchright was missing both `Browser.new_page` rows (and did not even import
+    their wrapper), so patchright users silently lost session recording for
+    pages opened that way. Deriving the table removes the class of bug.
+    """
+    return {
+        **spec,
+        "package_name": spec["package_name"].replace("playwright.", "patchright.", 1),
+    }
+
+
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    _to_patchright(spec) for spec in PLAYWRIGHT_FUNCTIONS
 ]
 
 
-class PatchrightInstrumentor(BaseInstrumentor):
+class PatchrightInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
+
     def __init__(self, async_client: AsyncLaminarClient):
         super().__init__()
         self.async_client = async_client
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        # Both sync and async methods use async_client
-        # because we are using a background asyncio loop for async sends
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    wrapped_method.get("wrapper")(
-                        tracer,
-                        self.async_client,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass
+                pr_version = version("patchright")
+            except Exception as e:
+                logger.debug(f"Failed to get patchright version {e}")
+                pr_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="patchright",
+                version=pr_version,
+            )
+        return self._scope
 
-        for wrapped_method in WRAPPED_METHODS_ASYNC:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    wrapped_method.get("wrapper")(
-                        tracer,
-                        self.async_client,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass
-
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS + WRAPPED_METHODS_ASYNC:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            # `unwrap` takes (holder, "attr"), not wrapt's
-            # (module, "Object.method") split used in `_instrument`. The
-            # wrapt split makes it getattr an attribute literally named
-            # "Object.method", find nothing, and silently no-op.
-            unwrap(f"{wrap_package}.{wrap_object}", wrap_method)
+    def wrapper_kwargs(self) -> dict[str, Any]:
+        # See PlaywrightInstrumentor: sync wrappers also get the async client.
+        return {"client": self.async_client}

--- a/src/lmnr/sdk/browser/playwright_otel.py
+++ b/src/lmnr/sdk/browser/playwright_otel.py
@@ -8,18 +8,18 @@ from lmnr.sdk.browser.pw_utils import (
     take_full_snapshot,
     take_full_snapshot_async,
 )
-from lmnr.sdk.utils import with_tracer_and_client_wrapper
-from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-from lmnr.version import __version__
+from importlib.metadata import version
+from typing import Any, Collection, Sequence
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import (
-    get_tracer,
-    Tracer,
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
 )
-from typing import Collection
-from wrapt import wrap_function_wrapper
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
+from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 
 try:
     if is_package_installed("playwright"):
@@ -52,9 +52,14 @@ _instruments = ("playwright >= 1.9.0",)
 logger = logging.getLogger(__name__)
 
 
-@with_tracer_and_client_wrapper
 def _wrap_new_browser_sync(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     browser: SyncBrowser = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
@@ -74,9 +79,14 @@ def _wrap_new_browser_sync(
     return browser
 
 
-@with_tracer_and_client_wrapper
 async def _wrap_new_browser_async(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     browser: Browser = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
@@ -95,9 +105,14 @@ async def _wrap_new_browser_async(
     return browser
 
 
-@with_tracer_and_client_wrapper
 def _wrap_new_context_sync(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     context: SyncBrowserContext = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
@@ -116,9 +131,14 @@ def _wrap_new_context_sync(
     return context
 
 
-@with_tracer_and_client_wrapper
 async def _wrap_new_context_async(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     context: BrowserContext = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
@@ -137,25 +157,40 @@ async def _wrap_new_context_async(
     return context
 
 
-@with_tracer_and_client_wrapper
 def _wrap_bring_to_front_sync(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     wrapped(*args, **kwargs)
     take_full_snapshot(instance)
 
 
-@with_tracer_and_client_wrapper
 async def _wrap_bring_to_front_async(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     await wrapped(*args, **kwargs)
     await take_full_snapshot_async(instance)
 
 
-@with_tracer_and_client_wrapper
 def _wrap_browser_new_page_sync(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     page = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
@@ -163,9 +198,14 @@ def _wrap_browser_new_page_sync(
     return page
 
 
-@with_tracer_and_client_wrapper
 async def _wrap_browser_new_page_async(
-    tracer: Tracer, client: AsyncLaminarClient, to_wrap, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+    *,
+    client: AsyncLaminarClient,
 ):
     page = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
@@ -173,154 +213,140 @@ async def _wrap_browser_new_page_async(
     return page
 
 
-WRAPPED_METHODS = [
-    {
-        "package": "playwright.sync_api",
-        "object": "BrowserType",
-        "method": "launch",
-        "wrapper": _wrap_new_browser_sync,
-    },
-    {
-        "package": "playwright.sync_api",
-        "object": "BrowserType",
-        "method": "connect",
-        "wrapper": _wrap_new_browser_sync,
-    },
-    {
-        "package": "playwright.sync_api",
-        "object": "BrowserType",
-        "method": "connect_over_cdp",
-        "wrapper": _wrap_new_browser_sync,
-    },
-    {
-        "package": "playwright.sync_api",
-        "object": "Browser",
-        "method": "new_context",
-        "wrapper": _wrap_new_context_sync,
-    },
-    {
-        "package": "playwright.sync_api",
-        "object": "BrowserType",
-        "method": "launch_persistent_context",
-        "wrapper": _wrap_new_context_sync,
-    },
-    {
-        "package": "playwright.sync_api",
-        "object": "Page",
-        "method": "bring_to_front",
-        "wrapper": _wrap_bring_to_front_sync,
-    },
-    {
-        "package": "playwright.sync_api",
-        "object": "Browser",
-        "method": "new_page",
-        "wrapper": _wrap_browser_new_page_sync,
-    },
+
+
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="playwright.sync_api",
+        object_name="BrowserType",
+        method_name="launch",
+        is_async=False,
+        wrapper_function=_wrap_new_browser_sync,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.sync_api",
+        object_name="BrowserType",
+        method_name="connect",
+        is_async=False,
+        wrapper_function=_wrap_new_browser_sync,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.sync_api",
+        object_name="BrowserType",
+        method_name="connect_over_cdp",
+        is_async=False,
+        wrapper_function=_wrap_new_browser_sync,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.sync_api",
+        object_name="Browser",
+        method_name="new_context",
+        is_async=False,
+        wrapper_function=_wrap_new_context_sync,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.sync_api",
+        object_name="BrowserType",
+        method_name="launch_persistent_context",
+        is_async=False,
+        wrapper_function=_wrap_new_context_sync,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.sync_api",
+        object_name="Page",
+        method_name="bring_to_front",
+        is_async=False,
+        wrapper_function=_wrap_bring_to_front_sync,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.sync_api",
+        object_name="Browser",
+        method_name="new_page",
+        is_async=False,
+        wrapper_function=_wrap_browser_new_page_sync,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.async_api",
+        object_name="BrowserType",
+        method_name="launch",
+        is_async=True,
+        wrapper_function=_wrap_new_browser_async,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.async_api",
+        object_name="BrowserType",
+        method_name="connect",
+        is_async=True,
+        wrapper_function=_wrap_new_browser_async,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.async_api",
+        object_name="BrowserType",
+        method_name="connect_over_cdp",
+        is_async=True,
+        wrapper_function=_wrap_new_browser_async,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.async_api",
+        object_name="Browser",
+        method_name="new_context",
+        is_async=True,
+        wrapper_function=_wrap_new_context_async,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.async_api",
+        object_name="BrowserType",
+        method_name="launch_persistent_context",
+        is_async=True,
+        wrapper_function=_wrap_new_context_async,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.async_api",
+        object_name="Page",
+        method_name="bring_to_front",
+        is_async=True,
+        wrapper_function=_wrap_bring_to_front_async,
+    ),
+    WrappedFunctionSpec(
+        package_name="playwright.async_api",
+        object_name="Browser",
+        method_name="new_page",
+        is_async=True,
+        wrapper_function=_wrap_browser_new_page_async,
+    ),
 ]
 
-WRAPPED_METHODS_ASYNC = [
-    {
-        "package": "playwright.async_api",
-        "object": "BrowserType",
-        "method": "launch",
-        "wrapper": _wrap_new_browser_async,
-    },
-    {
-        "package": "playwright.async_api",
-        "object": "BrowserType",
-        "method": "connect",
-        "wrapper": _wrap_new_browser_async,
-    },
-    {
-        "package": "playwright.async_api",
-        "object": "BrowserType",
-        "method": "connect_over_cdp",
-        "wrapper": _wrap_new_browser_async,
-    },
-    {
-        "package": "playwright.async_api",
-        "object": "Browser",
-        "method": "new_context",
-        "wrapper": _wrap_new_context_async,
-    },
-    {
-        "package": "playwright.async_api",
-        "object": "BrowserType",
-        "method": "launch_persistent_context",
-        "wrapper": _wrap_new_context_async,
-    },
-    {
-        "package": "playwright.async_api",
-        "object": "Page",
-        "method": "bring_to_front",
-        "wrapper": _wrap_bring_to_front_async,
-    },
-    {
-        "package": "playwright.async_api",
-        "object": "Browser",
-        "method": "new_page",
-        "wrapper": _wrap_browser_new_page_async,
-    },
-]
 
+class PlaywrightInstrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
-class PlaywrightInstrumentor(BaseInstrumentor):
     def __init__(self, async_client: AsyncLaminarClient):
         super().__init__()
         self.async_client = async_client
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        # Both sync and async methods use async_client because we are using
-        # a background asyncio loop for async sends
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    wrapped_method.get("wrapper")(
-                        tracer,
-                        self.async_client,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some module is missing
+                pw_version = version("playwright")
+            except Exception as e:
+                logger.debug(f"Failed to get playwright version {e}")
+                pw_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="playwright",
+                version=pw_version,
+            )
+        return self._scope
 
-        # Wrap async methods
-        for wrapped_method in WRAPPED_METHODS_ASYNC:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    wrapped_method.get("wrapper")(
-                        tracer,
-                        self.async_client,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some module is missing
-
-    def _uninstrument(self, **kwargs):
-        # Unwrap methods
-        for wrapped_method in WRAPPED_METHODS + WRAPPED_METHODS_ASYNC:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            # `unwrap` takes (holder, "attr"), not wrapt's
-            # (module, "Object.method") split used in `_instrument`. The
-            # wrapt split makes it getattr an attribute literally named
-            # "Object.method", find nothing, and silently no-op.
-            unwrap(f"{wrap_package}.{wrap_object}", wrap_method)
+    def wrapper_kwargs(self) -> dict[str, Any]:
+        # Both sync and async wrappers get the ASYNC client on purpose: sends go
+        # through a background asyncio loop either way.
+        return {"client": self.async_client}

--- a/src/lmnr/sdk/utils.py
+++ b/src/lmnr/sdk/utils.py
@@ -18,10 +18,6 @@ from opentelemetry.trace import Tracer
 
 from lmnr.sdk.log import get_default_logger
 
-if typing.TYPE_CHECKING:
-    from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-    from lmnr.sdk.client.synchronous.sync_client import LaminarClient
-
 logger = get_default_logger(__name__)
 
 WrappedFunction = typing.Callable[..., typing.Any]
@@ -112,47 +108,6 @@ def with_tracer_only_wrapper(
         return wrapper
 
     return _with_tracer
-
-
-def with_tracer_and_client_wrapper(
-    func: typing.Callable[
-        [
-            Tracer,
-            "LaminarClient | AsyncLaminarClient",
-            ToWrapT,
-            WrappedFunction,
-            typing.Any,
-            tuple[typing.Any, ...],
-            dict[str, typing.Any],
-        ],
-        typing.Any,
-    ],
-) -> typing.Callable[
-    [Tracer, "LaminarClient | AsyncLaminarClient", ToWrapT], InstrumentedWrapper
-]:
-    """Same as `with_tracer_wrapper`, but also binds a Laminar client.
-
-    `func` must accept
-    `(tracer, client, to_wrap, wrapped, instance, args, kwargs)`.
-    """
-
-    def _with_tracer_and_client(
-        tracer: Tracer,
-        client: "LaminarClient | AsyncLaminarClient",
-        to_wrap: ToWrapT,
-    ) -> InstrumentedWrapper:
-        @functools.wraps(func)
-        def wrapper(
-            wrapped: WrappedFunction,
-            instance: typing.Any,
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> typing.Any:
-            return func(tracer, client, to_wrap, wrapped, instance, args, kwargs)
-
-        return wrapper
-
-    return _with_tracer_and_client
 
 
 def is_method(func: typing.Callable[..., typing.Any]) -> bool:

--- a/tests/test_instrumentor_targets.py
+++ b/tests/test_instrumentor_targets.py
@@ -225,6 +225,107 @@ def test_claude_agent_alias_replacement_reaches_prior_from_imports():
 
 
 # ---------------------------------------------------------------------------
+# Browser group
+# ---------------------------------------------------------------------------
+
+
+def test_playwright_wraps_and_restores_every_target():
+    """playwright is installed here, so this is a real round trip. It also needs
+    a client, which reaches the wrappers through `wrapper_kwargs()` rather than
+    through the per-method spec."""
+    from lmnr.sdk.browser.playwright_otel import (
+        PlaywrightInstrumentor,
+        WRAPPED_FUNCTIONS,
+    )
+
+    targets = _reachable(
+        {
+            (r["package_name"], f"{r['object_name']}.{r['method_name']}")
+            for r in WRAPPED_FUNCTIONS
+        }
+    )
+    assert targets, "expected at least one playwright target to be importable"
+
+    instrumentor = PlaywrightInstrumentor(object())
+    was_instrumented = instrumentor.is_instrumented_by_opentelemetry
+    try:
+        if was_instrumented:
+            instrumentor.uninstrument()
+        originals = {}
+        for module_name, target in targets:
+            holder, attr = _resolve(module_name, target)
+            originals[(module_name, target)] = getattr(holder, attr)
+
+        instrumentor.instrument()
+        for module_name, target in targets:
+            assert _is_wrapped(module_name, target), f"missed {module_name}.{target}"
+
+        instrumentor.uninstrument()
+        for (module_name, target), original in originals.items():
+            holder, attr = _resolve(module_name, target)
+            assert getattr(holder, attr) is original, (
+                f"did not restore {module_name}.{target}"
+            )
+    finally:
+        if instrumentor.is_instrumented_by_opentelemetry:
+            instrumentor.uninstrument()
+        if was_instrumented:
+            instrumentor.instrument()
+
+
+def test_wrapper_kwargs_delivers_the_client_to_a_browser_wrapper():
+    """The client is instrumentor-level state, not per-method config, so it rides
+    the base's handler-kwargs channel. If that link broke, every browser wrapper
+    would raise TypeError on its keyword-only `client` argument."""
+    from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+        add_spec_wrapper,
+    )
+    from lmnr.sdk.browser.playwright_otel import PlaywrightInstrumentor
+
+    sentinel = object()
+    instrumentor = PlaywrightInstrumentor(sentinel)
+    assert instrumentor.wrapper_kwargs() == {"client": sentinel}
+
+    seen = {}
+
+    def handler(to_wrap, wrapped, instance, args, kwargs, *, client):
+        seen["client"] = client
+        return wrapped(*args, **kwargs)
+
+    wrapper = add_spec_wrapper(handler, {}, **instrumentor.wrapper_kwargs())
+    assert wrapper(lambda: "ok", None, (), {}) == "ok"
+    assert seen["client"] is sentinel
+
+
+def test_patchright_table_is_derived_from_playwright_and_covers_new_page():
+    """patchright's table used to be a hand-maintained copy of playwright's and
+    had drifted: both `Browser.new_page` rows were missing, so pages opened that
+    way silently lost session recording. It is now derived, so it cannot drift.
+    """
+    from lmnr.sdk.browser.patchright_otel import WRAPPED_FUNCTIONS as PATCHRIGHT
+    from lmnr.sdk.browser.playwright_otel import WRAPPED_FUNCTIONS as PLAYWRIGHT
+
+    assert len(PATCHRIGHT) == len(PLAYWRIGHT) == 14
+
+    # identical except for the package they target
+    assert {
+        (r["object_name"], r["method_name"], r["is_async"], r["wrapper_function"])
+        for r in PATCHRIGHT
+    } == {
+        (r["object_name"], r["method_name"], r["is_async"], r["wrapper_function"])
+        for r in PLAYWRIGHT
+    }
+    assert {r["package_name"] for r in PATCHRIGHT} == {
+        "patchright.sync_api",
+        "patchright.async_api",
+    }
+
+    # the rows that were missing before
+    new_page = [r for r in PATCHRIGHT if r["method_name"] == "new_page"]
+    assert {r["is_async"] for r in new_page} == {False, True}
+
+
+# ---------------------------------------------------------------------------
 # The unwrap() calling convention
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes affect how browser session recording and trace context propagation are hooked at runtime; incorrect wrapping or teardown could break recording or leave methods patched, though new tests mitigate regression risk.
> 
> **Overview**
> Browser telemetry instrumentors (Playwright, Patchright, browser-use, CDP browser-use, Bubus) are moved off hand-rolled `wrap_function_wrapper` / `unwrap` loops onto **`BaseLaminarInstrumentor`**, with targets declared as **`WrappedFunctionSpec`** tables and **`LaminarInstrumentorConfig`**. Wrappers no longer take a bound OTEL tracer via `with_tracer_and_client_wrapper`; the async Laminar client is injected through **`wrapper_kwargs()`**, and that helper is removed from `lmnr.sdk.utils`.
> 
> **Patchright** no longer maintains a duplicate wrap table—it **derives** specs from Playwright by retargeting package names, which restores missing **`Browser.new_page`** hooks that had silently skipped session recording. **Uninstrument** now delegates to the base class (correct unwrap semantics) and clears module-level caches (`_initialized_sessions`, `event_id_to_span_context`) so stale state cannot affect later runs. Each instrumentor reports an **`instrumentation_scope`** with the installed library version from `importlib.metadata`.
> 
> Tests add Playwright round-trip wrap/restore checks, **`wrapper_kwargs`** client plumbing, and assertions that the Patchright table stays aligned with Playwright.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7efd1a5527cdc3f040e7fb1de37be1d34359cf01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->