### PR TITLE
Chore/pyright fixes core utils

### DIFF
--- a/src/lmnr/__init__.py
+++ b/src/lmnr/__init__.py
@@ -9,9 +9,9 @@ from .sdk.client.synchronous.sync_client import LaminarClient
 from .sdk.datasets import EvaluationDataset, LaminarDataset
 from .sdk.decorators import observe
 from .sdk.evaluations import evaluate
+from .sdk.evaluations.models import HumanEvaluator
 from .sdk.laminar import Laminar
 from .sdk.types import (
-    HumanEvaluator,
     LaminarSpanContext,
     MaskInputOptions,
     SessionRecordingOptions,

--- a/src/lmnr/cli/datasets.py
+++ b/src/lmnr/cli/datasets.py
@@ -88,8 +88,8 @@ async def _pull_all_data(
             offset=current_offset,
             limit=batch_size,
         )
-        result.extend(data.items)
-        if stop_at is not None and current_offset + batch_size >= stop_at or current_offset + batch_size >= data.total_count:
+        result.extend(data["items"])
+        if stop_at is not None and current_offset + batch_size >= stop_at or current_offset + batch_size >= data["total_count"]:
             has_more = False
         current_offset += batch_size
 
@@ -220,9 +220,9 @@ async def handle_datasets_list(args: DatasetsArgs) -> None:
 
     # Print each dataset row
     for dataset in datasets:
-        created_at_str = dataset.created_at.strftime("%Y-%m-%d %H:%M:%S")
+        created_at_str = dataset["created_at"].strftime("%Y-%m-%d %H:%M:%S")
         print(
-            f"{dataset.id!s:<{id_width}}  {created_at_str:<{created_at_width}}  {dataset.name}"
+            f"{dataset['id']!s:<{id_width}}  {created_at_str:<{created_at_width}}  {dataset['name']}"
         )
 
     print(f"\nTotal: {len(datasets)} dataset(s)\n")

--- a/src/lmnr/opentelemetry_lib/decorators/__init__.py
+++ b/src/lmnr/opentelemetry_lib/decorators/__init__.py
@@ -1,7 +1,8 @@
 import asyncio
 import types
+from collections.abc import AsyncGenerator, Callable, Generator
 from functools import wraps
-from typing import Any, AsyncGenerator, Callable, Generator, Literal, TypeVar
+from typing import Any, Literal, TypeVar
 
 from opentelemetry import context as context_api
 from opentelemetry.trace import Span, Status, StatusCode

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/claude_agent/wrappers.py
@@ -7,6 +7,7 @@ from typing import Any, Sequence
 from lmnr import Laminar
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
     add_spec_wrapper,
+    stamp_instrumentation_scope,
 )
 from lmnr.sdk.log import get_default_logger
 
@@ -57,6 +58,7 @@ def wrap_sync(
         span_name(to_wrap),
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
+        stamp_instrumentation_scope(span, to_wrap)
         record_input(span, wrapped, args, kwargs)
 
         try:
@@ -83,6 +85,7 @@ async def wrap_async(
         span_name(to_wrap),
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
+        stamp_instrumentation_scope(span, to_wrap)
         record_input(span, wrapped, args, kwargs)
 
         if to_wrap.get("should_publish_span_context"):
@@ -116,6 +119,7 @@ def wrap_async_gen(
             span_name(to_wrap),
             span_type=to_wrap.get("span_type", "DEFAULT"),
         )
+        stamp_instrumentation_scope(span, to_wrap)
         collected = []
         async_iter = None
 
@@ -567,6 +571,7 @@ def wrap_query(
             span_name(to_wrap),
             span_type=to_wrap.get("span_type", "DEFAULT"),
         ) as span:
+            stamp_instrumentation_scope(span, to_wrap)
             record_input(span, wrapped, args, kwargs)
 
             collected = []

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_agent/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_agent/__init__.py
@@ -13,6 +13,9 @@ from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
     LaminarInstrumentorConfig,
     WrappedFunctionSpec,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
 from lmnr.sdk.utils import json_dumps
 
 from opentelemetry.trace import Span
@@ -31,11 +34,12 @@ def _wrap_run(
     kwargs: dict[str, Any],
 ):
     parent_span = Laminar.start_span(to_wrap.get("span_name") or "ComputerAgent.run")
+    stamp_instrumentation_scope(parent_span, to_wrap)
     instance._lmnr_parent_span = parent_span
 
     try:
         result: AsyncGenerator[dict[str, Any], None] = wrapped(*args, **kwargs)
-        return _abuild_from_streaming_response(parent_span, result)
+        return _abuild_from_streaming_response(to_wrap, parent_span, result)
     except Exception as e:
         if parent_span.is_recording():
             parent_span.set_status(Status(StatusCode.ERROR))
@@ -45,13 +49,16 @@ def _wrap_run(
 
 
 async def _abuild_from_streaming_response(
-    parent_span: Span, response: AsyncGenerator[dict[str, Any], None]
+    to_wrap: WrappedFunctionSpec,
+    parent_span: Span,
+    response: AsyncGenerator[dict[str, Any], None],
 ) -> AsyncGenerator[dict[str, Any], None]:
     with Laminar.use_span(parent_span, end_on_exit=True):
         response_iter = aiter(response)
         while True:
             step = None
             step_span = Laminar.start_span("ComputerAgent.step")
+            stamp_instrumentation_scope(step_span, to_wrap)
             with Laminar.use_span(step_span):
                 try:
                     step = await anext(response_iter)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_computer/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/cua_computer/__init__.py
@@ -14,6 +14,9 @@ from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
     LaminarInstrumentorConfig,
     WrappedFunctionSpec,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
 from lmnr.opentelemetry_lib.tracing.context import get_current_context
 
 from opentelemetry import trace
@@ -96,6 +99,7 @@ def _wrap(
 ):
     if to_wrap.get("action") == "start_parent_span":
         parent_span = Laminar.start_span("computer.run")
+        stamp_instrumentation_scope(parent_span, to_wrap)
         add_input_to_parent_span(parent_span, instance)
         result = wrapped(*args, **kwargs)
         try:
@@ -126,6 +130,7 @@ def _wrap(
         with Laminar.start_as_current_span(
             f"{instance_name}.{to_wrap['method_name']}", span_type="TOOL"
         ) as span:
+            stamp_instrumentation_scope(span, to_wrap)
             span.set_attribute(
                 "lmnr.span.input",
                 json_dumps(get_input_from_func_args(wrapped, True, args, kwargs)),
@@ -153,6 +158,7 @@ async def _wrap_async(
 ):
     if to_wrap.get("action") == "start_parent_span":
         parent_span = Laminar.start_span("computer.run")
+        stamp_instrumentation_scope(parent_span, to_wrap)
         add_input_to_parent_span(parent_span, instance)
         result = await wrapped(*args, **kwargs)
         try:
@@ -183,6 +189,7 @@ async def _wrap_async(
             f"{instance_name}.{to_wrap['method_name']}",
             span_type="TOOL",
         ) as span:
+            stamp_instrumentation_scope(span, to_wrap)
             span.set_attribute(
                 "lmnr.span.input",
                 json_dumps(get_input_from_func_args(wrapped, True, args, kwargs)),

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/daytona/wrappers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/daytona/wrappers.py
@@ -16,6 +16,9 @@ from lmnr import Laminar
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
     WrappedFunctionSpec,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.utils import (
     set_span_attribute,
     dont_throw,
@@ -312,6 +315,7 @@ def _wrap(
         tags=(kwargs.get("metadata") or {}).get("tags", []),
         metadata=(kwargs.get("metadata") or {}),
     )
+    stamp_instrumentation_scope(span, to_wrap)
 
     # Extract session_id and request from args/kwargs
     # execute_session_command(session_id, request)
@@ -382,6 +386,7 @@ async def _awrap(
         tags=(kwargs.get("metadata") or {}).get("tags", []),
         metadata=(kwargs.get("metadata") or {}),
     )
+    stamp_instrumentation_scope(span, to_wrap)
 
     # Extract session_id and request from args/kwargs
     # execute_session_command(session_id, request)
@@ -488,6 +493,7 @@ def _wrap_exec(
         tags=(kwargs.get("metadata") or {}).get("tags", []),
         metadata=(kwargs.get("metadata") or {}),
     )
+    stamp_instrumentation_scope(span, to_wrap)
 
     # Extract command and cwd from args/kwargs
     # exec(command, cwd=None, env=None, timeout=None)
@@ -553,6 +559,7 @@ async def _awrap_exec(
         tags=(kwargs.get("metadata") or {}).get("tags", []),
         metadata=(kwargs.get("metadata") or {}),
     )
+    stamp_instrumentation_scope(span, to_wrap)
 
     # Extract command and cwd from args/kwargs
     # exec(command, cwd=None, env=None, timeout=None)

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/kernel/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/kernel/__init__.py
@@ -17,6 +17,9 @@ from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
     LaminarInstrumentorConfig,
     WrappedFunctionSpec,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    stamp_instrumentation_scope,
+)
 from lmnr.sdk.decorators import observe
 from lmnr.sdk.utils import get_input_from_func_args, is_async, json_dumps
 from lmnr import Laminar
@@ -53,6 +56,7 @@ def _wrap(
         f"{to_wrap.get('class_name')}.{to_wrap['method_name']}",
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
+        stamp_instrumentation_scope(span, to_wrap)
         input_kv = get_input_from_func_args(wrapped, True, args, kwargs)
         if "id" in input_kv:
             input_kv["session_id"] = input_kv.get("id")
@@ -83,6 +87,7 @@ async def _wrap_async(
         f"{to_wrap.get('class_name')}.{to_wrap['method_name']}",
         span_type=to_wrap.get("span_type", "DEFAULT"),
     ) as span:
+        stamp_instrumentation_scope(span, to_wrap)
         input_kv = get_input_from_func_args(wrapped, True, args, kwargs)
         if "id" in input_kv:
             input_kv["session_id"] = input_kv.get("id")

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/shared/wrapper_helpers.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/shared/wrapper_helpers.py
@@ -73,8 +73,8 @@ def add_spec_wrapper(
     return wrapper
 
 
-def stamp_instrumentation_scope(
-    span: Span | None, to_wrap: WrappedFunctionSpec
+def set_instrumentation_scope_attributes(
+    span: Span | None, scope: LaminarInstrumentationScopeAttributes | None
 ) -> None:
     """Record which instrumentation produced this span.
 
@@ -82,17 +82,30 @@ def stamp_instrumentation_scope(
     resolves the single `lmnr.tracer` OTel tracer — so the real OTel
     InstrumentationScope is the same for all of them and cannot identify the
     source library. These attributes carry that information instead.
+
+    Prefer `stamp_instrumentation_scope`, which reads the scope off the spec.
+    This lower-level entry point exists for the handful of span-creating code
+    paths that are not spec wrappers and so have no `to_wrap` to read (e.g.
+    skyvern's global `LLM_API_HANDLER` swap), which take the scope from their
+    instrumentor directly.
     """
-    if span is None:
-        return
-    scope: LaminarInstrumentationScopeAttributes | None = to_wrap.get(
-        "instrumentation_scope"
-    )
-    if not scope:
+    if span is None or not scope:
         return
     set_span_attribute(
         span, "lmnr.span.instrumentation_scope.name", scope.get("name")
     )
     set_span_attribute(
         span, "lmnr.span.instrumentation_scope.version", scope.get("version")
+    )
+
+
+def stamp_instrumentation_scope(
+    span: Span | None, to_wrap: WrappedFunctionSpec
+) -> None:
+    """Record which instrumentation produced this span, reading the spec.
+
+    See `set_instrumentation_scope_attributes` for why these attributes exist.
+    """
+    set_instrumentation_scope_attributes(
+        span, to_wrap.get("instrumentation_scope")
     )

--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/skyvern/__init__.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/skyvern/__init__.py
@@ -12,6 +12,10 @@ from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
     LaminarInstrumentorConfig,
     WrappedFunctionSpec,
 )
+from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.wrapper_helpers import (
+    set_instrumentation_scope_attributes,
+    stamp_instrumentation_scope,
+)
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.utils import get_input_from_func_args, json_dumps
 
@@ -50,6 +54,7 @@ async def _wrap(
     # instrumentor no longer receives one. The attributes are passed through
     # verbatim so the emitted span is unchanged.
     with Laminar.start_as_current_span(span_name, attributes=attributes) as span:
+        stamp_instrumentation_scope(span, to_wrap)
         try:
             result = await wrapped(*args, **kwargs)
 
@@ -67,7 +72,9 @@ async def _wrap(
             raise
 
 
-def instrument_llm_handler():
+def instrument_llm_handler(
+    scope: LaminarInstrumentationScopeAttributes | None = None,
+):
     """Wrap skyvern's global LLM handler, returning the original for restoration.
 
     Reading `app.LLM_API_HANDLER` raises `RuntimeError` until skyvern's forge app
@@ -93,6 +100,7 @@ def instrument_llm_handler():
         }
 
         with Laminar.start_as_current_span(span_name, attributes=attributes) as span:
+            set_instrumentation_scope_attributes(span, scope)
             try:
                 result = await original_handler(*args, **kwargs)
 
@@ -216,7 +224,9 @@ class SkyvernInstrumentor(BaseLaminarInstrumentor):
         # `_instrument` before any method was wrapped, so a single uninitialized
         # global left ALL seven unwrapped — skyvern tracing silently did nothing.
         try:
-            self._original_llm_handler = instrument_llm_handler()
+            self._original_llm_handler = instrument_llm_handler(
+                self.instrumentation_scope()
+            )
         except Exception as e:
             logger.debug(f"Failed to instrument skyvern LLM_API_HANDLER: {e}")
 

--- a/src/lmnr/sdk/client/asynchronous/resources/datasets.py
+++ b/src/lmnr/sdk/client/asynchronous/resources/datasets.py
@@ -10,6 +10,9 @@ from lmnr.sdk.types import (
     Dataset,
     GetDatapointsResponse,
     PushDatapointsResponse,
+    parse_dataset,
+    parse_get_datapoints_response,
+    parse_push_datapoints_response,
 )
 from lmnr.sdk.utils import serialize
 
@@ -32,7 +35,7 @@ class AsyncDatasets(BaseAsyncResource):
             raise ValueError(
                 f"Error listing datasets: [{response.status_code}] {response.text}"
             )
-        return [Dataset.model_validate(dataset) for dataset in response.json()]
+        return [parse_dataset(dataset) for dataset in response.json()]
 
     async def get_dataset_by_name(self, name: str) -> list[Dataset]:
         """Get a dataset by name."""
@@ -45,7 +48,7 @@ class AsyncDatasets(BaseAsyncResource):
             raise ValueError(
                 f"Error getting dataset: [{response.status_code}] {response.text}"
             )
-        return [Dataset.model_validate(dataset) for dataset in response.json()]
+        return [parse_dataset(dataset) for dataset in response.json()]
 
     async def push(
         self,
@@ -89,7 +92,7 @@ class AsyncDatasets(BaseAsyncResource):
                     f"Error pushing data to dataset: [{response.status_code}] {response.text}"
                 )
 
-            response = PushDatapointsResponse.model_validate(response.json())
+            response = parse_push_datapoints_response(response.json())
         # Currently, the response only contains the dataset ID,
         # so it's safe to return the last response only.
         return response
@@ -126,4 +129,4 @@ class AsyncDatasets(BaseAsyncResource):
             raise ValueError(
                 f"Error pulling data from dataset: [{response.status_code}] {response.text}"
             )
-        return GetDatapointsResponse.model_validate(response.json())
+        return parse_get_datapoints_response(response.json())

--- a/src/lmnr/sdk/client/asynchronous/resources/evals.py
+++ b/src/lmnr/sdk/client/asynchronous/resources/evals.py
@@ -1,19 +1,32 @@
 """Evals resource for interacting with Laminar evaluations API."""
 
+from __future__ import annotations
+
 import uuid
 import warnings
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lmnr.sdk.client.asynchronous.resources.base import BaseAsyncResource
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.types import (
     GetDatapointsResponse,
-    InitEvaluationResponse,
-    EvaluationResultDatapoint,
-    PartialEvaluationDatapoint,
+    parse_get_datapoints_response,
 )
 from lmnr.sdk.utils import describe_response, serialize, json_dumps
+
+# `lmnr.sdk.evaluations` (a package) transitively imports this client package
+# (via `lmnr.sdk.datasets` -> `LaminarClient`), so importing
+# `lmnr.sdk.evaluations.models` at module level here would be circular.
+# Annotation-only uses are deferred via `TYPE_CHECKING` (safe under
+# `from __future__ import annotations`); actual constructors/functions are
+# imported lazily inside the methods that call them.
+if TYPE_CHECKING:
+    from lmnr.sdk.evaluations.models import (
+        EvaluationResultDatapoint,
+        InitEvaluationResponse,
+        PartialEvaluationDatapoint,
+    )
 
 INITIAL_EVALUATION_DATAPOINT_MAX_DATA_LENGTH = 16_000_000  # 16MB
 logger = get_default_logger(__name__)
@@ -38,6 +51,8 @@ class AsyncEvals(BaseAsyncResource):
         Returns:
             InitEvaluationResponse: The response from the initialization request.
         """
+        from lmnr.sdk.evaluations.models import parse_init_evaluation_response
+
         response = await self._client.post(
             self._base_url + "/v1/evals",
             json={
@@ -54,7 +69,7 @@ class AsyncEvals(BaseAsyncResource):
                 f"Error initializing evaluation: {describe_response(response)}"
             )
         resp_json = response.json()
-        return InitEvaluationResponse.model_validate(resp_json)
+        return parse_init_evaluation_response(resp_json)
 
     async def create_evaluation(
         self,
@@ -76,7 +91,7 @@ class AsyncEvals(BaseAsyncResource):
         evaluation = await self.init(
             name=name, group_name=group_name, metadata=metadata
         )
-        return evaluation.id
+        return evaluation["id"]
 
     async def update_evaluation(
         self,
@@ -97,6 +112,8 @@ class AsyncEvals(BaseAsyncResource):
         Returns:
             InitEvaluationResponse: The updated evaluation.
         """
+        from lmnr.sdk.evaluations.models import parse_init_evaluation_response
+
         response = await self._client.post(
             self._base_url + f"/v1/evals/{eval_id}",
             json={
@@ -113,7 +130,7 @@ class AsyncEvals(BaseAsyncResource):
             raise ValueError(
                 f"Error updating evaluation: {describe_response(response)}"
             )
-        return InitEvaluationResponse.model_validate(response.json())
+        return parse_init_evaluation_response(response.json())
 
     async def create_datapoint(
         self,
@@ -138,6 +155,7 @@ class AsyncEvals(BaseAsyncResource):
         Returns:
             uuid.UUID: The datapoint ID.
         """
+        from lmnr.sdk.evaluations.models import PartialEvaluationDatapoint
 
         datapoint_id = uuid.uuid4()
 
@@ -222,7 +240,7 @@ class AsyncEvals(BaseAsyncResource):
         )
         if response.status_code != 200:
             raise ValueError(f"Error fetching datapoints: {describe_response(response)}")
-        return GetDatapointsResponse.model_validate(response.json())
+        return parse_get_datapoints_response(response.json())
 
     async def update_datapoint(
         self,

--- a/src/lmnr/sdk/client/synchronous/resources/datasets.py
+++ b/src/lmnr/sdk/client/synchronous/resources/datasets.py
@@ -10,6 +10,9 @@ from lmnr.sdk.types import (
     Dataset,
     GetDatapointsResponse,
     PushDatapointsResponse,
+    parse_dataset,
+    parse_get_datapoints_response,
+    parse_push_datapoints_response,
 )
 from lmnr.sdk.utils import serialize
 
@@ -32,7 +35,7 @@ class Datasets(BaseResource):
             raise ValueError(
                 f"Error listing datasets: [{response.status_code}] {response.text}"
             )
-        return [Dataset.model_validate(dataset) for dataset in response.json()]
+        return [parse_dataset(dataset) for dataset in response.json()]
 
     def get_dataset_by_name(self, name: str) -> list[Dataset]:
         """Get a dataset by name."""
@@ -45,7 +48,7 @@ class Datasets(BaseResource):
             raise ValueError(
                 f"Error getting dataset: [{response.status_code}] {response.text}"
             )
-        return [Dataset.model_validate(dataset) for dataset in response.json()]
+        return [parse_dataset(dataset) for dataset in response.json()]
 
     def push(
         self,
@@ -89,7 +92,7 @@ class Datasets(BaseResource):
                     f"Error pushing data to dataset: [{response.status_code}] {response.text}"
                 )
 
-            response = PushDatapointsResponse.model_validate(response.json())
+            response = parse_push_datapoints_response(response.json())
         # Currently, the response only contains the dataset ID,
         # so it's safe to return the last response only.
         return response
@@ -126,4 +129,4 @@ class Datasets(BaseResource):
             raise ValueError(
                 f"Error pulling data from dataset: [{response.status_code}] {response.text}"
             )
-        return GetDatapointsResponse.model_validate(response.json())
+        return parse_get_datapoints_response(response.json())

--- a/src/lmnr/sdk/client/synchronous/resources/evals.py
+++ b/src/lmnr/sdk/client/synchronous/resources/evals.py
@@ -1,19 +1,32 @@
 """Evals resource for interacting with Laminar evaluations API."""
 
+from __future__ import annotations
+
 import uuid
 import warnings
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from lmnr.sdk.client.synchronous.resources.base import BaseResource
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.types import (
     GetDatapointsResponse,
-    EvaluationResultDatapoint,
-    InitEvaluationResponse,
-    PartialEvaluationDatapoint,
+    parse_get_datapoints_response,
 )
 from lmnr.sdk.utils import describe_response, serialize, json_dumps
+
+# `lmnr.sdk.evaluations` (a package) transitively imports this client package
+# (via `lmnr.sdk.datasets` -> `LaminarClient`), so importing
+# `lmnr.sdk.evaluations.models` at module level here would be circular.
+# Annotation-only uses are deferred via `TYPE_CHECKING` (safe under
+# `from __future__ import annotations`); actual constructors/functions are
+# imported lazily inside the methods that call them.
+if TYPE_CHECKING:
+    from lmnr.sdk.evaluations.models import (
+        EvaluationResultDatapoint,
+        InitEvaluationResponse,
+        PartialEvaluationDatapoint,
+    )
 
 INITIAL_EVALUATION_DATAPOINT_MAX_DATA_LENGTH = 16_000_000  # 16MB
 logger = get_default_logger(__name__)
@@ -38,6 +51,8 @@ class Evals(BaseResource):
         Returns:
             InitEvaluationResponse: The response from the initialization request.
         """
+        from lmnr.sdk.evaluations.models import parse_init_evaluation_response
+
         response = self._client.post(
             self._base_url + "/v1/evals",
             json={
@@ -54,7 +69,7 @@ class Evals(BaseResource):
                 f"Error initializing evaluation: {describe_response(response)}"
             )
         resp_json = response.json()
-        return InitEvaluationResponse.model_validate(resp_json)
+        return parse_init_evaluation_response(resp_json)
 
     def create_evaluation(
         self,
@@ -74,7 +89,7 @@ class Evals(BaseResource):
             uuid.UUID: The evaluation ID.
         """
         evaluation = self.init(name=name, group_name=group_name, metadata=metadata)
-        return evaluation.id
+        return evaluation["id"]
 
     def update_evaluation(
         self,
@@ -95,6 +110,8 @@ class Evals(BaseResource):
         Returns:
             InitEvaluationResponse: The updated evaluation.
         """
+        from lmnr.sdk.evaluations.models import parse_init_evaluation_response
+
         response = self._client.post(
             self._base_url + f"/v1/evals/{eval_id}",
             json={
@@ -111,7 +128,7 @@ class Evals(BaseResource):
             raise ValueError(
                 f"Error updating evaluation: {describe_response(response)}"
             )
-        return InitEvaluationResponse.model_validate(response.json())
+        return parse_init_evaluation_response(response.json())
 
     def create_datapoint(
         self,
@@ -136,6 +153,7 @@ class Evals(BaseResource):
         Returns:
             uuid.UUID: The datapoint ID.
         """
+        from lmnr.sdk.evaluations.models import PartialEvaluationDatapoint
 
         datapoint_id = uuid.uuid4()
 
@@ -260,7 +278,7 @@ class Evals(BaseResource):
         )
         if response.status_code != 200:
             raise ValueError(f"Error fetching datapoints: {describe_response(response)}")
-        return GetDatapointsResponse.model_validate(response.json())
+        return parse_get_datapoints_response(response.json())
 
     def _retry_save_datapoints(
         self,

--- a/src/lmnr/sdk/datasets/__init__.py
+++ b/src/lmnr/sdk/datasets/__init__.py
@@ -167,10 +167,10 @@ class LaminarDataset(EvaluationDataset):
             offset=offset,
             limit=self._fetch_size,
         )
-        self._pages[page_index] = resp.items
+        self._pages[page_index] = resp["items"]
         if self._len is None:
-            self._len = resp.total_count
-        return resp.items
+            self._len = resp["total_count"]
+        return resp["items"]
 
     def __len__(self) -> int:
         if self._len is None:

--- a/src/lmnr/sdk/debug/__init__.py
+++ b/src/lmnr/sdk/debug/__init__.py
@@ -27,6 +27,7 @@ from lmnr.sdk.debug.config import (
 )
 from lmnr.sdk.debug.pointer import build_debug_session_file, emit_pointer
 from lmnr.sdk.log import get_default_logger
+from lmnr.sdk.types import DebugContext
 
 logger = get_default_logger(__name__)
 
@@ -278,7 +279,7 @@ def init_debug_runtime(
 
 
 def init_debug_runtime_from_context(
-    debug: Any,
+    debug: DebugContext | None,
     client: Any,
     async_client: Any,
     debugger_url: str | None = None,

--- a/src/lmnr/sdk/debug/config.py
+++ b/src/lmnr/sdk/debug/config.py
@@ -10,8 +10,8 @@ import os
 import re
 import uuid
 from dataclasses import dataclass
-from typing import Any
 
+from lmnr.sdk.types import DebugContext
 from lmnr.sdk.debug.debug_session_file import (
     read_debug_session_file,
     resolve_debug_session_dir,
@@ -181,7 +181,7 @@ def build_debug_config() -> DebugConfig | None:
     )
 
 
-def build_debug_config_from_context(debug: Any) -> DebugConfig | None:
+def build_debug_config_from_context(debug: DebugContext | None) -> DebugConfig | None:
     """Build a debug config from a propagated `DebugContext` (the inherited path).
 
     Unlike `build_debug_config` (which reads `LMNR_DEBUG*`), this consumes the
@@ -200,16 +200,16 @@ def build_debug_config_from_context(debug: Any) -> DebugConfig | None:
     """
     if debug is None:
         return None
-    enabled = getattr(debug, "enabled", None)
-    session_id = getattr(debug, "session_id", None)
+    enabled = debug.get("enabled", None)
+    session_id = debug.get("session_id", None)
     if not enabled or not session_id:
         return None
 
-    replay_trace_id = getattr(debug, "replay_trace_id", None) or None
+    replay_trace_id = debug.get("replay_trace_id", None) or None
     # The needle is propagated verbatim; re-run it through the same normalizer
     # the env path uses so a downstream config holds an identical needle form.
     cache_until_span_id = _parse_cache_until_span_id(
-        getattr(debug, "cache_until", None)
+        debug.get("cache_until", None)
     )
 
     return DebugConfig(

--- a/src/lmnr/sdk/evaluations/__init__.py
+++ b/src/lmnr/sdk/evaluations/__init__.py
@@ -12,13 +12,11 @@ from lmnr.sdk.evaluations.models import (
     DEFAULT_BATCH_SIZE,
     MAX_EXPORT_BATCH_SIZE,
     EvaluationRunResult,
-)
-from lmnr.sdk.types import (
-    Datapoint,
     EvaluatorFunction,
     ExecutorFunction,
     HumanEvaluator,
 )
+from lmnr.sdk.types import Datapoint
 
 
 def evaluate(

--- a/src/lmnr/sdk/evaluations/evaluation.py
+++ b/src/lmnr/sdk/evaluations/evaluation.py
@@ -16,7 +16,12 @@ from lmnr.sdk.datasets import EvaluationDataset
 from lmnr.sdk.evaluations.models import (
     DEFAULT_BATCH_SIZE,
     MAX_EXPORT_BATCH_SIZE,
+    EvaluationDatapointDatasetLink,
+    EvaluationResultDatapoint,
     EvaluationRunResult,
+    EvaluatorFunction,
+    HumanEvaluator,
+    PartialEvaluationDatapoint,
 )
 from lmnr.sdk.evaluations.reporter import EvaluationReporter
 from lmnr.sdk.evaluations.utils import get_average_scores, get_evaluation_url
@@ -24,13 +29,8 @@ from lmnr.sdk.laminar import Laminar as L
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.types import (
     Datapoint,
-    EvaluationDatapointDatasetLink,
-    EvaluationResultDatapoint,
-    EvaluatorFunction,
-    HumanEvaluator,
     Numeric,
     NumericTypes,
-    PartialEvaluationDatapoint,
     SpanType,
     TraceType,
 )
@@ -254,7 +254,7 @@ class Evaluation:
                         if len(datasets) == 0:
                             self._logger.warning(f"Dataset {source.name} not found")
                         else:
-                            source.id = datasets[0].id
+                            source.id = datasets[0]["id"]
                     except Exception as e:
                         # Backward compatibility with old Laminar API (self hosted)
                         self._logger.warning(
@@ -268,14 +268,14 @@ class Evaluation:
                 group_name=self.group_name,
                 metadata=_with_debugger_session_metadata(self.metadata),
             )
-            evaluation_id = evaluation.id
-            project_id = evaluation.projectId
+            evaluation_id = evaluation["id"]
+            project_id = evaluation["projectId"]
             url = get_evaluation_url(project_id, evaluation_id, self.reporter.base_url)
 
             print(f"Check the results at {url}")
 
             self.reporter.start(len(self.data))
-            result_datapoints = await self._evaluate_in_batches(evaluation.id)
+            result_datapoints = await self._evaluate_in_batches(evaluation["id"])
             # Wait for all background upload tasks to complete
             if self.upload_tasks:
                 self._logger.debug(
@@ -288,7 +288,7 @@ class Evaluation:
             self.reporter.stop_with_error(e)
 
         average_scores = get_average_scores(result_datapoints)
-        self.reporter.stop(average_scores, evaluation.projectId, evaluation.id)
+        self.reporter.stop(average_scores, evaluation["projectId"], evaluation["id"])
         await self._shutdown()
         return {
             "average_scores": average_scores,
@@ -402,7 +402,7 @@ class Evaluation:
                 scores: dict[str, Numeric] = {}
                 for evaluator_name, evaluator in self.evaluators.items():
                     # Check if evaluator is a HumanEvaluator instance
-                    if isinstance(evaluator, HumanEvaluator):
+                    if isinstance(evaluator, dict):  # HumanEvaluator is a TypedDict
                         # Create an empty span for human evaluators
                         with L.start_as_current_span(
                             evaluator_name,
@@ -411,10 +411,10 @@ class Evaluation:
                             human_evaluator_span.set_attribute(
                                 SPAN_TYPE, SpanType.HUMAN_EVALUATOR.value
                             )
-                            if evaluator.options:
+                            if evaluator.get("options"):
                                 human_evaluator_span.set_attribute(
                                     HUMAN_EVALUATOR_OPTIONS,
-                                    json_dumps(evaluator.options),
+                                    json_dumps(evaluator.get("options")),
                                 )
                             # Human evaluators don't execute automatically, just create the span
                             L.set_span_output(None)

--- a/src/lmnr/sdk/evaluations/models.py
+++ b/src/lmnr/sdk/evaluations/models.py
@@ -1,10 +1,24 @@
+import datetime
+import json
 import uuid
-from typing import TypedDict
+from collections.abc import Awaitable, Callable
+from typing import Any, TypedDict
 
-from lmnr.sdk.types import Numeric
+from pydantic import BaseModel, Field
+
+from lmnr.sdk.types import (
+    EvaluationDatapointData,
+    EvaluationDatapointMetadata,
+    EvaluationDatapointTarget,
+    Numeric,
+    parse_iso_datetime,
+)
+from lmnr.sdk.utils import json_dumps, serialize
 
 DEFAULT_BATCH_SIZE = 5
 MAX_EXPORT_BATCH_SIZE = 64
+DEFAULT_DATAPOINT_MAX_DATA_LENGTH = 16_000_000  # 16MB
+
 
 class EvaluationRunResult(TypedDict):
     average_scores: dict[str, Numeric]
@@ -12,3 +26,166 @@ class EvaluationRunResult(TypedDict):
     project_id: uuid.UUID
     url: str
     error_message: str | None
+
+
+ExecutorFunctionReturnType = Any  # pyright: ignore[reportExplicitAny]
+EvaluatorFunctionReturnType = Numeric | dict[str, Numeric]
+
+ExecutorFunction = Callable[
+    [EvaluationDatapointData, Any],  # pyright: ignore[reportExplicitAny]
+    ExecutorFunctionReturnType | Awaitable[ExecutorFunctionReturnType],  # pyright: ignore[reportExplicitAny]
+]
+
+# EvaluatorFunction is a function that takes the output of the executor and the
+# target data, and returns a score. The score can be a single number or a
+# record of string keys and number values. The latter is useful for evaluating
+# multiple criteria in one go instead of running multiple evaluators.
+EvaluatorFunction = Callable[
+    [ExecutorFunctionReturnType, Any],  # pyright: ignore[reportExplicitAny]
+    EvaluatorFunctionReturnType | Awaitable[EvaluatorFunctionReturnType],
+]
+
+
+class HumanEvaluatorOptionsEntry(TypedDict):
+    label: str
+    value: float
+
+
+class HumanEvaluator(TypedDict, total=False):
+    options: list[HumanEvaluatorOptionsEntry]
+
+
+class InitEvaluationResponse(TypedDict):
+    id: uuid.UUID
+    createdAt: datetime.datetime
+    groupId: str
+    name: str
+    projectId: uuid.UUID
+
+
+def parse_init_evaluation_response(data: dict[str, Any]) -> InitEvaluationResponse:
+    """Parse an `InitEvaluationResponse` from a `POST /v1/evals` (or update)
+    response. Field names already match the wire shape (no aliasing)."""
+    return InitEvaluationResponse(
+        id=uuid.UUID(str(data["id"])),
+        createdAt=parse_iso_datetime(data["createdAt"]),
+        groupId=data["groupId"],
+        name=data["name"],
+        projectId=uuid.UUID(str(data["projectId"])),
+    )
+
+
+class EvaluationDatapointDatasetLink(TypedDict):
+    dataset_id: uuid.UUID
+    datapoint_id: uuid.UUID
+    created_at: datetime.datetime
+
+
+def _dataset_link_to_dict(link: EvaluationDatapointDatasetLink) -> dict[str, str]:
+    return {
+        "datasetId": str(link["dataset_id"]),
+        "datapointId": str(link["datapoint_id"]),
+        "createdAt": link["created_at"].isoformat(),
+    }
+
+
+class PartialEvaluationDatapoint(BaseModel):
+    id: uuid.UUID
+    data: EvaluationDatapointData
+    target: EvaluationDatapointTarget
+    index: int
+    trace_id: uuid.UUID
+    executor_span_id: uuid.UUID
+    metadata: EvaluationDatapointMetadata = Field(default=None)
+    dataset_link: EvaluationDatapointDatasetLink | None = Field(default=None)
+
+    # uuid is not serializable by default, so we need to convert it to a string
+    def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
+        serialized_data = serialize(self.data)
+        serialized_target = serialize(self.target)
+        str_data = json_dumps(serialized_data)
+        str_target = json_dumps(serialized_target)
+        try:
+            return {
+                "id": str(self.id),
+                "data": (
+                    str_data[:max_data_length]
+                    if len(str_data) > max_data_length
+                    else serialized_data
+                ),
+                "target": (
+                    str_target[:max_data_length]
+                    if len(str_target) > max_data_length
+                    else serialized_target
+                ),
+                "index": self.index,
+                "traceId": str(self.trace_id),
+                "executorSpanId": str(self.executor_span_id),
+                "metadata": (
+                    serialize(self.metadata) if self.metadata is not None else {}
+                ),
+                "datasetLink": (
+                    _dataset_link_to_dict(self.dataset_link)
+                    if self.dataset_link is not None
+                    else None
+                ),
+            }
+        except Exception as e:
+            raise ValueError(f"Error serializing PartialEvaluationDatapoint: {e}")
+
+
+class EvaluationResultDatapoint(BaseModel):
+    id: uuid.UUID
+    index: int
+    data: EvaluationDatapointData
+    target: EvaluationDatapointTarget
+    executor_output: ExecutorFunctionReturnType
+    scores: dict[str, Numeric | None]
+    trace_id: uuid.UUID
+    executor_span_id: uuid.UUID
+    metadata: EvaluationDatapointMetadata = Field(default=None)
+    dataset_link: EvaluationDatapointDatasetLink | None = Field(default=None)
+
+    # uuid is not serializable by default, so we need to convert it to a string
+    def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
+        try:
+            serialized_data = serialize(self.data)
+            serialized_target = serialize(self.target)
+            serialized_executor_output = serialize(self.executor_output)
+            str_data = json.dumps(serialized_data)
+            str_target = json.dumps(serialized_target)
+            str_executor_output = json.dumps(serialized_executor_output)
+            return {
+                # preserve only preview of the data, target and executor output
+                # (full data is in trace)
+                "id": str(self.id),
+                "data": (
+                    str_data[:max_data_length]
+                    if len(str_data) > max_data_length
+                    else serialized_data
+                ),
+                "target": (
+                    str_target[:max_data_length]
+                    if len(str_target) > max_data_length
+                    else serialized_target
+                ),
+                "executorOutput": (
+                    str_executor_output[:max_data_length]
+                    if len(str_executor_output) > max_data_length
+                    else serialized_executor_output
+                ),
+                "scores": self.scores,
+                "traceId": str(self.trace_id),
+                "executorSpanId": str(self.executor_span_id),
+                "index": self.index,
+                "metadata": (
+                    serialize(self.metadata) if self.metadata is not None else {}
+                ),
+                "datasetLink": (
+                    _dataset_link_to_dict(self.dataset_link)
+                    if self.dataset_link is not None
+                    else None
+                ),
+            }
+        except Exception as e:
+            raise ValueError(f"Error serializing EvaluationResultDatapoint: {e}")

--- a/src/lmnr/sdk/evaluations/utils.py
+++ b/src/lmnr/sdk/evaluations/utils.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
-from lmnr.sdk.types import EvaluationResultDatapoint, Numeric
+from lmnr.sdk.evaluations.models import EvaluationResultDatapoint
+from lmnr.sdk.types import Numeric
 from lmnr.sdk.utils import from_env, get_frontend_url
 
 

--- a/src/lmnr/sdk/laminar.py
+++ b/src/lmnr/sdk/laminar.py
@@ -59,6 +59,7 @@ from lmnr.sdk.utils import (
 
 from .log import get_default_logger
 from .types import (
+    DebugContext,
     LaminarSpanContext,
     LaminarSpanType,
     SessionRecordingOptions,
@@ -78,7 +79,7 @@ class ParsedParentSpanContext(TypedDict):
     metadata: dict[str, Any] | None
     # The propagated debugger block, if any (used to arm the debug runtime on a
     # downstream run). None when the context carried no debug block.
-    debug: Any | None
+    debug: DebugContext | None
 
 
 def _parse_parent_span_context(
@@ -643,7 +644,7 @@ class Laminar:
             cls.__logger.warning("Failed to initialize debug runtime: %s", exc)
 
     @classmethod
-    def _arm_debug_runtime_from_context(cls, debug: Any) -> None:
+    def _arm_debug_runtime_from_context(cls, debug: DebugContext | None) -> None:
         """Arm OR refresh the debug runtime from a propagated `DebugContext`.
 
         Called from the span-creation funnels when a parent `LaminarSpanContext`
@@ -674,8 +675,8 @@ class Laminar:
             # no / an unarmed debug block costs nothing.
             if (
                 debug is None
-                or not getattr(debug, "enabled", False)
-                or not getattr(debug, "session_id", None)
+                or not debug.get("enabled", False)
+                or not debug.get("session_id", None)
             ):
                 return
 

--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -4,25 +4,33 @@ import datetime
 import json
 import logging
 import uuid
-from collections.abc import Awaitable, Callable
 from enum import Enum
-from typing import Any, Literal
+from typing import Any, Literal, cast
 
 from opentelemetry.trace import SpanContext, TraceFlags
 from pydantic import BaseModel, Field
 from typing_extensions import TypedDict, override  # compatibility with python < 3.12
 
-from .utils import json_dumps, serialize
 
-DEFAULT_DATAPOINT_MAX_DATA_LENGTH = 16_000_000  # 16MB
+def parse_iso_datetime(value: str) -> datetime.datetime:
+    """Parse an ISO-8601 timestamp from the API, tolerating a trailing 'Z'.
+
+    `datetime.fromisoformat` only accepts a bare 'Z' suffix on Python >= 3.11;
+    this package supports 3.10, and the app-server emits UTC timestamps with
+    'Z'. Pydantic's own parser (speedate) handled this for us before these
+    responses were plain dicts; this is the manual equivalent.
+    """
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    return datetime.datetime.fromisoformat(value)
 
 
 Numeric = int | float
 NumericTypes = (int, float)  # for use with isinstance
 
-EvaluationDatapointData = Any  # non-null, must be JSON-serializable
-EvaluationDatapointTarget = Any | None  # must be JSON-serializable
-EvaluationDatapointMetadata = Any | None  # must be JSON-serializable
+EvaluationDatapointData = Any  # pyright: ignore[reportExplicitAny] non-null, must be JSON-serializable
+EvaluationDatapointTarget = Any | None  # pyright: ignore[reportExplicitAny] must be JSON-serializable
+EvaluationDatapointMetadata = Any | None  # pyright: ignore[reportExplicitAny] must be JSON-serializable
 LaminarSpanType = Literal[
     "DEFAULT",
     "LLM",
@@ -33,172 +41,37 @@ LaminarSpanType = Literal[
 # EvaluationDatapoint is a single data point in the evaluation
 class Datapoint(BaseModel):
     # input to the executor function.
-    data: EvaluationDatapointData
+    data: EvaluationDatapointData  # pyright: ignore[reportExplicitAny]
     # input to the evaluator function (alongside the executor output).
-    target: EvaluationDatapointTarget = Field(default_factory=dict)
-    metadata: EvaluationDatapointMetadata = Field(default_factory=dict)
+    target: EvaluationDatapointTarget = Field(default_factory=dict)  # pyright: ignore[reportAny]
+    metadata: EvaluationDatapointMetadata = Field(default_factory=dict)  # pyright: ignore[reportAny]
     id: uuid.UUID | None = Field(default=None)
     created_at: datetime.datetime | None = Field(default=None, alias="createdAt")
 
 
-class Dataset(BaseModel):
-    id: uuid.UUID = Field()
-    name: str = Field()
-    created_at: datetime.datetime = Field(alias="createdAt")
-
-
-class PushDatapointsResponse(BaseModel):
-    dataset_id: uuid.UUID = Field(alias="datasetId")
-
-
-ExecutorFunctionReturnType = Any
-EvaluatorFunctionReturnType = Numeric | dict[str, Numeric]
-
-ExecutorFunction = Callable[
-    [EvaluationDatapointData, Any],
-    ExecutorFunctionReturnType | Awaitable[ExecutorFunctionReturnType],
-]
-
-# EvaluatorFunction is a function that takes the output of the executor and the
-# target data, and returns a score. The score can be a single number or a
-# record of string keys and number values. The latter is useful for evaluating
-# multiple criteria in one go instead of running multiple evaluators.
-EvaluatorFunction = Callable[
-    [ExecutorFunctionReturnType, Any],
-    EvaluatorFunctionReturnType | Awaitable[EvaluatorFunctionReturnType],
-]
-
-
-class HumanEvaluatorOptionsEntry(TypedDict):
-    label: str
-    value: float
-
-
-class HumanEvaluator(BaseModel):
-    options: list[HumanEvaluatorOptionsEntry] = Field(default_factory=list)
-
-
-class InitEvaluationResponse(BaseModel):
+class Dataset(TypedDict):
     id: uuid.UUID
-    createdAt: datetime.datetime
-    groupId: str
     name: str
-    projectId: uuid.UUID
-
-
-class EvaluationDatapointDatasetLink(BaseModel):
-    dataset_id: uuid.UUID
-    datapoint_id: uuid.UUID
     created_at: datetime.datetime
 
-    def to_dict(self):
-        return {
-            "datasetId": str(self.dataset_id),
-            "datapointId": str(self.datapoint_id),
-            "createdAt": self.created_at.isoformat(),
-        }
+
+def parse_dataset(data: dict[str, str]) -> Dataset:
+    """Parse a `Dataset` from a `GET /v1/datasets` response entry."""
+    return Dataset(
+        id=uuid.UUID(str(data["id"])),
+        name=data["name"],
+        created_at=parse_iso_datetime(data["createdAt"]),
+    )
 
 
-class PartialEvaluationDatapoint(BaseModel):
-    id: uuid.UUID
-    data: EvaluationDatapointData
-    target: EvaluationDatapointTarget
-    index: int
-    trace_id: uuid.UUID
-    executor_span_id: uuid.UUID
-    metadata: EvaluationDatapointMetadata = Field(default=None)
-    dataset_link: EvaluationDatapointDatasetLink | None = Field(default=None)
-
-    # uuid is not serializable by default, so we need to convert it to a string
-    def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
-        serialized_data = serialize(self.data)
-        serialized_target = serialize(self.target)
-        str_data = json_dumps(serialized_data)
-        str_target = json_dumps(serialized_target)
-        try:
-            return {
-                "id": str(self.id),
-                "data": (
-                    str_data[:max_data_length]
-                    if len(str_data) > max_data_length
-                    else serialized_data
-                ),
-                "target": (
-                    str_target[:max_data_length]
-                    if len(str_target) > max_data_length
-                    else serialized_target
-                ),
-                "index": self.index,
-                "traceId": str(self.trace_id),
-                "executorSpanId": str(self.executor_span_id),
-                "metadata": (
-                    serialize(self.metadata) if self.metadata is not None else {}
-                ),
-                "datasetLink": (
-                    self.dataset_link.to_dict()
-                    if self.dataset_link is not None
-                    else None
-                ),
-            }
-        except Exception as e:
-            raise ValueError(f"Error serializing PartialEvaluationDatapoint: {e}")
+class PushDatapointsResponse(TypedDict):
+    dataset_id: uuid.UUID
 
 
-class EvaluationResultDatapoint(BaseModel):
-    id: uuid.UUID
-    index: int
-    data: EvaluationDatapointData
-    target: EvaluationDatapointTarget
-    executor_output: ExecutorFunctionReturnType
-    scores: dict[str, Numeric | None]
-    trace_id: uuid.UUID
-    executor_span_id: uuid.UUID
-    metadata: EvaluationDatapointMetadata = Field(default=None)
-    dataset_link: EvaluationDatapointDatasetLink | None = Field(default=None)
-
-    # uuid is not serializable by default, so we need to convert it to a string
-    def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
-        try:
-            serialized_data = serialize(self.data)
-            serialized_target = serialize(self.target)
-            serialized_executor_output = serialize(self.executor_output)
-            str_data = json.dumps(serialized_data)
-            str_target = json.dumps(serialized_target)
-            str_executor_output = json.dumps(serialized_executor_output)
-            return {
-                # preserve only preview of the data, target and executor output
-                # (full data is in trace)
-                "id": str(self.id),
-                "data": (
-                    str_data[:max_data_length]
-                    if len(str_data) > max_data_length
-                    else serialized_data
-                ),
-                "target": (
-                    str_target[:max_data_length]
-                    if len(str_target) > max_data_length
-                    else serialized_target
-                ),
-                "executorOutput": (
-                    str_executor_output[:max_data_length]
-                    if len(str_executor_output) > max_data_length
-                    else serialized_executor_output
-                ),
-                "scores": self.scores,
-                "traceId": str(self.trace_id),
-                "executorSpanId": str(self.executor_span_id),
-                "index": self.index,
-                "metadata": (
-                    serialize(self.metadata) if self.metadata is not None else {}
-                ),
-                "datasetLink": (
-                    self.dataset_link.to_dict()
-                    if self.dataset_link is not None
-                    else None
-                ),
-            }
-        except Exception as e:
-            raise ValueError(f"Error serializing EvaluationResultDatapoint: {e}")
+def parse_push_datapoints_response(data: dict[str, str]) -> PushDatapointsResponse:
+    """Parse a `PushDatapointsResponse` from a `POST /v1/datasets/datapoints`
+    response."""
+    return PushDatapointsResponse(dataset_id=uuid.UUID(str(data["datasetId"])))
 
 
 class SpanType(Enum):
@@ -209,6 +82,7 @@ class SpanType(Enum):
     EVALUATOR = "EVALUATOR"
     HUMAN_EVALUATOR = "HUMAN_EVALUATOR"
     EVALUATION = "EVALUATION"
+    TOOL = "TOOL"
 
 
 class TraceType(Enum):
@@ -216,9 +90,19 @@ class TraceType(Enum):
     EVALUATION = "EVALUATION"
 
 
-class GetDatapointsResponse(BaseModel):
+class GetDatapointsResponse(TypedDict):
     items: list[Datapoint]
-    total_count: int = Field(alias="totalCount")
+    total_count: int
+
+
+def parse_get_datapoints_response(data: dict[str, int | list[dict[str, Any]]]) -> GetDatapointsResponse:  # pyright: ignore[reportExplicitAny]
+    """Parse a `GetDatapointsResponse` from a `GET /v1/datasets/datapoints`
+    response. Each item still goes through `Datapoint.model_validate` for its
+    own uuid/datetime coercion."""
+    return GetDatapointsResponse(
+        items=[Datapoint.model_validate(item) for item in cast(list[dict[str, Any]], data["items"])],  # pyright: ignore[reportExplicitAny]
+        total_count=cast(int, data["totalCount"]),
+    )
 
 
 class TraceBlockContent(TypedDict, total=False):
@@ -280,10 +164,10 @@ class SessionBlock(TypedDict):
     # Block type; one of `SessionBlockType` for known blocks.
     type: str
     # Type-specific payload; narrow via the `*BlockContent` shapes.
-    content: dict[str, Any]
+    content: dict[str, Any]  # pyright: ignore[reportExplicitAny]
 
 
-class DebugContext(BaseModel):
+class DebugContext(TypedDict, total=False):
     """Debugger context propagated as ONE nested block of a LaminarSpanContext.
 
     Carries the debug-replay v2 coordinates a downstream run needs to consult
@@ -300,34 +184,45 @@ class DebugContext(BaseModel):
       sends it un-normalized as `replayTraceId` to the cache endpoint).
     - `cache_until`: the cache-window span-id needle, kept VERBATIM (hyphenated
       or not, full UUID or short suffix) — the server resolves it.
+
+    `total=False` so a producer/test can omit keys it doesn't care about; every
+    consumer reads via `.get(key, default)`, never attribute access.
     """
 
-    enabled: bool = Field(default=False)
-    session_id: str | None = Field(default=None)
-    replay_trace_id: str | None = Field(default=None)
-    cache_until: str | None = Field(default=None)
+    enabled: bool
+    session_id: str | None
+    replay_trace_id: str | None
+    cache_until: str | None
 
-    @classmethod
-    def deserialize(cls, data: dict[str, Any]) -> "DebugContext":
-        """Parse a debug block from a dict, accepting camelCase and snake_case.
 
-        All ids are kept VERBATIM: the producer emits the run's exact session /
-        replay-trace / cache-until strings (un-normalized), so the consumer must
-        round-trip them unchanged or a downstream run fails to join the run.
-        """
-        return cls(
-            # Strict `is True`, NOT bool(...): the producer always emits a real
-            # boolean, so anything else (e.g. the string "false", which is
-            # truthy) is a malformed/forged block and must NOT arm a downstream
-            # runtime.
-            enabled=data.get("enabled") is True,
-            session_id=(data.get("session_id") or data.get("sessionId")) or None,
-            replay_trace_id=(
-                data.get("replay_trace_id") or data.get("replayTraceId")
-            )
-            or None,
-            cache_until=(data.get("cache_until") or data.get("cacheUntil")) or None,
+def deserialize_debug_context(data: dict[str, Any]) -> DebugContext:  # pyright: ignore[reportExplicitAny]
+    """Parse a debug block from a dict, accepting camelCase and snake_case.
+
+    All ids are kept VERBATIM: the producer emits the run's exact session /
+    replay-trace / cache-until strings (un-normalized), so the consumer must
+    round-trip them unchanged or a downstream run fails to join the run.
+    """
+    return DebugContext(
+        # Strict `is True`, NOT bool(...): the producer always emits a real
+        # boolean, so anything else (e.g. the string "false", which is
+        # truthy) is a malformed/forged block and must NOT arm a downstream
+        # runtime.
+        enabled=data.get("enabled") is True,
+        session_id=(data.get("session_id") or data.get("sessionId")) or None,
+        replay_trace_id=(
+            data.get("replay_trace_id") or data.get("replayTraceId")
         )
+        or None,
+        cache_until=(data.get("cache_until") or data.get("cacheUntil")) or None,
+    )
+
+
+#: Shape of a plain (non-`LaminarSpanContext`, non-`SpanContext`) dict a
+#: caller can hand to `LaminarSpanContext.deserialize` /
+#: `try_to_otel_span_context` -- e.g. a JSON-decoded header or env var.
+SpanContextDict = dict[
+    str, str | bool | int | float | list[str] | dict[str, str | bool | int | float]
+]
 
 
 class LaminarSpanContext(BaseModel):
@@ -350,7 +245,7 @@ class LaminarSpanContext(BaseModel):
     user_id: str | None = Field(default=None)
     session_id: str | None = Field(default=None)
     trace_type: TraceType | None = Field(default=None)
-    metadata: dict[str, Any] | None = Field(default=None)
+    metadata: dict[str, dict[str, str | int | float | bool]] | None = Field(default=None)
     debug: DebugContext | None = Field(default=None)
 
     @override
@@ -360,7 +255,7 @@ class LaminarSpanContext(BaseModel):
     @classmethod
     def try_to_otel_span_context(
         cls,
-        span_context: "LaminarSpanContext" | dict[str, Any] | str | SpanContext,
+        span_context: LaminarSpanContext | SpanContextDict | str | SpanContext,
         logger: logging.Logger | None = None,
     ) -> SpanContext:
         if logger is None:
@@ -373,17 +268,27 @@ class LaminarSpanContext(BaseModel):
                 is_remote=span_context.is_remote,
                 trace_flags=TraceFlags(TraceFlags.SAMPLED),
             )
-        elif isinstance(span_context, SpanContext) or (
-            isinstance(getattr(span_context, "trace_id", None), int)
-            and isinstance(getattr(span_context, "span_id", None), int)
-        ):
+        elif isinstance(span_context, SpanContext):
             logger.warning(
                 "span_context provided" +
                 " is likely a raw OpenTelemetry span context. Will try to use it. " +
                 "Please use `LaminarSpanContext` instead."
             )
             return span_context
-        elif isinstance(span_context, (dict, str)):
+        elif isinstance(getattr(span_context, "trace_id", None), int) and isinstance(
+            getattr(span_context, "span_id", None), int
+        ):
+            # Not an actual `SpanContext` instance (that's handled above), but
+            # duck-types as one (e.g. a `SpanContext` from a different otel
+            # version). The `getattr` checks are the only signal here, so this
+            # cast is trusting the same runtime check pyright can't itself see.
+            logger.warning(
+                "span_context provided" +
+                " is likely a raw OpenTelemetry span context. Will try to use it. " +
+                "Please use `LaminarSpanContext` instead."
+            )
+            return cast(SpanContext, cast(object, span_context))
+        elif isinstance(span_context, (dict, str)):  # pyright: ignore[reportUnnecessaryIsInstance]
             try:
                 laminar_span_context = cls.deserialize(span_context)
                 return SpanContext(
@@ -395,10 +300,10 @@ class LaminarSpanContext(BaseModel):
             except Exception:
                 raise ValueError("Invalid span_context provided")
         else:
-            raise ValueError("Invalid span_context provided")
+            raise TypeError("Invalid span_context provided")  # pyright: ignore[reportUnreachable]
 
     @classmethod
-    def deserialize(cls, data: dict[str, Any] | str) -> "LaminarSpanContext":
+    def deserialize(cls, data: SpanContextDict | str) -> LaminarSpanContext:
         if isinstance(data, dict):
             # Convert camelCase to snake_case for known fields
             debug_raw = data.get("debug")
@@ -414,16 +319,16 @@ class LaminarSpanContext(BaseModel):
                 "trace_type": data.get("trace_type") or data.get("traceType"),
                 "metadata": data.get("metadata") or data.get("metadata", {}),
                 "debug": (
-                    DebugContext.deserialize(debug_raw)
+                    deserialize_debug_context(debug_raw)
                     if isinstance(debug_raw, dict)
                     else None
                 ),
             }
             return cls.model_validate(converted_data)
-        elif isinstance(data, str):
-            return cls.deserialize(json.loads(data))
+        elif isinstance(data, str):  # pyright: ignore[reportUnnecessaryIsInstance]
+            return cls.deserialize(json.loads(data))  # pyright: ignore[reportAny]
         else:
-            raise ValueError("Invalid span_context provided")
+            raise TypeError("Invalid span_context provided")  # pyright: ignore[reportUnreachable]
 
 
 class ModelProvider(str, Enum):

--- a/src/lmnr/sdk/types.py
+++ b/src/lmnr/sdk/types.py
@@ -223,6 +223,8 @@ def deserialize_debug_context(data: dict[str, Any]) -> DebugContext:  # pyright:
 SpanContextDict = dict[
     str, str | bool | int | float | list[str] | dict[str, str | bool | int | float]
 ]
+MetadataMemberType = str | int | float | bool | None
+MetadataType = dict[str, MetadataMemberType | list[MetadataMemberType] | dict[str, MetadataMemberType | list[MetadataMemberType]]]
 
 
 class LaminarSpanContext(BaseModel):
@@ -245,7 +247,7 @@ class LaminarSpanContext(BaseModel):
     user_id: str | None = Field(default=None)
     session_id: str | None = Field(default=None)
     trace_type: TraceType | None = Field(default=None)
-    metadata: dict[str, dict[str, str | int | float | bool]] | None = Field(default=None)
+    metadata: MetadataType | None = Field(default=None)
     debug: DebugContext | None = Field(default=None)
 
     @override

--- a/src/lmnr/sdk/utils.py
+++ b/src/lmnr/sdk/utils.py
@@ -1,5 +1,4 @@
 import base64
-import collections.abc
 import dataclasses
 import datetime
 import enum
@@ -8,24 +7,27 @@ import inspect
 import os
 import queue
 import re
-import typing
 import uuid
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from typing import Any, cast
 
 import dotenv
+import httpx
 import orjson
 import pydantic
 from opentelemetry.trace import Tracer
+from typing_extensions import TypeVar
 
 from lmnr.sdk.log import get_default_logger
 
 logger = get_default_logger(__name__)
 
-WrappedFunction = typing.Callable[..., typing.Any]
+WrappedFunction = Callable[..., Any]  # pyright: ignore[reportExplicitAny]
 
 #: The shape wrapt's `wrap_function_wrapper` expects.
-InstrumentedWrapper = typing.Callable[
-    [WrappedFunction, typing.Any, tuple[typing.Any, ...], dict[str, typing.Any]],
-    typing.Any,
+InstrumentedWrapper = Callable[
+    [WrappedFunction, Any, tuple[Any, ...], dict[str, Any]],  # pyright: ignore[reportExplicitAny]
+    Any,  # pyright: ignore[reportExplicitAny]
 ]
 
 #: Deliberately UNBOUND. `to_wrap` has no single shape across the legacy
@@ -33,22 +35,29 @@ InstrumentedWrapper = typing.Callable[
 #: method path. Binding this to a spec type would break that caller. The
 #: instrumentations already on `BaseLaminarInstrumentor` use the typed
 #: `WrappedFunctionSpec` contract instead of these helpers.
-ToWrapT = typing.TypeVar("ToWrapT")
+ToWrapT = TypeVar("ToWrapT")
 
+@dataclasses.dataclass
+class _WrappedCallable:
+    __wrapped__: Callable[..., Any]  # pyright: ignore[reportExplicitAny]
 
+#: `wrapt`'s wrapper contract is genuinely untyped -- `instance`/`args`/`kwargs`
+#: (and the wrapped call's return value) can be anything, for any wrapped
+#: callable across every instrumentation. Explicit `Any` here is the honest
+#: type, not a shortcut; the `pyright: ignore`s below are load-bearing.
 def with_tracer_wrapper(
-    func: typing.Callable[
+    func: Callable[
         [
             Tracer,
             ToWrapT,
             WrappedFunction,
-            typing.Any,
-            tuple[typing.Any, ...],
-            dict[str, typing.Any],
+            Any,  # pyright: ignore[reportExplicitAny]
+            tuple[Any, ...],  # pyright: ignore[reportExplicitAny]
+            dict[str, Any],  # pyright: ignore[reportExplicitAny]
         ],
-        typing.Any,
+        Any,  # pyright: ignore[reportExplicitAny]
     ],
-) -> typing.Callable[[Tracer, ToWrapT], InstrumentedWrapper]:
+) -> Callable[[Tracer, ToWrapT], InstrumentedWrapper]:
     """Bind a tracer and a per-instrumented-method config into an instrumentation
     function, producing the wrapper factory `wrapt.wrap_function_wrapper` expects.
 
@@ -63,13 +72,15 @@ def with_tracer_wrapper(
 
     def _with_tracer(tracer: Tracer, to_wrap: ToWrapT) -> InstrumentedWrapper:
         @functools.wraps(func)
-        def wrapper(
+        def wrapper(  # pyright: ignore[reportAny]
             wrapped: WrappedFunction,
-            instance: typing.Any,
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> typing.Any:
-            return func(tracer, to_wrap, wrapped, instance, args, kwargs)
+            instance: Any,  # pyright: ignore[reportExplicitAny, reportAny]
+            args: tuple[Any, ...],  # pyright: ignore[reportExplicitAny]
+            kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
+        ) -> Any:  # pyright: ignore[reportExplicitAny]
+            return func(  # pyright: ignore[reportAny]
+                tracer, to_wrap, wrapped, instance, args, kwargs
+            )
 
         return wrapper
 
@@ -77,17 +88,17 @@ def with_tracer_wrapper(
 
 
 def with_tracer_only_wrapper(
-    func: typing.Callable[
+    func: Callable[
         [
             Tracer,
             WrappedFunction,
-            typing.Any,
-            tuple[typing.Any, ...],
-            dict[str, typing.Any],
+            Any,  # pyright: ignore[reportExplicitAny]
+            tuple[Any, ...],  # pyright: ignore[reportExplicitAny]
+            dict[str, Any],  # pyright: ignore[reportExplicitAny]
         ],
-        typing.Any,
+        Any,  # pyright: ignore[reportExplicitAny]
     ],
-) -> typing.Callable[[Tracer], InstrumentedWrapper]:
+) -> Callable[[Tracer], InstrumentedWrapper]:
     """`with_tracer_wrapper` for instrumentations with no per-method config.
 
     `func` must accept `(tracer, wrapped, instance, args, kwargs)`. Every wrapper
@@ -97,20 +108,20 @@ def with_tracer_only_wrapper(
 
     def _with_tracer(tracer: Tracer) -> InstrumentedWrapper:
         @functools.wraps(func)
-        def wrapper(
+        def wrapper(  # pyright: ignore[reportAny]
             wrapped: WrappedFunction,
-            instance: typing.Any,
-            args: tuple[typing.Any, ...],
-            kwargs: dict[str, typing.Any],
-        ) -> typing.Any:
-            return func(tracer, wrapped, instance, args, kwargs)
+            instance: Any,  # pyright: ignore[reportExplicitAny, reportAny]
+            args: tuple[Any, ...],  # pyright: ignore[reportExplicitAny]
+            kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
+        ) -> Any:  # pyright: ignore[reportExplicitAny]
+            return func(tracer, wrapped, instance, args, kwargs)  # pyright: ignore[reportAny]
 
         return wrapper
 
     return _with_tracer
 
 
-def is_method(func: typing.Callable[..., typing.Any]) -> bool:
+def is_method(func: Callable[..., object]) -> bool:
     # inspect.ismethod is True for bound methods only, but in the decorator,
     # the method is not bound yet, so we need to check if the first parameter
     # is either 'self' or 'cls'. This only relies on naming conventions
@@ -121,13 +132,13 @@ def is_method(func: typing.Callable[..., typing.Any]) -> bool:
     return len(params) > 0 and params[0] in ["self", "cls"]
 
 
-def is_async(func: typing.Callable[..., typing.Any]) -> bool:
+def is_async(func: Callable[..., object] | _WrappedCallable) -> bool:
     # `__wrapped__` is set automatically by `functools.wraps` and
     # `functools.update_wrapper`
     # so we can use it to get the original function
     try:
         while hasattr(func, "__wrapped__"):
-            func = func.__wrapped__
+            func = cast(_WrappedCallable, func).__wrapped__
 
         if not inspect.isfunction(func):
             return False
@@ -145,16 +156,25 @@ def is_async(func: typing.Callable[..., typing.Any]) -> bool:
         return False
 
 
-def is_async_iterator(o: typing.Any) -> bool:
+def is_async_iterator(o: object) -> bool:
     return hasattr(o, "__aiter__") and hasattr(o, "__anext__")
 
 
-def is_iterator(o: typing.Any) -> bool:
+def is_iterator(o: object) -> bool:
     return hasattr(o, "__iter__") and hasattr(o, "__next__")
 
 
-def serialize(obj: typing.Any) -> str | dict[str, typing.Any]:
-    def serialize_inner(o: typing.Any):
+#: Recursive JSON-like value produced by `serialize`. Dict keys are `JsonValue`
+#: too, not just `str`: a key goes through the same `serialize_inner` as any
+#: other value (e.g. an `int`/`float`/`bool`/`None` dict key round-trips
+#: unchanged, only a non-primitive key gets stringified), so it can't be
+#: narrowed to `str` without misrepresenting what the function actually
+#: returns for a dict with non-string keys.
+JsonValue = None | bool | int | float | str | list["JsonValue"] | dict["JsonValue", "JsonValue"]
+
+
+def serialize(obj: Any) -> JsonValue:  # pyright: ignore[reportExplicitAny, reportAny]
+    def serialize_inner(o: Any) -> JsonValue:  # pyright: ignore[reportExplicitAny, reportAny]
         if isinstance(o, (datetime.datetime, datetime.date)):
             return o.strftime("%Y-%m-%dT%H:%M:%S.%f%z")
         elif o is None:
@@ -164,19 +184,28 @@ def serialize(obj: typing.Any) -> str | dict[str, typing.Any]:
         elif isinstance(o, uuid.UUID):
             return str(o)  # same as in final return, but explicit
         elif isinstance(o, enum.Enum):
-            return o.value
-        elif dataclasses.is_dataclass(o):
-            return dataclasses.asdict(o)
+            return o.value  # pyright: ignore[reportAny]
+        elif dataclasses.is_dataclass(o) and not isinstance(o, type):  # pyright: ignore[reportAny]
+            # `asdict` only recurses into nested dataclasses, so its dict/list
+            # values aren't necessarily `JsonValue` (e.g. a `datetime` field
+            # stays a `datetime`) -- this cast doesn't change that pre-existing
+            # behavior, it just describes the same shape the code always had.
+            return cast(JsonValue, dataclasses.asdict(o))
         elif isinstance(o, bytes):
             return o.decode("utf-8")
         elif isinstance(o, pydantic.BaseModel):
             return serialize(o.model_dump())
         elif isinstance(o, (tuple, set, frozenset, list)):
-            return [serialize_inner(item) for item in o]
+            items = cast(Iterable[Any], o)  # pyright: ignore[reportExplicitAny]
+            return [serialize_inner(item) for item in items]  # pyright: ignore[reportAny]
         elif isinstance(o, dict):
-            return {serialize_inner(k): serialize_inner(v) for k, v in o.items()}
+            mapping = cast(dict[Any, Any], o)  # pyright: ignore[reportExplicitAny]
+            return {
+                serialize_inner(k): serialize_inner(v)
+                for k, v in mapping.items()  # pyright: ignore[reportAny]
+            }
         elif isinstance(o, queue.Queue):
-            return type(o).__name__
+            return type(o).__name__  # pyright: ignore[reportUnknownArgumentType]
 
         return str(o)
 
@@ -184,18 +213,20 @@ def serialize(obj: typing.Any) -> str | dict[str, typing.Any]:
 
 
 def get_input_from_func_args(
-    func: typing.Callable,
+    func: Callable[..., Any],  # pyright: ignore[reportExplicitAny]
     is_method: bool = False,
-    func_args: list[typing.Any] = [],
-    func_kwargs: dict[str, typing.Any] = {},
+    func_args: list[Any] | None = None,  # pyright: ignore[reportExplicitAny]
+    func_kwargs: dict[str, Any] | None = None,  # pyright: ignore[reportExplicitAny]
     ignore_inputs: list[str] | None = None,
-) -> dict[str, typing.Any]:
+) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]
+    func_args = func_args if func_args is not None else []
+    func_kwargs = func_kwargs if func_kwargs is not None else {}
     # Remove implicitly passed "self" or "cls" argument for
     # instance or class methods
     try:
         res = {
             k: v
-            for k, v in func_kwargs.items()
+            for k, v in func_kwargs.items()  # pyright: ignore[reportAny]
             if not (ignore_inputs and k in ignore_inputs)
         }
         for i, k in enumerate(inspect.signature(func).parameters.keys()):
@@ -259,13 +290,13 @@ def get_frontend_url(
     return url
 
 
-def is_otel_attribute_value_type(value: typing.Any) -> bool:
-    def is_primitive_type(value: typing.Any) -> bool:
+def is_otel_attribute_value_type(value: object) -> bool:
+    def is_primitive_type(value: object) -> bool:
         return isinstance(value, (int, float, str, bool))
 
     if is_primitive_type(value):
         return True
-    elif isinstance(value, typing.Sequence):
+    elif isinstance(value, Sequence):
         if len(value) > 0:
             return is_primitive_type(value[0]) and all(
                 isinstance(v, type(value[0])) for v in value
@@ -315,7 +346,7 @@ def parse_otel_headers(headers_str: str | None) -> dict[str, str]:
     if not headers_str:
         return {}
 
-    headers = {}
+    headers: dict[str, str] = {}
     for pair in headers_str.split(","):
         if "=" in pair:
             key, value = pair.split("=", 1)
@@ -325,7 +356,7 @@ def parse_otel_headers(headers_str: str | None) -> dict[str, str]:
     return headers
 
 
-def format_id(id_value: str | int | uuid.UUID) -> str:
+def format_id(id_value: str | int | uuid.UUID | object) -> str:
     """Format trace/span/evaluation ID to a UUID string, or return valid UUID strings as-is.
 
     Args:
@@ -335,26 +366,26 @@ def format_id(id_value: str | int | uuid.UUID) -> str:
         str: UUID string representation
 
     Raises:
-        ValueError: If id_value cannot be converted to a valid UUID
+        TypeError: If id_value cannot be converted to a valid UUID
     """
     if isinstance(id_value, uuid.UUID):
         return str(id_value)
     elif isinstance(id_value, int):
         return str(uuid.UUID(int=id_value))
     elif isinstance(id_value, str):
-        uuid.UUID(id_value)
+        _ = uuid.UUID(id_value)
         return id_value
     else:
-        raise ValueError(f"Invalid ID type: {type(id_value)}")
+        raise TypeError(f"Invalid ID type: {type(id_value)}")
 
 
-DEFAULT_PLACEHOLDER = {}
+DEFAULT_PLACEHOLDER: dict[Any, Any] = {}  # pyright: ignore[reportExplicitAny]
 
 
 _UNWRAP_MISS = object()
 
 
-def _unwrap_container(o: typing.Any) -> typing.Any:
+def _unwrap_container(o: object) -> dict[Any, Any] | list[Any] | object:  # pyright: ignore[reportExplicitAny]
     """Open a container into a plain dict/list, or return `_UNWRAP_MISS`.
 
     Single source of truth for "what counts as a container", shared by
@@ -369,18 +400,18 @@ def _unwrap_container(o: typing.Any) -> typing.Any:
     """
     if isinstance(o, pydantic.BaseModel):
         return o.model_dump()
-    if isinstance(o, collections.abc.Mapping):
-        return dict(o)
+    if isinstance(o, Mapping):
+        return dict(cast(Mapping[Any, Any], o))  # pyright: ignore[reportExplicitAny]
     if isinstance(o, (set, frozenset)):
-        return list(o)
-    if isinstance(o, collections.abc.Sequence) and not isinstance(
+        return list(cast("set[Any] | frozenset[Any]", o))  # pyright: ignore[reportExplicitAny]
+    if isinstance(o, Sequence) and not isinstance(
         o, (str, bytes, bytearray)
     ):
-        return list(o)
+        return list(cast(Sequence[Any], o))  # pyright: ignore[reportExplicitAny]
     return _UNWRAP_MISS
 
 
-def default_json(o):
+def default_json(o: object) -> str | dict[Any, Any] | list[Any]:  # pyright: ignore[reportExplicitAny]
     # STANDARD base64 (`+`/`/`), not pydantic's URL-safe `ser_json_bytes`
     # alphabet: consumers decode with `base64.b64decode`, which defaults to
     # `validate=False` and silently DROPS out-of-alphabet characters instead of
@@ -395,20 +426,19 @@ def default_json(o):
     # SINGLE quotes — "{'a': 1}" — which is not JSON and no consumer can parse.
     unwrapped = _unwrap_container(o)
     if unwrapped is not _UNWRAP_MISS:
-        return unwrapped
+        return cast("dict[Any, Any] | list[Any]", unwrapped)  # pyright: ignore[reportExplicitAny]
 
     try:
         return str(o)
     except Exception:
         logger.debug("Failed to serialize data to JSON, inner type: %s", type(o))
-        pass
     return DEFAULT_PLACEHOLDER
 
 
 MAX_ERROR_BODY_CHARS = 2000
 
 
-def describe_response(response) -> str:
+def describe_response(response: httpx.Response | None) -> str:
     """Render an HTTP error response as a readable one-liner.
 
     Error bodies are not always JSON — app-server returns plain text for
@@ -450,7 +480,7 @@ _ORJSON_NATIVE_KEY_TYPES = (
 )
 
 
-def _stringify_dict_keys(value: typing.Any) -> typing.Any:
+def _stringify_dict_keys(value: JsonValue) -> JsonValue:
     """Coerce the mapping keys orjson cannot encode into strings.
 
     `OPT_NON_STR_KEYS` only covers a fixed set of scalar key types, and orjson
@@ -470,24 +500,35 @@ def _stringify_dict_keys(value: typing.Any) -> typing.Any:
     opened = _unwrap_container(value)
     if opened is _UNWRAP_MISS:
         return value
+    opened = cast("dict[Any, Any] | list[Any]", opened)  # pyright: ignore[reportExplicitAny]
 
     if isinstance(opened, dict):
-        return {
-            (
-                key
-                if isinstance(key, _ORJSON_NATIVE_KEY_TYPES)
-                else (
-                    base64.b64encode(key).decode("utf-8")
-                    if isinstance(key, (bytes, bytearray))
-                    else str(key)
-                )
-            ): _stringify_dict_keys(inner)
-            for key, inner in opened.items()
-        }
-    return [_stringify_dict_keys(item) for item in opened]
+        # Keys can stay non-`str` (e.g. `uuid.UUID`/`datetime`) here -- they're
+        # exactly the `_ORJSON_NATIVE_KEY_TYPES` orjson encodes itself, wider
+        # than what `JsonValue` allows as a key. `default_json` handles them at
+        # dump time, so this cast just describes what orjson actually accepts.
+        return cast(
+            "JsonValue",
+            {
+                (
+                    key
+                    if isinstance(key, _ORJSON_NATIVE_KEY_TYPES)
+                    else (
+                        base64.b64encode(key).decode("utf-8")
+                        if isinstance(key, (bytes, bytearray))
+                        else str(key)  # pyright: ignore[reportAny]
+                    )
+                ): _stringify_dict_keys(inner)  # pyright: ignore[reportAny]
+                for key, inner in opened.items()  # pyright: ignore[reportAny]
+            },
+        )
+    return [
+        _stringify_dict_keys(item)  # pyright: ignore[reportAny]
+        for item in opened  # pyright: ignore[reportAny]
+    ]
 
 
-def json_dumps(data: dict | list) -> str:
+def json_dumps(data: JsonValue | dict[Any, Any] | list[Any]) -> str:  # pyright: ignore[reportExplicitAny]
     try:
         return orjson.dumps(
             data,
@@ -495,7 +536,7 @@ def json_dumps(data: dict | list) -> str:
             option=_JSON_DUMPS_OPTIONS,
         ).decode("utf-8")
     except Exception:
-        pass
+        logger.debug("Failed to json dump the value, trying with stringified keys...")
     try:
         # An unencodable mapping key is the one failure worth retrying — it
         # aborts the whole document, losing every sibling value with it.

--- a/src/lmnr/sdk/utils.py
+++ b/src/lmnr/sdk/utils.py
@@ -219,14 +219,14 @@ def get_input_from_func_args(
     func_kwargs: dict[str, Any] | None = None,  # pyright: ignore[reportExplicitAny]
     ignore_inputs: list[str] | None = None,
 ) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]
-    func_args = func_args if func_args is not None else []
-    func_kwargs = func_kwargs if func_kwargs is not None else {}
+    normalized_args = func_args if func_args is not None else []
+    normalized_kwargs = func_kwargs if func_kwargs is not None else {}
     # Remove implicitly passed "self" or "cls" argument for
     # instance or class methods
     try:
         res = {
             k: v
-            for k, v in func_kwargs.items()  # pyright: ignore[reportAny]
+            for k, v in normalized_kwargs.items()  # pyright: ignore[reportAny]
             if not (ignore_inputs and k in ignore_inputs)
         }
         for i, k in enumerate(inspect.signature(func).parameters.keys()):
@@ -235,8 +235,8 @@ def get_input_from_func_args(
             if ignore_inputs and k in ignore_inputs:
                 continue
             # If param has default value, then it's not present in func args
-            if i < len(func_args):
-                res[k] = func_args[i]
+            if i < len(normalized_args):
+                res[k] = normalized_args[i]
         return res
     except Exception:
         logger.warning("Failed to get input from func args")

--- a/tests/test_413_error_reporting.py
+++ b/tests/test_413_error_reporting.py
@@ -10,7 +10,7 @@ import pytest
 from lmnr.sdk.client.asynchronous.resources import evals as async_evals
 from lmnr.sdk.client.synchronous.resources import evals as sync_evals
 from lmnr.sdk.client.synchronous.sync_client import LaminarClient
-from lmnr.sdk.types import PartialEvaluationDatapoint
+from lmnr.sdk.evaluations.models import PartialEvaluationDatapoint
 from lmnr.sdk.utils import MAX_ERROR_BODY_CHARS, describe_response
 
 

--- a/tests/test_client_evaluations.py
+++ b/tests/test_client_evaluations.py
@@ -8,7 +8,7 @@ import uuid
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from lmnr import LaminarClient, AsyncLaminarClient
-from lmnr.sdk.types import PartialEvaluationDatapoint
+from lmnr.sdk.evaluations.models import PartialEvaluationDatapoint
 
 
 class TestAsyncLaminarClientEvaluations:
@@ -99,8 +99,8 @@ class TestAsyncLaminarClientEvaluations:
             call_json = mock_post.call_args[1]["json"]
             assert call_json["name"] == "Renamed Evaluation"
             assert call_json["metadata"] == {"revision": 2}
-            assert result.id == eval_id
-            assert result.name == "Renamed Evaluation"
+            assert result["id"] == eval_id
+            assert result["name"] == "Renamed Evaluation"
 
     @pytest.mark.asyncio
     async def test_update_evaluation_error(self, async_client):
@@ -354,8 +354,8 @@ class TestLaminarClientEvaluations:
             call_json = mock_post.call_args[1]["json"]
             assert call_json["name"] == "Renamed Evaluation"
             assert call_json["metadata"] == {"revision": 2}
-            assert result.id == eval_id
-            assert result.name == "Renamed Evaluation"
+            assert result["id"] == eval_id
+            assert result["name"] == "Renamed Evaluation"
 
     def test_update_evaluation_error(self, sync_client):
         """Test evaluation update raises on non-200 responses."""

--- a/tests/test_dataset_subsampling.py
+++ b/tests/test_dataset_subsampling.py
@@ -224,10 +224,10 @@ def _paged_laminar_dataset(total: int, fetch_size: int):
     client = MagicMock()
 
     def pull(name=None, id=None, offset=0, limit=fetch_size):
-        resp = MagicMock()
-        resp.items = all_items[offset : offset + limit]
-        resp.total_count = total
-        return resp
+        return {
+            "items": all_items[offset : offset + limit],
+            "total_count": total,
+        }
 
     client.datasets.pull.side_effect = pull
     ds.set_client(client)
@@ -301,16 +301,17 @@ async def test_eval_over_chained_dataset_has_dataset_link(
     dataset_id = uuid.uuid4()
     all_items = [make_dp(i) for i in range(5)]
 
-    eval_resp = MagicMock()
-    eval_resp.id = "00000000-0000-0000-0000-000000000000"
-    eval_resp.projectId = "mock-project-id"
+    eval_resp = {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "projectId": "mock-project-id",
+    }
     mock_init.return_value = eval_resp
 
     def pull(name=None, id=None, offset=0, limit=25):
-        resp = MagicMock()
-        resp.items = all_items[offset : offset + limit]
-        resp.total_count = len(all_items)
-        return resp
+        return {
+            "items": all_items[offset : offset + limit],
+            "total_count": len(all_items),
+        }
 
     mock_pull.side_effect = pull
 
@@ -336,7 +337,7 @@ async def test_eval_over_chained_dataset_has_dataset_link(
 
     assert seen_links, "expected dataset_link on chained-dataset result datapoints"
     for link in seen_links:
-        assert link.dataset_id == dataset_id
+        assert link["dataset_id"] == dataset_id
     # shuffle(seed=1).take(2) over 5 datapoints -> 2 processed datapoints,
     # each saved twice (partial + final).
     assert processed == 4

--- a/tests/test_debug_config.py
+++ b/tests/test_debug_config.py
@@ -8,7 +8,7 @@ from lmnr.sdk.debug.config import (
     build_debug_config,
     build_debug_config_from_context,
 )
-from lmnr.sdk.types import DebugContext, LaminarSpanContext
+from lmnr.sdk.types import DebugContext, LaminarSpanContext, deserialize_debug_context
 
 _DEBUG_ENV_KEYS = (
     "LMNR_DEBUG",
@@ -239,7 +239,7 @@ _REPLAY = "00000000-0000-0000-0000-0000000000bb"
 
 
 def test_debug_context_parse_camel_case():
-    ctx = DebugContext.deserialize(
+    ctx = deserialize_debug_context(
         {
             "enabled": True,
             "sessionId": _SESSION,
@@ -247,14 +247,14 @@ def test_debug_context_parse_camel_case():
             "cacheUntil": "0123-456789abcdef",
         }
     )
-    assert ctx.enabled is True
-    assert ctx.session_id == _SESSION
-    assert ctx.replay_trace_id == _REPLAY
-    assert ctx.cache_until == "0123-456789abcdef"
+    assert ctx["enabled"] is True
+    assert ctx["session_id"] == _SESSION
+    assert ctx["replay_trace_id"] == _REPLAY
+    assert ctx["cache_until"] == "0123-456789abcdef"
 
 
 def test_debug_context_parse_snake_case():
-    ctx = DebugContext.deserialize(
+    ctx = deserialize_debug_context(
         {
             "enabled": True,
             "session_id": _SESSION,
@@ -262,9 +262,9 @@ def test_debug_context_parse_snake_case():
             "cache_until": "abcdef",
         }
     )
-    assert ctx.session_id == _SESSION
-    assert ctx.replay_trace_id == _REPLAY
-    assert ctx.cache_until == "abcdef"
+    assert ctx["session_id"] == _SESSION
+    assert ctx["replay_trace_id"] == _REPLAY
+    assert ctx["cache_until"] == "abcdef"
 
 
 def test_debug_context_keeps_non_uuid_ids_verbatim():
@@ -272,23 +272,23 @@ def test_debug_context_keeps_non_uuid_ids_verbatim():
     # and propagates that exact value, so the consumer must round-trip it
     # unchanged. Dropping non-UUID ids to None would make the downstream treat
     # the block as session-less and never join the run.
-    ctx = DebugContext.deserialize(
+    ctx = deserialize_debug_context(
         {
             "enabled": True,
             "session_id": "my-session",
             "replay_trace_id": "my-replay",
         }
     )
-    assert ctx.session_id == "my-session"
-    assert ctx.replay_trace_id == "my-replay"
+    assert ctx["session_id"] == "my-session"
+    assert ctx["replay_trace_id"] == "my-replay"
 
 
 def test_debug_context_empty_ids_become_none():
-    ctx = DebugContext.deserialize(
+    ctx = deserialize_debug_context(
         {"enabled": True, "session_id": "", "replay_trace_id": ""}
     )
-    assert ctx.session_id is None
-    assert ctx.replay_trace_id is None
+    assert ctx["session_id"] is None
+    assert ctx["replay_trace_id"] is None
 
 
 def test_debug_context_non_boolean_enabled_never_arms():
@@ -296,10 +296,10 @@ def test_debug_context_non_boolean_enabled_never_arms():
     # the string "false", or 1) is a malformed/forged block and must parse to
     # enabled=False, never arming a downstream runtime.
     for enabled in ("false", "true", 1, {"x": 1}):
-        ctx = DebugContext.deserialize(
+        ctx = deserialize_debug_context(
             {"enabled": enabled, "session_id": "my-session"}
         )
-        assert ctx.enabled is False
+        assert ctx["enabled"] is False
 
 
 def test_laminar_span_context_parses_nested_debug():
@@ -311,8 +311,8 @@ def test_laminar_span_context_parses_nested_debug():
         }
     )
     assert sc.debug is not None
-    assert sc.debug.enabled is True
-    assert sc.debug.session_id == _SESSION
+    assert sc.debug["enabled"] is True
+    assert sc.debug["session_id"] == _SESSION
 
 
 def test_laminar_span_context_no_debug_is_none():

--- a/tests/test_debug_runtime.py
+++ b/tests/test_debug_runtime.py
@@ -202,8 +202,8 @@ def test_env_context_arms_debug_runtime_from_block(monkeypatch):
 
     assert "debug" in armed_with
     assert armed_with["debug"] is not None
-    assert armed_with["debug"].enabled is True
-    assert armed_with["debug"].session_id == session_id
+    assert armed_with["debug"]["enabled"] is True
+    assert armed_with["debug"]["session_id"] == session_id
     _reset_runtime()
 
 

--- a/tests/test_evaluations.py
+++ b/tests/test_evaluations.py
@@ -9,17 +9,18 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from lmnr import Laminar
 from lmnr.sdk.evaluations import evaluate
 from lmnr.sdk.evaluations.utils import get_average_scores
-from lmnr.sdk.types import Datapoint, EvaluationResultDatapoint, HumanEvaluator
+from lmnr.sdk.evaluations.models import EvaluationResultDatapoint, HumanEvaluator
+from lmnr.sdk.types import Datapoint
 
 
 # Fixtures for common mock objects
 @pytest.fixture
 def mock_eval_response():
     """Create a mock evaluation response."""
-    response = MagicMock()
-    response.id = "00000000-0000-0000-0000-000000000000"
-    response.projectId = "mock-project-id"
-    return response
+    return {
+        "id": "00000000-0000-0000-0000-000000000000",
+        "projectId": "mock-project-id",
+    }
 
 
 @pytest.fixture
@@ -31,25 +32,23 @@ def mock_datapoints_response():
 @pytest.fixture
 def mock_dataset_push_response():
     """Create a mock dataset push response."""
-    response = MagicMock()
-    response.dataset_id = "00000000-0000-0000-0000-000000000001"
-    return response
+    return {"dataset_id": "00000000-0000-0000-0000-000000000001"}
 
 
 @pytest.fixture
 def mock_dataset_pull_response():
     """Create a mock dataset pull response."""
-    response = MagicMock()
-    response.items = [
-        Datapoint(
-            id=uuid.uuid4(),
-            data="test",
-            target="test",
-            createdAt=datetime.now(),
-        )
-    ]
-    response.total_count = 1
-    return response
+    return {
+        "items": [
+            Datapoint(
+                id=uuid.uuid4(),
+                data="test",
+                target="test",
+                createdAt=datetime.now(),
+            )
+        ],
+        "total_count": 1,
+    }
 
 
 # Helper functions for common test logic
@@ -568,7 +567,7 @@ async def test_evaluate_propagates_evaluation_id_to_all_spans(
     # 2 datapoints * (evaluation + executor + inner_user_span + 1 evaluator) = 8
     assert len(spans) == 8
 
-    expected_eval_id = mock_eval_response.id
+    expected_eval_id = mock_eval_response["id"]
     for span in spans:
         actual = span.attributes.get(
             "lmnr.association.properties.metadata.evaluation_id"

--- a/tests/test_shared_instrumentor.py
+++ b/tests/test_shared_instrumentor.py
@@ -220,3 +220,62 @@ def test_wrapper_kwargs_defaults_to_empty_and_reaches_the_wrapper():
         lambda: None, None, (), {}
     )
     assert seen["extra"] == {"client": "sentinel"}
+
+
+# ---------------------------------------------------------------------------
+# Every span-creating instrumentor stamps its scope
+# ---------------------------------------------------------------------------
+
+#: Migrated instrumentors that mint spans of their own. Since they all resolve
+#: the single `lmnr.tracer` OTel tracer, the real OTel InstrumentationScope
+#: cannot identify the source library — `lmnr.span.instrumentation_scope.*` is
+#: the only thing that can, so a package that creates spans without stamping
+#: emits unattributable spans. `langgraph` and `opentelemetry` are deliberately
+#: absent: they create no spans (langgraph only attaches context values,
+#: opentelemetry patches a DataDog `SpanContext` bug).
+_SPAN_CREATING_INSTRUMENTATION_PACKAGES = [
+    "anthropic",
+    "claude_agent",
+    "cua_agent",
+    "cua_computer",
+    "daytona",
+    "google_genai",
+    "groq",
+    "kernel",
+    "litellm",
+    "openai",
+    "skyvern",
+]
+
+
+@pytest.mark.parametrize("package", _SPAN_CREATING_INSTRUMENTATION_PACKAGES)
+def test_span_creating_instrumentors_stamp_their_scope(package):
+    """Source-level guard, because most of these packages need their third-party
+    SDK installed to exercise at runtime. It catches the failure mode that
+    actually happened: a wrapper migrated to the shared contract, receiving the
+    scope on its spec, but never stamping it onto the span it creates."""
+    import pathlib
+
+    import lmnr.opentelemetry_lib.opentelemetry.instrumentation as instrumentation
+
+    # A namespace package (no `__init__.py`), so `__file__` is None.
+    root = pathlib.Path(list(instrumentation.__path__)[0]) / package
+    sources = [p.read_text() for p in root.rglob("*.py")]
+
+    creates_spans = any(
+        marker in src
+        for src in sources
+        for marker in (
+            "safe_start_span(",
+            "Laminar.start_span(",
+            "Laminar.start_active_span(",
+            "Laminar.start_as_current_span(",
+        )
+    )
+    assert creates_spans, f"{package} no longer creates spans; update this list"
+
+    assert any(
+        "stamp_instrumentation_scope(" in src
+        or "set_instrumentation_scope_attributes(" in src
+        for src in sources
+    ), f"{package} creates spans but never stamps lmnr.span.instrumentation_scope.*"

--- a/tests/test_temporal_instrumentation.py
+++ b/tests/test_temporal_instrumentation.py
@@ -196,8 +196,8 @@ def test_restore_preserves_debug_block():
     restored = restore_context_from_headers(headers)
     assert restored is not None
     assert restored.debug is not None
-    assert restored.debug.enabled is True
-    assert restored.debug.cache_until == "abcdef"
+    assert restored.debug["enabled"] is True
+    assert restored.debug["cache_until"] == "abcdef"
 
 
 def test_restore_falls_back_to_traceparent():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -757,16 +757,16 @@ def test_format_id_with_invalid_string():
 
 def test_format_id_with_invalid_types():
     """Test format_id with invalid input types."""
-    with pytest.raises(ValueError, match="Invalid ID type"):
+    with pytest.raises(TypeError, match="Invalid ID type"):
         format_id(None)
 
-    with pytest.raises(ValueError, match="Invalid ID type"):
+    with pytest.raises(TypeError, match="Invalid ID type"):
         format_id([])
 
-    with pytest.raises(ValueError, match="Invalid ID type"):
+    with pytest.raises(TypeError, match="Invalid ID type"):
         format_id({})
 
-    with pytest.raises(ValueError, match="Invalid ID type"):
+    with pytest.raises(TypeError, match="Invalid ID type"):
         format_id(1.5)
 
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches public SDK shapes (TypedDict responses, HumanEvaluator as dict, debug context parsing) and broad instrumentation span attributes; behavior should match tests but custom callers relying on Pydantic models or HumanEvaluator instances may need updates.
> 
> **Overview**
> This PR tightens static typing (especially **pyright** in `sdk/utils` and `sdk/types`) and reshapes how HTTP and debug payloads are represented in Python.
> 
> **API and evaluation models** move from Pydantic response objects to **`TypedDict` + `parse_*` helpers** for datasets (`Dataset`, `GetDatapointsResponse`, etc.) and eval init responses. Sync/async clients, CLI dataset commands, and `LaminarDataset` now use **dict key access** (e.g. `resp["items"]`). Evaluation-specific types (`HumanEvaluator`, executor/evaluator callables, datapoint upload models) live under **`lmnr.sdk.evaluations.models`**; **`HumanEvaluator` is exported from the package root** but is a **TypedDict** (human eval detection uses `isinstance(..., dict)`). Eval client resources use **lazy imports** and `TYPE_CHECKING` to avoid circular imports with the evaluations package.
> 
> **Debug propagation** replaces `DebugContext` as a Pydantic model with a **TypedDict** and **`deserialize_debug_context`**, with consumers reading fields via `.get()`.
> 
> **Tracing**: instrumentors that create their own spans now call **`stamp_instrumentation_scope`** (or **`set_instrumentation_scope_attributes`** for Skyvern’s global LLM handler), recording `lmnr.span.instrumentation_scope.*` on spans. A new parametrized test guards span-creating packages for missing stamps.
> 
> Tests and small utilities are updated accordingly (e.g. `format_id` raises **`TypeError`** for bad types, `parse_iso_datetime` for `Z` suffixes on Python 3.10).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 626edd3214571abb04d3f8e54b800078cdbc1d95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->