### PR TITLE
move LLM instrumentations to the new wrappers pattern

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/anthropic/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/anthropic/__init__.py
@@ -1,24 +1,33 @@
 """OpenTelemetry Anthropic instrumentation"""
 
 import logging
-from typing import Callable, Collection
+from importlib.metadata import version
+from typing import Any, Callable, Collection, Sequence
 
 from opentelemetry import context as context_api
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY, unwrap
+from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_USAGE_INPUT_TOKENS,
     GEN_AI_USAGE_OUTPUT_TOKENS,
 )
-from opentelemetry.trace import Span, Tracer, get_tracer
+from opentelemetry.trace import Span
 from opentelemetry.trace.status import Status, StatusCode
-from wrapt import wrap_function_wrapper
 
 from anthropic._streaming import AsyncStream, Stream
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     safe_start_span,
 )
-from lmnr.sdk.utils import with_tracer_wrapper
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
 
 from .config import Config
 from .rollout import get_anthropic_rollout_wrapper
@@ -38,135 +47,10 @@ from .utils import (
     run_async,
     set_span_attribute,
 )
-from .version import __version__
 
 logger = logging.getLogger(__name__)
 
 _instruments = ("anthropic >= 0.3.11",)
-
-
-WRAPPED_METHODS = [
-    {
-        "package": "anthropic.resources.completions",
-        "object": "Completions",
-        "method": "create",
-        "span_name": "anthropic.completion",
-    },
-    {
-        "package": "anthropic.resources.messages",
-        "object": "Messages",
-        "method": "create",
-        "span_name": "anthropic.chat",
-    },
-    {
-        "package": "anthropic.resources.messages",
-        "object": "Messages",
-        "method": "parse",
-        "span_name": "anthropic.chat",
-    },
-    {
-        "package": "anthropic.resources.messages",
-        "object": "Messages",
-        "method": "stream",
-        "span_name": "anthropic.chat",
-    },
-    # This method is on an async resource, but is meant to be called as
-    # an async context manager (async with), which we don't need to await;
-    # thus, we wrap it with a sync wrapper
-    {
-        "package": "anthropic.resources.messages",
-        "object": "AsyncMessages",
-        "method": "stream",
-        "span_name": "anthropic.chat",
-    },
-    # Beta API methods (regular Anthropic SDK)
-    {
-        "package": "anthropic.resources.beta.messages.messages",
-        "object": "Messages",
-        "method": "create",
-        "span_name": "anthropic.chat",
-    },
-    {
-        "package": "anthropic.resources.beta.messages.messages",
-        "object": "Messages",
-        "method": "parse",
-        "span_name": "anthropic.chat",
-    },
-    {
-        "package": "anthropic.resources.beta.messages.messages",
-        "object": "Messages",
-        "method": "stream",
-        "span_name": "anthropic.chat",
-    },
-    # read note on async with above
-    {
-        "package": "anthropic.resources.beta.messages.messages",
-        "object": "AsyncMessages",
-        "method": "stream",
-        "span_name": "anthropic.chat",
-    },
-    # Beta API methods (Bedrock SDK)
-    {
-        "package": "anthropic.lib.bedrock._beta_messages",
-        "object": "Messages",
-        "method": "create",
-        "span_name": "anthropic.chat",
-    },
-    {
-        "package": "anthropic.lib.bedrock._beta_messages",
-        "object": "Messages",
-        "method": "stream",
-        "span_name": "anthropic.chat",
-    },
-    # read note on async with above
-    {
-        "package": "anthropic.lib.bedrock._beta_messages",
-        "object": "AsyncMessages",
-        "method": "stream",
-        "span_name": "anthropic.chat",
-    },
-]
-
-WRAPPED_AMETHODS = [
-    {
-        "package": "anthropic.resources.completions",
-        "object": "AsyncCompletions",
-        "method": "create",
-        "span_name": "anthropic.completion",
-    },
-    {
-        "package": "anthropic.resources.messages",
-        "object": "AsyncMessages",
-        "method": "create",
-        "span_name": "anthropic.chat",
-    },
-    {
-        "package": "anthropic.resources.messages",
-        "object": "AsyncMessages",
-        "method": "parse",
-        "span_name": "anthropic.chat",
-    },
-    # Beta API async methods (regular Anthropic SDK)
-    {
-        "package": "anthropic.resources.beta.messages.messages",
-        "object": "AsyncMessages",
-        "method": "create",
-        "span_name": "anthropic.chat",
-    },
-    {
-        "package": "anthropic.resources.beta.messages.messages",
-        "object": "AsyncMessages",
-        "method": "parse",
-        "span_name": "anthropic.chat",
-    },
-    # Beta API async methods (Bedrock SDK)
-    {
-        "package": "anthropic.lib.bedrock._beta_messages",
-        "object": "AsyncMessages",
-        "method": "create",
-        "span_name": "anthropic.chat",
-    },
-]
 
 
 def is_streaming_response(response):
@@ -365,21 +249,19 @@ async def _ahandle_response(span: Span, response, record_raw_response=False):
             pass
 
 
-@with_tracer_wrapper
 def _wrap(
-    tracer: Tracer,
-    to_wrap,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
-    """Instruments and calls every function defined in TO_WRAP."""
+    """Instruments and calls every function defined in WRAPPED_FUNCTIONS."""
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=to_wrap.get("span_name"),
+        name=to_wrap.get("span_name") or "anthropic.chat",
         attributes={"gen_ai.system": "anthropic"},
         span_type="LLM",
     )
@@ -388,6 +270,7 @@ def _wrap(
         logger.warning("Failed to start span for anthropic chat")
         return wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_input(span, kwargs)
 
     rollout_wrapper = get_anthropic_rollout_wrapper()
@@ -456,21 +339,19 @@ def _wrap(
     return response
 
 
-@with_tracer_wrapper
 async def _awrap(
-    tracer,
-    to_wrap,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
-    """Instruments and calls every function defined in TO_WRAP."""
+    """Instruments and calls every function defined in WRAPPED_FUNCTIONS."""
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return await wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=to_wrap.get("span_name"),
+        name=to_wrap.get("span_name") or "anthropic.chat",
         attributes={"gen_ai.system": "anthropic"},
         span_type="LLM",
     )
@@ -479,6 +360,7 @@ async def _awrap(
         logger.warning("Failed to start span for async anthropic chat")
         return await wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     await _ahandle_input(span, kwargs)
 
     rollout_wrapper = get_anthropic_rollout_wrapper()
@@ -540,8 +422,167 @@ async def _awrap(
     return response
 
 
-class AnthropicInstrumentor(BaseInstrumentor):
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.completions",
+        object_name="Completions",
+        method_name="create",
+        span_name="anthropic.completion",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.messages",
+        object_name="Messages",
+        method_name="create",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.messages",
+        object_name="Messages",
+        method_name="parse",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.messages",
+        object_name="Messages",
+        method_name="stream",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    # This method is on an async resource, but is meant to be called as
+    # an async context manager (async with), which we don't need to await;
+    # thus, we wrap it with a sync wrapper
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.messages",
+        object_name="AsyncMessages",
+        method_name="stream",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    # Beta API methods (regular Anthropic SDK)
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.beta.messages.messages",
+        object_name="Messages",
+        method_name="create",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.beta.messages.messages",
+        object_name="Messages",
+        method_name="parse",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.beta.messages.messages",
+        object_name="Messages",
+        method_name="stream",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    # read note on async with above
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.beta.messages.messages",
+        object_name="AsyncMessages",
+        method_name="stream",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    # Beta API methods (Bedrock SDK)
+    WrappedFunctionSpec(
+        package_name="anthropic.lib.bedrock._beta_messages",
+        object_name="Messages",
+        method_name="create",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.lib.bedrock._beta_messages",
+        object_name="Messages",
+        method_name="stream",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    # read note on async with above
+    WrappedFunctionSpec(
+        package_name="anthropic.lib.bedrock._beta_messages",
+        object_name="AsyncMessages",
+        method_name="stream",
+        span_name="anthropic.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.completions",
+        object_name="AsyncCompletions",
+        method_name="create",
+        span_name="anthropic.completion",
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.messages",
+        object_name="AsyncMessages",
+        method_name="create",
+        span_name="anthropic.chat",
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.messages",
+        object_name="AsyncMessages",
+        method_name="parse",
+        span_name="anthropic.chat",
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+    # Beta API async methods (regular Anthropic SDK)
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.beta.messages.messages",
+        object_name="AsyncMessages",
+        method_name="create",
+        span_name="anthropic.chat",
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="anthropic.resources.beta.messages.messages",
+        object_name="AsyncMessages",
+        method_name="parse",
+        span_name="anthropic.chat",
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+    # Beta API async methods (Bedrock SDK)
+    WrappedFunctionSpec(
+        package_name="anthropic.lib.bedrock._beta_messages",
+        object_name="AsyncMessages",
+        method_name="create",
+        span_name="anthropic.chat",
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+]
+
+
+class AnthropicInstrumentor(BaseLaminarInstrumentor):
     """An instrumentor for Anthropic's client library."""
+
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def __init__(
         self,
@@ -555,66 +596,25 @@ class AnthropicInstrumentor(BaseInstrumentor):
         Config.enrich_token_usage = enrich_token_usage
         Config.get_common_metrics_attributes = get_common_metrics_attributes
         Config.use_legacy_attributes = use_legacy_attributes
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap(
-                        tracer,
-                        wrapped_method,
-                    ),
-                )
-                logger.debug(
-                    f"Successfully wrapped {wrap_package}.{wrap_object}.{wrap_method}"
-                )
+                anthropic_version = version("anthropic")
             except Exception as e:
-                logger.debug(
-                    f"Failed to wrap {wrap_package}.{wrap_object}.{wrap_method}: {e}"
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-        for wrapped_method in WRAPPED_AMETHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _awrap(
-                        tracer,
-                        wrapped_method,
-                    ),
-                )
-            except Exception:
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            unwrap(
-                f"{wrap_package}.{wrap_object}",
-                wrapped_method.get("method"),
+                logger.debug(f"Failed to get anthropic version {e}")
+                anthropic_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="anthropic",
+                version=anthropic_version,
             )
-        for wrapped_method in WRAPPED_AMETHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            unwrap(
-                f"{wrap_package}.{wrap_object}",
-                wrapped_method.get("method"),
-            )
+        return self._scope

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/google_genai/__init__.py
@@ -4,25 +4,35 @@ import json
 import logging
 import os
 from collections import defaultdict
-from typing import AsyncGenerator, Callable, Collection, Generator
+from importlib.metadata import version
+from typing import Any, AsyncGenerator, Callable, Collection, Generator, Sequence
 
 from google.genai import types
 from opentelemetry import context as context_api
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY, unwrap
+from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv._incubating.attributes import gen_ai_attributes
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
-from opentelemetry.trace import Span, Status, StatusCode, Tracer, get_tracer
-from wrapt import wrap_function_wrapper
+from opentelemetry.trace import Span, Status, StatusCode
 
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     safe_start_span,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
 )
 from lmnr.opentelemetry_lib.tracing.context import (
     get_event_attributes_from_context,
 )
 from lmnr.sdk.laminar import Laminar
-from lmnr.sdk.utils import json_dumps, with_tracer_wrapper
+from lmnr.sdk.utils import json_dumps
 
 from .config import (
     Config,
@@ -41,42 +51,6 @@ from .utils import (
 logger = logging.getLogger(__name__)
 
 _instruments = ("google-genai >= 1.0.0",)
-
-WRAPPED_METHODS = [
-    {
-        "package": "google.genai.models",
-        "object": "Models",
-        "method": "generate_content",
-        "span_name": "gemini.generate_content",
-        "is_streaming": False,
-        "is_async": False,
-    },
-    {
-        "package": "google.genai.models",
-        "object": "AsyncModels",
-        "method": "generate_content",
-        "span_name": "gemini.generate_content",
-        "is_streaming": False,
-        "is_async": True,
-    },
-    {
-        "package": "google.genai.models",
-        "object": "Models",
-        "method": "generate_content_stream",
-        "span_name": "gemini.generate_content_stream",
-        "is_streaming": True,
-        "is_async": False,
-    },
-    {
-        "package": "google.genai.models",
-        "object": "AsyncModels",
-        "method": "generate_content_stream",
-        "span_name": "gemini.generate_content_stream",
-        "is_streaming": True,
-        "is_async": True,
-    },
-]
-
 
 def should_send_prompts():
     return (
@@ -385,13 +359,18 @@ async def _abuild_from_streaming_response(
             span.end()
 
 
-@with_tracer_wrapper
-def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
+def _wrap(
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=to_wrap.get("span_name"),
+        name=to_wrap.get("span_name") or "gemini.generate_content",
         attributes={"gen_ai.system": "gemini"},
         span_type="LLM",
     )
@@ -399,6 +378,7 @@ def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         logger.warning("Failed to start span for google genai")
         return wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _set_request_attributes(span, args, kwargs)
 
     try:
@@ -423,7 +403,7 @@ def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
                         instance,
                         args,
                         kwargs,
-                        is_streaming=to_wrap.get("is_streaming", False),
+                        is_streaming=bool(to_wrap.get("is_streaming")),
                         is_async=False,
                     )
             else:
@@ -449,13 +429,18 @@ def _wrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         raise
 
 
-@with_tracer_wrapper
-async def _awrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
+async def _awrap(
+    to_wrap: WrappedFunctionSpec,
+    wrapped,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
+):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return await wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=to_wrap.get("span_name"),
+        name=to_wrap.get("span_name") or "gemini.generate_content",
         attributes={"gen_ai.system": "gemini"},
         span_type="LLM",
     )
@@ -463,6 +448,7 @@ async def _awrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         logger.warning("Failed to start span for async google genai")
         return await wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _set_request_attributes(span, args, kwargs)
 
     try:
@@ -489,7 +475,7 @@ async def _awrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
                         instance,
                         args,
                         kwargs,
-                        is_streaming=to_wrap.get("is_streaming", False),
+                        is_streaming=bool(to_wrap.get("is_streaming")),
                         is_async=True,
                     )
                 # If result is a coroutine or async generator, await/iterate it
@@ -530,34 +516,73 @@ async def _awrap(tracer: Tracer, to_wrap, wrapped, instance, args, kwargs):
         raise
 
 
-class GoogleGenAiSdkInstrumentor(BaseInstrumentor):
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="google.genai.models",
+        object_name="Models",
+        method_name="generate_content",
+        span_name="gemini.generate_content",
+        is_streaming=False,
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="google.genai.models",
+        object_name="AsyncModels",
+        method_name="generate_content",
+        span_name="gemini.generate_content",
+        is_streaming=False,
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="google.genai.models",
+        object_name="Models",
+        method_name="generate_content_stream",
+        span_name="gemini.generate_content_stream",
+        is_streaming=True,
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="google.genai.models",
+        object_name="AsyncModels",
+        method_name="generate_content_stream",
+        span_name="gemini.generate_content_stream",
+        is_streaming=True,
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+]
+
+
+class GoogleGenAiSdkInstrumentor(BaseLaminarInstrumentor):
     """An instrumentor for Google GenAI's client library."""
+
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def __init__(self, exception_logger=None):
         super().__init__()
         Config.exception_logger = exception_logger
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, "0.0.1a1", tracer_provider)
-
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_function_wrapper(
-                wrapped_method.get("package"),
-                f"{wrapped_method.get('object')}.{wrapped_method.get('method')}",
-                (
-                    _awrap(tracer, wrapped_method)
-                    if wrapped_method.get("is_async")
-                    else _wrap(tracer, wrapped_method)
-                ),
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                google_genai_version = version("google-genai")
+            except Exception as e:
+                logger.debug(f"Failed to get google-genai version {e}")
+                google_genai_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="google-genai",
+                version=google_genai_version,
             )
-
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            unwrap(
-                f"{wrapped_method.get('package')}.{wrapped_method.get('object')}",
-                wrapped_method.get("method"),
-            )
+        return self._scope

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/groq/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/groq/__init__.py
@@ -1,7 +1,8 @@
 """OpenTelemetry Groq instrumentation"""
 
 import logging
-from typing import Collection
+from importlib.metadata import version
+from typing import Any, Collection, Sequence
 
 from opentelemetry import context as context_api
 from .config import Config
@@ -13,42 +14,30 @@ from .span_utils import (
     set_response_attributes,
     set_streaming_response_attributes,
 )
-from .version import __version__
 
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     dont_throw,
     safe_start_span,
 )
-from lmnr.sdk.utils import with_tracer_wrapper
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY, unwrap
-from opentelemetry.trace import Tracer, get_tracer
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
+from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.trace.status import Status, StatusCode
-from wrapt import wrap_function_wrapper
 
 from groq._streaming import AsyncStream, Stream
 
 logger = logging.getLogger(__name__)
 
 _instruments = ("groq >= 0.9.0",)
-
-
-WRAPPED_METHODS = [
-    {
-        "package": "groq.resources.chat.completions",
-        "object": "Completions",
-        "method": "create",
-        "span_name": "groq.chat",
-    },
-]
-WRAPPED_AMETHODS = [
-    {
-        "package": "groq.resources.chat.completions",
-        "object": "AsyncCompletions",
-        "method": "create",
-        "span_name": "groq.chat",
-    },
-]
 
 
 def is_streaming_response(response):
@@ -153,20 +142,18 @@ def _handle_response(span, response):
     set_response_attributes(span, response)
 
 
-@with_tracer_wrapper
 def _wrap(
-    tracer: Tracer,
-    to_wrap,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
-    """Instruments and calls every function defined in TO_WRAP."""
+    """Instruments and calls every function defined in WRAPPED_FUNCTIONS."""
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
-    name = to_wrap.get("span_name")
+    name = to_wrap.get("span_name") or "groq.chat"
     span = safe_start_span(
         name=name, attributes={"gen_ai.system": "groq"}, span_type="LLM"
     )
@@ -174,6 +161,7 @@ def _wrap(
         logger.warning("Failed to start span for groq chat")
         return wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_input(span, kwargs)
 
     try:
@@ -208,20 +196,18 @@ def _wrap(
     return response
 
 
-@with_tracer_wrapper
 async def _awrap(
-    tracer,
-    to_wrap,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
-    instance,
-    args,
-    kwargs,
+    instance: Any,
+    args: Sequence[Any],
+    kwargs: dict[str, Any],
 ):
-    """Instruments and calls every function defined in TO_WRAP."""
+    """Instruments and calls every function defined in WRAPPED_FUNCTIONS."""
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return await wrapped(*args, **kwargs)
 
-    name = to_wrap.get("span_name")
+    name = to_wrap.get("span_name") or "groq.chat"
     span = safe_start_span(
         name=name, attributes={"gen_ai.system": "groq"}, span_type="LLM"
     )
@@ -229,6 +215,7 @@ async def _awrap(
         logger.warning("Failed to start span for groq chat")
         return await wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_input(span, kwargs)
 
     try:
@@ -256,8 +243,30 @@ async def _awrap(
     return response
 
 
-class GroqInstrumentor(BaseInstrumentor):
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="groq.resources.chat.completions",
+        object_name="Completions",
+        method_name="create",
+        span_name="groq.chat",
+        is_async=False,
+        wrapper_function=_wrap,
+    ),
+    WrappedFunctionSpec(
+        package_name="groq.resources.chat.completions",
+        object_name="AsyncCompletions",
+        method_name="create",
+        span_name="groq.chat",
+        is_async=True,
+        wrapper_function=_awrap,
+    ),
+]
+
+
+class GroqInstrumentor(BaseLaminarInstrumentor):
     """An instrumentor for Groq's client library."""
+
+    _scope: LaminarInstrumentationScopeAttributes | None = None
 
     def __init__(
         self,
@@ -267,59 +276,25 @@ class GroqInstrumentor(BaseInstrumentor):
         super().__init__()
         Config.enrich_token_usage = enrich_token_usage
         Config.use_legacy_attributes = use_legacy_attributes
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
 
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
             try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _wrap(
-                        tracer,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-        for wrapped_method in WRAPPED_AMETHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            wrap_method = wrapped_method.get("method")
-            try:
-                wrap_function_wrapper(
-                    wrap_package,
-                    f"{wrap_object}.{wrap_method}",
-                    _awrap(
-                        tracer,
-                        wrapped_method,
-                    ),
-                )
-            except ModuleNotFoundError:
-                pass  # that's ok, we don't want to fail if some methods do not exist
-
-    def _uninstrument(self, **kwargs):
-        for wrapped_method in WRAPPED_METHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            unwrap(
-                f"{wrap_package}.{wrap_object}",
-                wrapped_method.get("method"),
+                groq_version = version("groq")
+            except Exception as e:
+                logger.debug(f"Failed to get groq version {e}")
+                groq_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="groq",
+                version=groq_version,
             )
-        for wrapped_method in WRAPPED_AMETHODS:
-            wrap_package = wrapped_method.get("package")
-            wrap_object = wrapped_method.get("object")
-            unwrap(
-                f"{wrap_package}.{wrap_object}",
-                wrapped_method.get("method"),
-            )
+        return self._scope

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/chat_wrappers.py
@@ -12,7 +12,7 @@ from ..shared import (
     propagate_trace_context,
     set_tools_attributes,
 )
-from lmnr.sdk.utils import json_dumps, with_tracer_only_wrapper
+from lmnr.sdk.utils import json_dumps
 from ..shared.config import Config
 from ..utils import (
     dont_throw,
@@ -23,12 +23,17 @@ from lmnr.opentelemetry_lib.tracing.context import (
     get_event_attributes_from_context,
     is_in_litellm_context,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     safe_start_span,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
-from opentelemetry.trace import Tracer
 from opentelemetry.trace.status import Status, StatusCode
 from wrapt import ObjectProxy
 
@@ -37,9 +42,8 @@ SPAN_NAME = "openai.chat"
 logger = logging.getLogger(__name__)
 
 
-@with_tracer_only_wrapper
 def chat_wrapper(
-    tracer: Tracer,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
     instance,
     args,
@@ -56,12 +60,15 @@ def chat_wrapper(
         return wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=SPAN_NAME, attributes={"gen_ai.system": "openai"}, span_type="LLM"
+        name=to_wrap.get("span_name") or SPAN_NAME,
+        attributes={"gen_ai.system": "openai"},
+        span_type="LLM",
     )
 
     if span is None:
         return wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_request(span, kwargs, instance)
 
     try:
@@ -125,9 +132,8 @@ def chat_wrapper(
     return response
 
 
-@with_tracer_only_wrapper
 async def achat_wrapper(
-    tracer: Tracer,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
     instance,
     args,
@@ -140,12 +146,15 @@ async def achat_wrapper(
         return await wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=SPAN_NAME, attributes={"gen_ai.system": "openai"}, span_type="LLM"
+        name=to_wrap.get("span_name") or SPAN_NAME,
+        attributes={"gen_ai.system": "openai"},
+        span_type="LLM",
     )
 
     if span is None:
         return await wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_request(span, kwargs, instance)
 
     try:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/completion_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/completion_wrappers.py
@@ -20,12 +20,18 @@ from ..utils import (
     is_openai_v1,
     should_send_prompts,
 )
-from lmnr.sdk.utils import json_dumps, with_tracer_only_wrapper
+from lmnr.sdk.utils import json_dumps
 from lmnr.opentelemetry_lib.tracing.context import (
     get_event_attributes_from_context,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     safe_start_span,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
 )
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
@@ -36,18 +42,20 @@ SPAN_NAME = "openai.completion"
 logger = logging.getLogger(__name__)
 
 
-@with_tracer_only_wrapper
-def completion_wrapper(tracer, wrapped, instance, args, kwargs):
+def completion_wrapper(to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
     # span needs to be opened and closed manually because the response is a generator
     span = safe_start_span(
-        name=SPAN_NAME, attributes={"gen_ai.system": "openai"}, span_type="LLM"
+        name=to_wrap.get("span_name") or SPAN_NAME,
+        attributes={"gen_ai.system": "openai"},
+        span_type="LLM",
     )
     if span is None:
         return wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_request(span, kwargs, instance)
 
     try:
@@ -70,17 +78,21 @@ def completion_wrapper(tracer, wrapped, instance, args, kwargs):
     return response
 
 
-@with_tracer_only_wrapper
-async def acompletion_wrapper(tracer, wrapped, instance, args, kwargs):
+async def acompletion_wrapper(
+    to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs
+):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return await wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=SPAN_NAME, attributes={"gen_ai.system": "openai"}, span_type="LLM"
+        name=to_wrap.get("span_name") or SPAN_NAME,
+        attributes={"gen_ai.system": "openai"},
+        span_type="LLM",
     )
     if span is None:
         return await wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_request(span, kwargs, instance)
 
     try:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/embeddings_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/shared/embeddings_wrappers.py
@@ -17,10 +17,16 @@ from ..utils import (
     is_openai_v1,
     should_send_prompts,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    WrappedFunctionSpec,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     safe_start_span,
 )
-from lmnr.sdk.utils import json_dumps, with_tracer_only_wrapper
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
+from lmnr.sdk.utils import json_dumps
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.trace import Status, StatusCode
@@ -29,9 +35,8 @@ SPAN_NAME = "openai.embeddings"
 logger = logging.getLogger(__name__)
 
 
-@with_tracer_only_wrapper
 def embeddings_wrapper(
-    tracer,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
     instance,
     args,
@@ -41,13 +46,14 @@ def embeddings_wrapper(
         return wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=SPAN_NAME,
+        name=to_wrap.get("span_name") or SPAN_NAME,
         attributes={"gen_ai.system": "openai"},
         span_type="LLM",
     )
     if span is None:
         return wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_request(span, kwargs, instance)
 
     try:
@@ -66,9 +72,8 @@ def embeddings_wrapper(
         span.end()
 
 
-@with_tracer_only_wrapper
 async def aembeddings_wrapper(
-    tracer,
+    to_wrap: WrappedFunctionSpec,
     wrapped,
     instance,
     args,
@@ -78,13 +83,14 @@ async def aembeddings_wrapper(
         return await wrapped(*args, **kwargs)
 
     span = safe_start_span(
-        name=SPAN_NAME,
+        name=to_wrap.get("span_name") or SPAN_NAME,
         attributes={"gen_ai.system": "openai"},
         span_type="LLM",
     )
     if span is None:
         return await wrapped(*args, **kwargs)
 
+    stamp_instrumentation_scope(span, to_wrap)
     _handle_request(span, kwargs, instance)
 
     try:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v0/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v0/__init__.py
@@ -1,6 +1,15 @@
+from importlib.metadata import version
 from typing import Collection
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
+from lmnr.sdk.log import get_default_logger
 from ..shared.chat_wrappers import (
     achat_wrapper,
     chat_wrapper,
@@ -9,71 +18,91 @@ from ..shared.completion_wrappers import (
     acompletion_wrapper,
     completion_wrapper,
 )
-from ..shared.config import Config
 from ..shared.embeddings_wrappers import (
     aembeddings_wrapper,
     embeddings_wrapper,
 )
-from ..version import __version__
-from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import get_tracer
-from wrapt import wrap_function_wrapper
 
 _instruments = ("openai >= 0.27.0", "openai < 1.0.0")
+logger = get_default_logger(__name__)
 
 
-class OpenAIV0Instrumentor(BaseInstrumentor):
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="openai",
+        object_name="Completion",
+        method_name="create",
+        span_name="openai.completion",
+        is_async=False,
+        wrapper_function=completion_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai",
+        object_name="Completion",
+        method_name="acreate",
+        span_name="openai.completion",
+        is_async=True,
+        wrapper_function=acompletion_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai",
+        object_name="ChatCompletion",
+        method_name="create",
+        span_name="openai.chat",
+        is_async=False,
+        wrapper_function=chat_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai",
+        object_name="ChatCompletion",
+        method_name="acreate",
+        span_name="openai.chat",
+        is_async=True,
+        wrapper_function=achat_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai",
+        object_name="Embedding",
+        method_name="create",
+        span_name="openai.embeddings",
+        is_async=False,
+        wrapper_function=embeddings_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai",
+        object_name="Embedding",
+        method_name="acreate",
+        span_name="openai.embeddings",
+        is_async=True,
+        wrapper_function=aembeddings_wrapper,
+    ),
+]
+
+
+class OpenAIV0Instrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
+
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        wrap_function_wrapper(
-            "openai",
-            "Completion.create",
-            completion_wrapper(tracer),
-        )
-
-        wrap_function_wrapper(
-            "openai",
-            "Completion.acreate",
-            acompletion_wrapper(tracer),
-        )
-        wrap_function_wrapper(
-            "openai",
-            "ChatCompletion.create",
-            chat_wrapper(
-                tracer,
-            ),
-        )
-        wrap_function_wrapper(
-            "openai",
-            "ChatCompletion.acreate",
-            achat_wrapper(
-                tracer,
-            ),
-        )
-        wrap_function_wrapper(
-            "openai",
-            "Embedding.create",
-            embeddings_wrapper(
-                tracer,
-            ),
-        )
-        wrap_function_wrapper(
-            "openai",
-            "Embedding.acreate",
-            aembeddings_wrapper(
-                tracer,
-            ),
-        )
-
-    def _uninstrument(self, **kwargs):
-        unwrap("openai", "Completion.create")
-        unwrap("openai", "Completion.acreate")
-        unwrap("openai", "ChatCompletion.create")
-        unwrap("openai", "ChatCompletion.acreate")
-        unwrap("openai", "Embedding.create")
-        unwrap("openai", "Embedding.acreate")
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                openai_version = version("openai")
+            except Exception as e:
+                logger.debug(f"Failed to get openai version {e}")
+                openai_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="openai",
+                version=openai_version,
+            )
+        return self._scope

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/__init__.py
@@ -1,7 +1,14 @@
+from importlib.metadata import version
 from typing import Collection
 
-from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
-
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
+    BaseLaminarInstrumentor,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    LaminarInstrumentationScopeAttributes,
+    LaminarInstrumentorConfig,
+    WrappedFunctionSpec,
+)
 from lmnr.sdk.log import get_default_logger
 from ..shared.chat_wrappers import (
     achat_wrapper,
@@ -30,198 +37,208 @@ from .responses_wrappers import (
     responses_get_or_create_wrapper,
 )
 
-from ..version import __version__
-from opentelemetry.instrumentation.utils import unwrap
-from opentelemetry.trace import get_tracer
-from wrapt import wrap_function_wrapper
-
 
 _instruments = ("openai >= 1.0.0",)
 logger = get_default_logger(__name__)
 
 
-class OpenAIV1Instrumentor(BaseInstrumentor):
+WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
+    WrappedFunctionSpec(
+        package_name="openai.resources.chat.completions",
+        object_name="Completions",
+        method_name="create",
+        span_name="openai.chat",
+        is_async=False,
+        wrapper_function=chat_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.completions",
+        object_name="Completions",
+        method_name="create",
+        span_name="openai.completion",
+        is_async=False,
+        wrapper_function=completion_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.embeddings",
+        object_name="Embeddings",
+        method_name="create",
+        span_name="openai.embeddings",
+        is_async=False,
+        wrapper_function=embeddings_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.chat.completions",
+        object_name="AsyncCompletions",
+        method_name="create",
+        span_name="openai.chat",
+        is_async=True,
+        wrapper_function=achat_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.completions",
+        object_name="AsyncCompletions",
+        method_name="create",
+        span_name="openai.completion",
+        is_async=True,
+        wrapper_function=acompletion_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.embeddings",
+        object_name="AsyncEmbeddings",
+        method_name="create",
+        span_name="openai.embeddings",
+        is_async=True,
+        wrapper_function=aembeddings_wrapper,
+    ),
+    # in newer versions, Completions.parse are out of beta
+    WrappedFunctionSpec(
+        package_name="openai.resources.chat.completions",
+        object_name="Completions",
+        method_name="parse",
+        span_name="openai.chat",
+        is_async=False,
+        wrapper_function=chat_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.chat.completions",
+        object_name="AsyncCompletions",
+        method_name="parse",
+        span_name="openai.chat",
+        is_async=True,
+        wrapper_function=achat_wrapper,
+    ),
+    # Beta APIs may not be available consistently in all versions. The base
+    # instrumentor swallows AttributeError / ModuleNotFoundError / ImportError
+    # per row, which is what the old `_try_wrap` helper did by hand.
+    WrappedFunctionSpec(
+        package_name="openai.resources.beta.assistants",
+        object_name="Assistants",
+        method_name="create",
+        is_async=False,
+        wrapper_function=assistants_create_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.beta.chat.completions",
+        object_name="Completions",
+        method_name="parse",
+        span_name="openai.chat",
+        is_async=False,
+        wrapper_function=chat_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.beta.chat.completions",
+        object_name="AsyncCompletions",
+        method_name="parse",
+        span_name="openai.chat",
+        is_async=True,
+        wrapper_function=achat_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.beta.threads.runs",
+        object_name="Runs",
+        method_name="create",
+        is_async=False,
+        wrapper_function=runs_create_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.beta.threads.runs",
+        object_name="Runs",
+        method_name="retrieve",
+        is_async=False,
+        wrapper_function=runs_retrieve_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.beta.threads.runs",
+        object_name="Runs",
+        method_name="create_and_stream",
+        span_name="openai.assistant.run_stream",
+        is_async=False,
+        wrapper_function=runs_create_and_stream_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.beta.threads.messages",
+        object_name="Messages",
+        method_name="list",
+        span_name="openai.assistant.run",
+        is_async=False,
+        wrapper_function=messages_list_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.responses",
+        object_name="Responses",
+        method_name="create",
+        span_name="openai.response",
+        is_async=False,
+        wrapper_function=responses_get_or_create_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.responses",
+        object_name="Responses",
+        method_name="retrieve",
+        span_name="openai.response",
+        is_async=False,
+        wrapper_function=responses_get_or_create_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.responses",
+        object_name="Responses",
+        method_name="cancel",
+        span_name="openai.response",
+        is_async=False,
+        wrapper_function=responses_cancel_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.responses",
+        object_name="AsyncResponses",
+        method_name="create",
+        span_name="openai.response",
+        is_async=True,
+        wrapper_function=async_responses_get_or_create_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.responses",
+        object_name="AsyncResponses",
+        method_name="retrieve",
+        span_name="openai.response",
+        is_async=True,
+        wrapper_function=async_responses_get_or_create_wrapper,
+    ),
+    WrappedFunctionSpec(
+        package_name="openai.resources.responses",
+        object_name="AsyncResponses",
+        method_name="cancel",
+        span_name="openai.response",
+        is_async=True,
+        wrapper_function=async_responses_cancel_wrapper,
+    ),
+]
+
+
+class OpenAIV1Instrumentor(BaseLaminarInstrumentor):
+    _scope: LaminarInstrumentationScopeAttributes | None = None
+
+    def __init__(self):
+        super().__init__()
+        self.instrumentor_config = LaminarInstrumentorConfig(
+            wrapped_functions=[
+                {**spec, "instrumentation_scope": self.instrumentation_scope()}
+                for spec in WRAPPED_FUNCTIONS
+            ]
+        )
+
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
-    def _try_wrap(self, module, function, wrapper):
-        """
-        Wrap a function if it exists, otherwise do nothing.
-        This is useful for handling cases where the function is not available in
-        the older versions of the library.
-
-        Args:
-            module (str): The module to wrap, e.g. "openai.resources.chat.completions"
-            function (str): "Object.function" to wrap, e.g. "Completions.parse"
-            wrapper (callable): The wrapper to apply to the function.
-        """
-        try:
-            wrap_function_wrapper(module, function, wrapper)
-        except (AttributeError, ModuleNotFoundError, ImportError):
-            logger.debug(f"Failed to wrap {module}.{function}")
-            pass
-
-    def _instrument(self, **kwargs):
-        tracer_provider = kwargs.get("tracer_provider")
-        tracer = get_tracer(__name__, __version__, tracer_provider)
-
-        wrap_function_wrapper(
-            "openai.resources.chat.completions",
-            "Completions.create",
-            chat_wrapper(
-                tracer,
-            ),
-        )
-
-        wrap_function_wrapper(
-            "openai.resources.completions",
-            "Completions.create",
-            completion_wrapper(tracer),
-        )
-
-        wrap_function_wrapper(
-            "openai.resources.embeddings",
-            "Embeddings.create",
-            embeddings_wrapper(
-                tracer,
-            ),
-        )
-
-        wrap_function_wrapper(
-            "openai.resources.chat.completions",
-            "AsyncCompletions.create",
-            achat_wrapper(
-                tracer,
-            ),
-        )
-        wrap_function_wrapper(
-            "openai.resources.completions",
-            "AsyncCompletions.create",
-            acompletion_wrapper(tracer),
-        )
-        wrap_function_wrapper(
-            "openai.resources.embeddings",
-            "AsyncEmbeddings.create",
-            aembeddings_wrapper(
-                tracer,
-            ),
-        )
-        # in newer versions, Completions.parse are out of beta
-        self._try_wrap(
-            "openai.resources.chat.completions",
-            "Completions.parse",
-            chat_wrapper(
-                tracer,
-            ),
-        )
-        self._try_wrap(
-            "openai.resources.chat.completions",
-            "AsyncCompletions.parse",
-            achat_wrapper(
-                tracer,
-            ),
-        )
-
-        # Beta APIs may not be available consistently in all versions
-        self._try_wrap(
-            "openai.resources.beta.assistants",
-            "Assistants.create",
-            assistants_create_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.beta.chat.completions",
-            "Completions.parse",
-            chat_wrapper(
-                tracer,
-            ),
-        )
-        self._try_wrap(
-            "openai.resources.beta.chat.completions",
-            "AsyncCompletions.parse",
-            achat_wrapper(
-                tracer,
-            ),
-        )
-        self._try_wrap(
-            "openai.resources.beta.threads.runs",
-            "Runs.create",
-            runs_create_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.beta.threads.runs",
-            "Runs.retrieve",
-            runs_retrieve_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.beta.threads.runs",
-            "Runs.create_and_stream",
-            runs_create_and_stream_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.beta.threads.messages",
-            "Messages.list",
-            messages_list_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.responses",
-            "Responses.create",
-            responses_get_or_create_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.responses",
-            "Responses.retrieve",
-            responses_get_or_create_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.responses",
-            "Responses.cancel",
-            responses_cancel_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.responses",
-            "AsyncResponses.create",
-            async_responses_get_or_create_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.responses",
-            "AsyncResponses.retrieve",
-            async_responses_get_or_create_wrapper(tracer),
-        )
-        self._try_wrap(
-            "openai.resources.responses",
-            "AsyncResponses.cancel",
-            async_responses_cancel_wrapper(tracer),
-        )
-
-    def _uninstrument(self, **kwargs):
-        self.try_unwrap("openai.resources.chat.completions.Completions", "create")
-        self.try_unwrap("openai.resources.completions.Completions", "create")
-        self.try_unwrap("openai.resources.embeddings.Embeddings", "create")
-        self.try_unwrap("openai.resources.chat.completions.AsyncCompletions", "create")
-        self.try_unwrap("openai.resources.completions.AsyncCompletions", "create")
-        self.try_unwrap("openai.resources.embeddings.AsyncEmbeddings", "create")
-        self.try_unwrap("openai.resources.images.Images", "generate")
-        self.try_unwrap("openai.resources.chat.completions.Completions", "parse")
-        self.try_unwrap("openai.resources.chat.completions.AsyncCompletions", "parse")
-        self.try_unwrap("openai.resources.beta.assistants.Assistants", "create")
-        self.try_unwrap("openai.resources.beta.chat.completions.Completions", "parse")
-        self.try_unwrap(
-            "openai.resources.beta.chat.completions.AsyncCompletions", "parse"
-        )
-        self.try_unwrap("openai.resources.beta.threads.runs.Runs", "create")
-        self.try_unwrap("openai.resources.beta.threads.runs.Runs", "retrieve")
-        self.try_unwrap("openai.resources.beta.threads.runs.Runs", "create_and_stream")
-        self.try_unwrap("openai.resources.beta.threads.messages.Messages", "list")
-        self.try_unwrap("openai.resources.responses.Responses", "create")
-        self.try_unwrap("openai.resources.responses.Responses", "retrieve")
-        self.try_unwrap("openai.resources.responses.Responses", "cancel")
-        self.try_unwrap("openai.resources.responses.AsyncResponses", "create")
-        self.try_unwrap("openai.resources.responses.AsyncResponses", "retrieve")
-        self.try_unwrap("openai.resources.responses.AsyncResponses", "cancel")
-
-    def try_unwrap(self, module, function):
-        try:
-            unwrap(module, function)
-        except (AttributeError, ModuleNotFoundError, ImportError):
-            logger.debug(f"Failed to unwrap {module}.{function}")
-            pass
+    def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
+        if self._scope is None:
+            try:
+                openai_version = version("openai")
+            except Exception as e:
+                logger.debug(f"Failed to get openai version {e}")
+                openai_version = "unknown"
+            self._scope = LaminarInstrumentationScopeAttributes(
+                name="openai",
+                version=openai_version,
+            )
+        return self._scope

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/assistant_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/assistant_wrappers.py
@@ -2,7 +2,6 @@ import logging
 import time
 
 from opentelemetry import context as context_api
-from opentelemetry.trace import Span, Tracer
 from ..shared import (
     set_span_attribute,
     model_as_dict,
@@ -11,10 +10,17 @@ from ..utils import (
     dont_throw,
 )
 from lmnr.opentelemetry_lib.tracing.context import (
-    get_current_context,
     get_event_attributes_from_context,
 )
-from lmnr.sdk.utils import with_tracer_only_wrapper
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    WrappedFunctionSpec,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
+    safe_start_span,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
 from opentelemetry.instrumentation.utils import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
@@ -34,31 +40,7 @@ assistants = {}
 runs = {}
 
 
-# We are not reusing the safe_start_span from shared utils because we need to pass the
-# start_time parameter, which we don't want to expose on Laminar.start_span.
-# Assistants API is deprecated anyway, so it's not risky to leave old `tracer` path here.
-def _safe_start_span(
-    tracer: Tracer,
-    name: str,
-    start_time: int | None = None,
-) -> Span | None:
-    try:
-        return tracer.start_span(
-            name,
-            start_time=start_time,
-            context=get_current_context(),
-            attributes={
-                "gen_ai.system": "openai",
-                "lmnr.span.type": "LLM",
-            },
-        )
-    except Exception:
-        logger.debug(f"[openai assistants] Failed to start span: {name}", exc_info=True)
-        return None
-
-
-@with_tracer_only_wrapper
-def assistants_create_wrapper(tracer, wrapped, instance, args, kwargs):
+def assistants_create_wrapper(to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
@@ -72,8 +54,7 @@ def assistants_create_wrapper(tracer, wrapped, instance, args, kwargs):
     return response
 
 
-@with_tracer_only_wrapper
-def runs_create_wrapper(tracer, wrapped, instance, args, kwargs):
+def runs_create_wrapper(to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
@@ -100,8 +81,7 @@ def runs_create_wrapper(tracer, wrapped, instance, args, kwargs):
         raise
 
 
-@with_tracer_only_wrapper
-def runs_retrieve_wrapper(tracer, wrapped, instance, args, kwargs):
+def runs_retrieve_wrapper(to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs):
     @dont_throw
     def process_response(response):
         if type(response) is LegacyAPIResponse:
@@ -131,8 +111,7 @@ def runs_retrieve_wrapper(tracer, wrapped, instance, args, kwargs):
         raise
 
 
-@with_tracer_only_wrapper
-def messages_list_wrapper(tracer, wrapped, instance, args, kwargs):
+def messages_list_wrapper(to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
@@ -149,13 +128,16 @@ def messages_list_wrapper(tracer, wrapped, instance, args, kwargs):
         response_dict.get("data", []), key=lambda x: x.get("created_at", 0)
     )
 
-    span = _safe_start_span(
-        tracer,
-        "openai.assistant.run",
+    span = safe_start_span(
+        name=to_wrap.get("span_name") or "openai.assistant.run",
+        attributes={"gen_ai.system": "openai"},
+        span_type="LLM",
         start_time=run.get("start_time"),
     )
     if span is None:
         return response
+
+    stamp_instrumentation_scope(span, to_wrap)
 
     if exception := run.get("exception"):
         span.set_attribute(ERROR_TYPE, exception.__class__.__name__)
@@ -243,20 +225,22 @@ def messages_list_wrapper(tracer, wrapped, instance, args, kwargs):
     return response
 
 
-@with_tracer_only_wrapper
-def runs_create_and_stream_wrapper(tracer, wrapped, instance, args, kwargs):
+def runs_create_and_stream_wrapper(to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
     assistant_id = kwargs.get("assistant_id")
     instructions = kwargs.get("instructions")
 
-    span = _safe_start_span(
-        tracer,
-        "openai.assistant.run_stream",
+    span = safe_start_span(
+        name=to_wrap.get("span_name") or "openai.assistant.run_stream",
+        attributes={"gen_ai.system": "openai"},
+        span_type="LLM",
     )
     if span is None:
         return wrapped(*args, **kwargs)
+
+    stamp_instrumentation_scope(span, to_wrap)
 
     i = 0
     if assistants.get(assistant_id) is not None:

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/openai/v1/responses_wrappers.py
@@ -52,14 +52,23 @@ from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
     GEN_AI_USAGE_OUTPUT_TOKENS,
 )
 from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
-from opentelemetry.trace import Span, SpanKind, StatusCode, Tracer
+from opentelemetry.trace import Span, SpanKind, StatusCode
 from typing_extensions import NotRequired
 
 from lmnr.opentelemetry_lib.tracing.context import (
     get_current_context,
     get_event_attributes_from_context,
 )
-from lmnr.sdk.utils import json_dumps, with_tracer_only_wrapper
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
+    WrappedFunctionSpec,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
+    safe_start_span,
+)
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
+from lmnr.sdk.utils import json_dumps
 from openai._legacy_response import LegacyAPIResponse
 
 from ..shared import (
@@ -519,9 +528,8 @@ def set_data_attributes(traced_response: TracedData, span: Span):
 
 
 @dont_throw
-@with_tracer_only_wrapper
 def responses_get_or_create_wrapper(
-    tracer: Tracer, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs
 ):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
@@ -534,22 +542,21 @@ def responses_get_or_create_wrapper(
     # Debugger replay (non-streaming only): probe the server-side cache before
     # the live call. Streaming responses fall through to the live path below.
     if _replay_enabled() and not kwargs.get("stream", False):
-        return _replay_response_sync(tracer, start_time, wrapped, args, kwargs)
+        return _replay_response_sync(to_wrap, start_time, wrapped, args, kwargs)
 
     try:
         response = wrapped(*args, **kwargs)
         if isinstance(response, Stream):
             return response
     except Exception as e:
-        _process_exception(tracer, start_time, kwargs, e)
+        _process_exception(to_wrap, start_time, kwargs, e)
         raise
-    return _process_response(tracer, start_time, response, kwargs)
+    return _process_response(to_wrap, start_time, response, kwargs)
 
 
 @dont_throw
-@with_tracer_only_wrapper
 async def async_responses_get_or_create_wrapper(
-    tracer: Tracer, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs
 ):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return await wrapped(*args, **kwargs)
@@ -560,19 +567,21 @@ async def async_responses_get_or_create_wrapper(
     start_time = time.time_ns()
 
     if _replay_enabled() and not kwargs.get("stream", False):
-        return await _replay_response_async(tracer, start_time, wrapped, args, kwargs)
+        return await _replay_response_async(to_wrap, start_time, wrapped, args, kwargs)
 
     try:
         response = await wrapped(*args, **kwargs)
         if isinstance(response, (Stream, AsyncStream)):
             return response
     except Exception as e:
-        _process_exception(tracer, start_time, kwargs, e)
+        _process_exception(to_wrap, start_time, kwargs, e)
         raise
-    return _process_response(tracer, start_time, response, kwargs)
+    return _process_response(to_wrap, start_time, response, kwargs)
 
 
-def _open_replay_span(tracer: Tracer, start_time: int, kwargs) -> Span:
+def _open_replay_span(
+    to_wrap: WrappedFunctionSpec, start_time: int, kwargs
+) -> Span | None:
     """Open the Responses-API span up front (before the live call) and stamp
     `gen_ai.input.messages` so the replay cache can hash the input.
 
@@ -580,12 +589,16 @@ def _open_replay_span(tracer: Tracer, start_time: int, kwargs) -> Span:
     or the source-trace hash and the replay-run hash diverge. Both go through
     `build_genai_input_messages(process_input(kwargs["input"]))`.
     """
-    span = tracer.start_span(
-        SPAN_NAME,
+    span = safe_start_span(
+        name=to_wrap.get("span_name") or SPAN_NAME,
         kind=SpanKind.CLIENT,
         start_time=start_time,
         context=get_current_context(),
+        span_type="LLM",
     )
+    if span is None:
+        return None
+    stamp_instrumentation_scope(span, to_wrap)
     if should_send_prompts():
         processed_input = process_input(kwargs.get("input"))
         input_messages = build_genai_input_messages(processed_input)
@@ -608,7 +621,7 @@ def _record_raw_response(span: Span, response) -> None:
         pass
 
 
-def _finish_live_replay(tracer: Tracer, start_time: int, span: Span, response, kwargs):
+def _finish_live_replay(start_time: int, span: Span, response, kwargs):
     """Process a live response onto the pre-opened replay span and end it."""
     parsed_response = parse_response(response)
     traced_data = _build_traced_data(start_time, parsed_response, kwargs)
@@ -641,10 +654,12 @@ def _serve_cached_response(start_time: int, span: Span, outcome, kwargs):
     return cached
 
 
-def _replay_response_sync(tracer: Tracer, start_time, wrapped, args, kwargs):
+def _replay_response_sync(to_wrap: WrappedFunctionSpec, start_time, wrapped, args, kwargs):
     from lmnr.sdk.debug.replay import cache_outcome_for
 
-    span = _open_replay_span(tracer, start_time, kwargs)
+    span = _open_replay_span(to_wrap, start_time, kwargs)
+    if span is None:
+        return wrapped(*args, **kwargs)
     outcome = cache_outcome_for(span)
     if outcome is not None and outcome.kind == "hit":
         served = _serve_cached_response(start_time, span, outcome, kwargs)
@@ -662,13 +677,17 @@ def _replay_response_sync(tracer: Tracer, start_time, wrapped, args, kwargs):
         span.set_status(StatusCode.ERROR, str(e))
         span.end()
         raise
-    return _finish_live_replay(tracer, start_time, span, response, kwargs)
+    return _finish_live_replay(start_time, span, response, kwargs)
 
 
-async def _replay_response_async(tracer: Tracer, start_time, wrapped, args, kwargs):
+async def _replay_response_async(
+    to_wrap: WrappedFunctionSpec, start_time, wrapped, args, kwargs
+):
     from lmnr.sdk.debug.replay import acache_outcome_for
 
-    span = _open_replay_span(tracer, start_time, kwargs)
+    span = _open_replay_span(to_wrap, start_time, kwargs)
+    if span is None:
+        return await wrapped(*args, **kwargs)
     outcome = await acache_outcome_for(span)
     if outcome is not None and outcome.kind == "hit":
         served = _serve_cached_response(start_time, span, outcome, kwargs)
@@ -686,11 +705,11 @@ async def _replay_response_async(tracer: Tracer, start_time, wrapped, args, kwar
         span.set_status(StatusCode.ERROR, str(e))
         span.end()
         raise
-    return _finish_live_replay(tracer, start_time, span, response, kwargs)
+    return _finish_live_replay(start_time, span, response, kwargs)
 
 
 @dont_throw
-def _process_exception(tracer: Tracer, start_time, kwargs, e):
+def _process_exception(to_wrap: WrappedFunctionSpec, start_time, kwargs, e):
     response_id = kwargs.get("response_id")
     existing_data = {}
     if response_id and response_id in responses:
@@ -730,12 +749,16 @@ def _process_exception(tracer: Tracer, start_time, kwargs, e):
     except Exception:
         traced_data = None
 
-    span = tracer.start_span(
-        SPAN_NAME,
+    span = safe_start_span(
+        name=to_wrap.get("span_name") or SPAN_NAME,
         kind=SpanKind.CLIENT,
         start_time=(start_time if traced_data is None else int(traced_data.start_time)),
         context=get_current_context(),
+        span_type="LLM",
     )
+    if span is None:
+        return
+    stamp_instrumentation_scope(span, to_wrap)
     span.set_attribute(ERROR_TYPE, e.__class__.__name__)
     span.record_exception(e, attributes=get_event_attributes_from_context())
     span.set_status(StatusCode.ERROR, str(e))
@@ -809,7 +832,7 @@ def _build_traced_data(start_time, parsed_response, kwargs) -> Optional[TracedDa
 
 
 @dont_throw
-def _process_response(tracer: Tracer, start_time, response, kwargs):
+def _process_response(to_wrap: WrappedFunctionSpec, start_time, response, kwargs):
     parsed_response = parse_response(response)
 
     response_id = getattr(parsed_response, "id", None)
@@ -821,21 +844,25 @@ def _process_response(tracer: Tracer, start_time, response, kwargs):
         return response
 
     if parsed_response.status == "completed":
-        span = tracer.start_span(
-            SPAN_NAME,
+        span = safe_start_span(
+            name=to_wrap.get("span_name") or SPAN_NAME,
             kind=SpanKind.CLIENT,
             start_time=int(traced_data.start_time),
             context=get_current_context(),
+            span_type="LLM",
         )
-        set_data_attributes(traced_data, span)
-        span.end()
+        if span is not None:
+            stamp_instrumentation_scope(span, to_wrap)
+            set_data_attributes(traced_data, span)
+            span.end()
 
     return response
 
 
 @dont_throw
-@with_tracer_only_wrapper
-def responses_cancel_wrapper(tracer: Tracer, wrapped, instance, args, kwargs):
+def responses_cancel_wrapper(
+    to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs
+):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return wrapped(*args, **kwargs)
 
@@ -853,26 +880,27 @@ def responses_cancel_wrapper(tracer: Tracer, wrapped, instance, args, kwargs):
         return response
     existing_data = responses.pop(response_id, None)
     if existing_data is not None:
-        span = tracer.start_span(
-            SPAN_NAME,
+        span = safe_start_span(
+            name=to_wrap.get("span_name") or SPAN_NAME,
             kind=SpanKind.CLIENT,
             start_time=int(existing_data.start_time),
-            record_exception=True,
             context=get_current_context(),
+            span_type="LLM",
         )
-        span.record_exception(
-            Exception("Response cancelled"),
-            attributes=get_event_attributes_from_context(),
-        )
-        set_data_attributes(existing_data, span)
-        span.end()
+        if span is not None:
+            stamp_instrumentation_scope(span, to_wrap)
+            span.record_exception(
+                Exception("Response cancelled"),
+                attributes=get_event_attributes_from_context(),
+            )
+            set_data_attributes(existing_data, span)
+            span.end()
     return response
 
 
 @dont_throw
-@with_tracer_only_wrapper
 async def async_responses_cancel_wrapper(
-    tracer: Tracer, wrapped, instance, args, kwargs
+    to_wrap: WrappedFunctionSpec, wrapped, instance, args, kwargs
 ):
     if context_api.get_value(_SUPPRESS_INSTRUMENTATION_KEY):
         return await wrapped(*args, **kwargs)
@@ -891,19 +919,21 @@ async def async_responses_cancel_wrapper(
         return response
     existing_data = responses.pop(response_id, None)
     if existing_data is not None:
-        span = tracer.start_span(
-            SPAN_NAME,
+        span = safe_start_span(
+            name=to_wrap.get("span_name") or SPAN_NAME,
             kind=SpanKind.CLIENT,
             start_time=int(existing_data.start_time),
-            record_exception=True,
             context=get_current_context(),
+            span_type="LLM",
         )
-        span.record_exception(
-            Exception("Response cancelled"),
-            attributes=get_event_attributes_from_context(),
-        )
-        set_data_attributes(existing_data, span)
-        span.end()
+        if span is not None:
+            stamp_instrumentation_scope(span, to_wrap)
+            span.record_exception(
+                Exception("Response cancelled"),
+                attributes=get_event_attributes_from_context(),
+            )
+            set_data_attributes(existing_data, span)
+            span.end()
     return response
 
 

--- a/tests/test_instrumentor_targets.py
+++ b/tests/test_instrumentor_targets.py
@@ -14,6 +14,7 @@ import importlib
 import sys
 
 import pytest
+from wrapt import ObjectProxy
 
 # (instrumentor import path, class name, {(module, "Object.method" | "func"), ...})
 #
@@ -59,6 +60,82 @@ INSTRUMENTOR_TARGETS: dict[str, tuple[str, str, set[tuple[str, str]]]] = {
             ("claude_agent_sdk", "create_sdk_mcp_server"),
         },
     ),
+    "groq": (
+        "lmnr.opentelemetry_lib.opentelemetry.instrumentation.groq",
+        "GroqInstrumentor",
+        {
+            ("groq.resources.chat.completions", "Completions.create"),
+            ("groq.resources.chat.completions", "AsyncCompletions.create"),
+        },
+    ),
+    "anthropic": (
+        "lmnr.opentelemetry_lib.opentelemetry.instrumentation.anthropic",
+        "AnthropicInstrumentor",
+        {
+            ("anthropic.resources.completions", "Completions.create"),
+            ("anthropic.resources.completions", "AsyncCompletions.create"),
+            ("anthropic.resources.messages", "Messages.create"),
+            ("anthropic.resources.messages", "Messages.parse"),
+            ("anthropic.resources.messages", "Messages.stream"),
+            ("anthropic.resources.messages", "AsyncMessages.create"),
+            ("anthropic.resources.messages", "AsyncMessages.parse"),
+            ("anthropic.resources.messages", "AsyncMessages.stream"),
+            ("anthropic.resources.beta.messages.messages", "Messages.create"),
+            ("anthropic.resources.beta.messages.messages", "Messages.parse"),
+            ("anthropic.resources.beta.messages.messages", "Messages.stream"),
+            ("anthropic.resources.beta.messages.messages", "AsyncMessages.create"),
+            ("anthropic.resources.beta.messages.messages", "AsyncMessages.parse"),
+            ("anthropic.resources.beta.messages.messages", "AsyncMessages.stream"),
+            ("anthropic.lib.bedrock._beta_messages", "Messages.create"),
+            ("anthropic.lib.bedrock._beta_messages", "Messages.stream"),
+            ("anthropic.lib.bedrock._beta_messages", "AsyncMessages.create"),
+            ("anthropic.lib.bedrock._beta_messages", "AsyncMessages.stream"),
+        },
+    ),
+    "google_genai": (
+        "lmnr.opentelemetry_lib.opentelemetry.instrumentation.google_genai",
+        "GoogleGenAiSdkInstrumentor",
+        {
+            ("google.genai.models", "Models.generate_content"),
+            ("google.genai.models", "Models.generate_content_stream"),
+            ("google.genai.models", "AsyncModels.generate_content"),
+            ("google.genai.models", "AsyncModels.generate_content_stream"),
+        },
+    ),
+    # Driven through the version-gate dispatcher rather than `OpenAIV1Instrumentor`
+    # directly, because that is what actually gets instrumented in production and
+    # what the conftest session fixture flipped on.
+    #
+    # `openai.resources.images.Images.generate` is deliberately absent: it appears
+    # only in the pre-migration `_uninstrument` list, never in `_instrument` — an
+    # orphan unwrap of something nothing ever wrapped.
+    "openai": (
+        "lmnr.opentelemetry_lib.opentelemetry.instrumentation.openai",
+        "OpenAIInstrumentor",
+        {
+            ("openai.resources.chat.completions", "Completions.create"),
+            ("openai.resources.chat.completions", "AsyncCompletions.create"),
+            ("openai.resources.chat.completions", "Completions.parse"),
+            ("openai.resources.chat.completions", "AsyncCompletions.parse"),
+            ("openai.resources.completions", "Completions.create"),
+            ("openai.resources.completions", "AsyncCompletions.create"),
+            ("openai.resources.embeddings", "Embeddings.create"),
+            ("openai.resources.embeddings", "AsyncEmbeddings.create"),
+            ("openai.resources.beta.assistants", "Assistants.create"),
+            ("openai.resources.beta.chat.completions", "Completions.parse"),
+            ("openai.resources.beta.chat.completions", "AsyncCompletions.parse"),
+            ("openai.resources.beta.threads.runs", "Runs.create"),
+            ("openai.resources.beta.threads.runs", "Runs.retrieve"),
+            ("openai.resources.beta.threads.runs", "Runs.create_and_stream"),
+            ("openai.resources.beta.threads.messages", "Messages.list"),
+            ("openai.resources.responses", "Responses.create"),
+            ("openai.resources.responses", "Responses.retrieve"),
+            ("openai.resources.responses", "Responses.cancel"),
+            ("openai.resources.responses", "AsyncResponses.create"),
+            ("openai.resources.responses", "AsyncResponses.retrieve"),
+            ("openai.resources.responses", "AsyncResponses.cancel"),
+        },
+    ),
     # NOTE: skyvern is deliberately absent. It is also migrated, but its
     # instrumentor module hard-imports `skyvern` at module level, and skyvern
     # requires Python 3.11+ while this SDK supports 3.10 — so it cannot be a dev
@@ -77,23 +154,39 @@ def _resolve(module_name: str, target: str):
 
 
 def _is_wrapped(module_name: str, target: str) -> bool:
+    """True when *we* wrapped the target, i.e. it is a wrapt proxy.
+
+    Deliberately not `hasattr(..., "__wrapped__")`: `functools.wraps` sets that
+    too, and the anthropic/openai/groq SDKs decorate their own generated
+    `create` methods with `@required_args`, which uses `functools.wraps`. Those
+    targets therefore look "wrapped" straight out of the box, so the weaker
+    probe reports an uninstrumented method as still-instrumented. Every
+    instrumentor here wraps through wrapt, which produces an `ObjectProxy`.
+    """
     holder, attr = _resolve(module_name, target)
-    return hasattr(getattr(holder, attr), "__wrapped__")
+    return isinstance(getattr(holder, attr), ObjectProxy)
 
 
 def _reachable(targets: set[tuple[str, str]]) -> set[tuple[str, str]]:
     """Drop targets whose module cannot be imported in this environment.
 
-    Every `_instrument` here swallows ModuleNotFoundError per wrap, so an
-    unreachable target is legitimately left unwrapped rather than being a
-    failure. Asserting on them anyway would make the suite depend on the target
-    library's own optional extras.
+    Every `_instrument` here swallows ModuleNotFoundError / AttributeError per
+    wrap, so an unreachable target is legitimately left unwrapped rather than
+    being a failure. Asserting on them anyway would make the suite depend on the
+    target library's own optional extras.
+
+    The final attribute is checked too, not just the holder path: some methods
+    exist on one resource class and not its sibling — e.g.
+    `anthropic.lib.bedrock._beta_messages.Messages` has no `stream` or `parse`
+    even though the regular and beta `Messages` do.
     """
     ok = set()
     for module_name, target in targets:
         try:
-            _resolve(module_name, target)
+            holder, attr = _resolve(module_name, target)
         except (ImportError, AttributeError):
+            continue
+        if not hasattr(holder, attr):
             continue
         ok.add((module_name, target))
     return ok


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Large refactor across all major LLM tracing entry points and OpenAI Responses replay span lifecycle; intended behavior parity but regressions in wrapping targets or span attributes would affect production observability.
> 
> **Overview**
> **Migrates Anthropic, Google GenAI, Groq, and OpenAI (v0/v1) onto the shared `BaseLaminarInstrumentor` pattern**, replacing per-instrumentor `wrap_function_wrapper` / `unwrap` loops and `with_tracer_wrapper` with declarative `WRAPPED_FUNCTIONS` (`WrappedFunctionSpec`) and centralized `_instrument` / `_uninstrument` from the base class.
> 
> Wrapper signatures now lead with `to_wrap: WrappedFunctionSpec` instead of a injected `Tracer`; spans are started via `safe_start_span`, and **`stamp_instrumentation_scope`** records `lmnr.span.instrumentation_scope.*` (library name + version from `importlib.metadata`) on each LLM span. OpenAI chat/completion/embeddings, assistant, and Responses paths—including debug replay—are updated to the same shape; assistant spans drop the bespoke tracer-only `_safe_start_span` in favor of `safe_start_span`.
> 
> **Tests** extend `test_instrumentor_targets` for groq, anthropic, google_genai, and openai, and treat instrumentation as present only when the target is a **wrapt `ObjectProxy`** (avoiding false positives from SDK `functools.wraps`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85d95b90c710a4af00695398dfa17323af2a575. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->