### PR TITLE
Chore/pyright fixes browser utils

### DIFF
--- a/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/shared/base_instrumentor.py
+++ b/src/lmnr/opentelemetry_lib/opentelemetry/instrumentation/shared/base_instrumentor.py
@@ -1,17 +1,18 @@
+import importlib
+import sys
 from abc import ABC, abstractmethod
 from logging import Logger
 from typing import Any
 
-import importlib
-import sys
-
 from opentelemetry.instrumentation.instrumentor import BaseInstrumentor
 from opentelemetry.instrumentation.utils import unwrap
-from wrapt import wrap_function_wrapper, FunctionWrapper
+from typing_extensions import override
+from wrapt import FunctionWrapper, wrap_function_wrapper
+
+from lmnr.sdk.log import get_default_logger
 
 from .types import LaminarInstrumentationScopeAttributes, LaminarInstrumentorConfig
 from .wrapper_helpers import add_spec_wrapper
-from lmnr.sdk.log import get_default_logger
 
 
 class BaseLaminarInstrumentor(BaseInstrumentor, ABC):
@@ -129,7 +130,8 @@ class BaseLaminarInstrumentor(BaseInstrumentor, ABC):
         del self._module_function_originals[key]
 
     # default implementation, can be overridden by subclasses
-    def _instrument(self, **kwargs):
+    @override
+    def _instrument(self, **kwargs: dict[str, Any]):  #pyright: ignore[reportExplicitAny]
         handler_kwargs = self.wrapper_kwargs()
         for wrapped_function_spec in self.instrumentor_config["wrapped_functions"]:
             package_name = wrapped_function_spec["package_name"]
@@ -174,7 +176,8 @@ class BaseLaminarInstrumentor(BaseInstrumentor, ABC):
                 # don't re-raise, we don't want to fail the entire program
 
     # default implementation, can be overridden by subclasses
-    def _uninstrument(self, **kwargs):
+    @override
+    def _uninstrument(self, **kwargs: dict[str, Any]):  #pyright: ignore[reportExplicitAny]
         for wrapped_function_spec in self.instrumentor_config["wrapped_functions"]:
             package_name = wrapped_function_spec["package_name"]
             object_name = wrapped_function_spec.get("object_name")

--- a/src/lmnr/sdk/browser/background_send_events.py
+++ b/src/lmnr/sdk/browser/background_send_events.py
@@ -143,7 +143,7 @@ def _cleanup_background_loop():
             except KeyboardInterrupt:
                 logger.debug("Interrupted, cancelling pending async sends")
                 for f in futures_to_wait:
-                    _ = f.cancel()
+                    _cancelled = f.cancel()
                 raise
             except Exception as e:
                 logger.debug(f"Error in async send: {e}")
@@ -151,7 +151,7 @@ def _cleanup_background_loop():
     # Stop the background loop
     if _background_loop is not None and not _background_loop.is_closed():
         try:
-            _ = _background_loop.call_soon_threadsafe(_background_loop.stop)
+            _stop_handle = _background_loop.call_soon_threadsafe(_background_loop.stop)
             # Wait for thread to finish
             if _background_loop_thread is not None:
                 _background_loop_thread.join(timeout=THREAD_JOIN_TIMEOUT_SECONDS)

--- a/src/lmnr/sdk/browser/background_send_events.py
+++ b/src/lmnr/sdk/browser/background_send_events.py
@@ -27,7 +27,7 @@ while achieving cross-thread execution.
 import asyncio
 import atexit
 import threading
-from typing import Any
+from concurrent.futures import Future
 
 from lmnr.sdk.log import get_default_logger
 
@@ -51,7 +51,7 @@ _background_loop = None
 _background_loop_thread = None
 _background_loop_lock = threading.Lock()
 _background_loop_ready = threading.Event()
-_pending_async_futures: set[asyncio.Future[Any]] = set()
+_pending_async_futures: set[Future[None]] = set()
 
 
 def get_background_loop() -> asyncio.AbstractEventLoop:
@@ -64,7 +64,7 @@ def get_background_loop() -> asyncio.AbstractEventLoop:
     Returns:
         The background event loop running in a separate thread.
     """
-    global _background_loop, _background_loop_thread
+    global _background_loop_thread
 
     with _background_loop_lock:
         if _background_loop is None:
@@ -82,16 +82,19 @@ def get_background_loop() -> asyncio.AbstractEventLoop:
             _background_loop_thread.start()
 
             # Register cleanup handler
-            atexit.register(_cleanup_background_loop)
+            _cleanup_handler = atexit.register(_cleanup_background_loop)
 
     # Wait for loop to be created (outside the lock to avoid blocking other threads)
     if not _background_loop_ready.wait(timeout=LOOP_CREATION_TIMEOUT_SECONDS):
         raise RuntimeError("Background loop creation timed out")
 
+    if _background_loop is None:
+        raise RuntimeError("Background loop creation failed")
+
     return _background_loop
 
 
-def track_async_send(future: asyncio.Future) -> None:
+def track_async_send(future: Future[None]) -> None:
     """
     Track an async send future for cleanup at exit.
 
@@ -104,7 +107,7 @@ def track_async_send(future: asyncio.Future) -> None:
     with _background_loop_lock:
         _pending_async_futures.add(future)
 
-    def remove_on_done(f):
+    def remove_on_done(f: Future[None]) -> None:
         """Remove the future from tracking when it completes."""
         with _background_loop_lock:
             _pending_async_futures.discard(f)
@@ -119,8 +122,6 @@ def _cleanup_background_loop():
     Called automatically at program exit via atexit. Waits for each pending send
     to complete with a timeout, then stops the background loop gracefully.
     """
-    global _background_loop
-
     # Create a snapshot of pending futures to avoid holding the lock during waits
     with _background_loop_lock:
         futures_to_wait = list(_pending_async_futures)
@@ -130,7 +131,7 @@ def _cleanup_background_loop():
     if pending_count > 0:
         logger.info(
             f"Finishing sending {pending_count} browser events... "
-            "Ctrl+C to cancel (may result in incomplete session recording)."
+            + "Ctrl+C to cancel (may result in incomplete session recording)."
         )
 
         # Wait for all pending futures to complete
@@ -142,7 +143,7 @@ def _cleanup_background_loop():
             except KeyboardInterrupt:
                 logger.debug("Interrupted, cancelling pending async sends")
                 for f in futures_to_wait:
-                    f.cancel()
+                    _ = f.cancel()
                 raise
             except Exception as e:
                 logger.debug(f"Error in async send: {e}")
@@ -150,7 +151,7 @@ def _cleanup_background_loop():
     # Stop the background loop
     if _background_loop is not None and not _background_loop.is_closed():
         try:
-            _background_loop.call_soon_threadsafe(_background_loop.stop)
+            _ = _background_loop.call_soon_threadsafe(_background_loop.stop)
             # Wait for thread to finish
             if _background_loop_thread is not None:
                 _background_loop_thread.join(timeout=THREAD_JOIN_TIMEOUT_SECONDS)

--- a/src/lmnr/sdk/browser/browser_use_cdp_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_cdp_otel.py
@@ -1,8 +1,8 @@
 import asyncio
 import uuid
-from collections.abc import Collection, Sequence
+from collections.abc import Callable, Collection, Coroutine, Sequence
 from importlib.metadata import version
-from typing import Any
+from typing import Any, TypeVar
 
 from typing_extensions import override
 
@@ -22,6 +22,11 @@ from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 from lmnr.sdk.log import get_default_logger
 
 logger = get_default_logger(__name__)
+
+#: `_wrap` returns exactly what `wrapped` returns, whatever that is per
+#: call site — bounding it lets pyright track that identity instead of
+#: widening to `Any`.
+T = TypeVar("T")
 
 
 class BrowserUseCdpSpec(WrappedFunctionSpec, total=False):
@@ -43,13 +48,13 @@ _initialized_sessions: set[str] = set()
 
 
 async def process_wrapped_result(
-    result: Any,
-    instance: Any,
+    result: Any,  # pyright: ignore[reportExplicitAny, reportAny]
+    instance: Any,  # pyright: ignore[reportExplicitAny, reportAny]
     client: AsyncLaminarClient,
     to_wrap: BrowserUseCdpSpec,
 ):
     if to_wrap.get("action") == "inject_session_recorder":
-        session_id = result.session_id
+        session_id = str(result.session_id)
         if session_id in _initialized_sessions:
             return
         # Add eagerly to prevent parallel calls from double-initializing
@@ -67,20 +72,22 @@ async def process_wrapped_result(
         target_id = result
         if target_id:
             cdp_session = await instance.get_or_create_cdp_session(target_id)
-            _ = await take_full_snapshot(cdp_session)
+            _success = await take_full_snapshot(cdp_session)
 
 
 async def _wrap(
     to_wrap: BrowserUseCdpSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    wrapped: Callable[..., Coroutine[Any, Any, T]],  # pyright: ignore[reportExplicitAny]
+    instance: Any,  # pyright: ignore[reportExplicitAny, reportAny]
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
     client: AsyncLaminarClient,
-):
+) -> T:
     result = await wrapped(*args, **kwargs)
-    _ = asyncio.create_task(process_wrapped_result(result, instance, client, to_wrap))
+    _process_task = asyncio.create_task(
+        process_wrapped_result(result, instance, client, to_wrap)
+    )
 
     return result
 
@@ -140,13 +147,13 @@ class BrowserUseInstrumentor(BaseLaminarInstrumentor):
         return self._scope
 
     @override
-    def wrapper_kwargs(self) -> dict[str, Any]:
+    def wrapper_kwargs(self) -> dict[str, AsyncLaminarClient]:
         # The client is instrumentor-level, not per-method, so it rides the
         # base's handler-kwargs channel rather than being stuffed into each spec.
         return {"client": self.async_client}
 
     @override
-    def _uninstrument(self, **kwargs: Any):
+    def _uninstrument(self, **kwargs: dict[str, Any]):  # pyright: ignore[reportExplicitAny]
         super()._uninstrument(**kwargs)
         # Session ids must not outlive the instrumentation: a stale entry would
         # make a later run skip recorder injection for a reused session id.

--- a/src/lmnr/sdk/browser/browser_use_cdp_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_cdp_otel.py
@@ -1,7 +1,10 @@
 import asyncio
 import uuid
+from collections.abc import Collection, Sequence
 from importlib.metadata import version
-from typing import Any, Sequence
+from typing import Any
+
+from typing_extensions import override
 
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
     BaseLaminarInstrumentor,
@@ -11,14 +14,12 @@ from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
     LaminarInstrumentorConfig,
     WrappedFunctionSpec,
 )
-from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.browser.cdp_utils import (
     start_recording_events,
     take_full_snapshot,
 )
-
-from typing import Collection
+from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
+from lmnr.sdk.log import get_default_logger
 
 logger = get_default_logger(__name__)
 
@@ -41,8 +42,12 @@ _instruments = ("browser-use >= 0.6.0rc1",)
 _initialized_sessions: set[str] = set()
 
 
-
-async def process_wrapped_result(result, instance, client, to_wrap):
+async def process_wrapped_result(
+    result: Any,
+    instance: Any,
+    client: AsyncLaminarClient,
+    to_wrap: BrowserUseCdpSpec,
+):
     if to_wrap.get("action") == "inject_session_recorder":
         session_id = result.session_id
         if session_id in _initialized_sessions:
@@ -62,7 +67,7 @@ async def process_wrapped_result(result, instance, client, to_wrap):
         target_id = result
         if target_id:
             cdp_session = await instance.get_or_create_cdp_session(target_id)
-            await take_full_snapshot(cdp_session)
+            _ = await take_full_snapshot(cdp_session)
 
 
 async def _wrap(
@@ -75,7 +80,7 @@ async def _wrap(
     client: AsyncLaminarClient,
 ):
     result = await wrapped(*args, **kwargs)
-    asyncio.create_task(process_wrapped_result(result, instance, client, to_wrap))
+    _ = asyncio.create_task(process_wrapped_result(result, instance, client, to_wrap))
 
     return result
 
@@ -87,7 +92,10 @@ WRAPPED_FUNCTIONS: list[BrowserUseCdpSpec] = [
         method_name="get_or_create_cdp_session",
         is_async=True,
         action="inject_session_recorder",
-        wrapper_function=_wrap,
+        # `_wrap` takes a keyword-only `client`, forwarded via `wrapper_kwargs()`
+        # below (see wrapper_helpers.add_spec_wrapper) — WrapperHandler can't
+        # express that extra parameter, so this is a known-safe mismatch.
+        wrapper_function=_wrap,  # pyright: ignore[reportArgumentType]
     ),
     BrowserUseCdpSpec(
         package_name="browser_use.browser.session",
@@ -95,7 +103,7 @@ WRAPPED_FUNCTIONS: list[BrowserUseCdpSpec] = [
         method_name="on_SwitchTabEvent",
         is_async=True,
         action="take_full_snapshot",
-        wrapper_function=_wrap,
+        wrapper_function=_wrap,  # pyright: ignore[reportArgumentType]
     ),
 ]
 
@@ -105,17 +113,19 @@ class BrowserUseInstrumentor(BaseLaminarInstrumentor):
 
     def __init__(self, async_client: AsyncLaminarClient):
         super().__init__()
-        self.async_client = async_client
-        self.instrumentor_config = LaminarInstrumentorConfig(
+        self.async_client: AsyncLaminarClient = async_client
+        self.instrumentor_config: LaminarInstrumentorConfig = LaminarInstrumentorConfig(
             wrapped_functions=[
                 {**spec, "instrumentation_scope": self.instrumentation_scope()}
                 for spec in WRAPPED_FUNCTIONS
             ]
         )
 
+    @override
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
+    @override
     def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
         if self._scope is None:
             try:
@@ -129,12 +139,14 @@ class BrowserUseInstrumentor(BaseLaminarInstrumentor):
             )
         return self._scope
 
+    @override
     def wrapper_kwargs(self) -> dict[str, Any]:
         # The client is instrumentor-level, not per-method, so it rides the
         # base's handler-kwargs channel rather than being stuffed into each spec.
         return {"client": self.async_client}
 
-    def _uninstrument(self, **kwargs):
+    @override
+    def _uninstrument(self, **kwargs: Any):
         super()._uninstrument(**kwargs)
         # Session ids must not outlive the instrumentation: a stale entry would
         # make a later run skip recorder injection for a reused session id.

--- a/src/lmnr/sdk/browser/browser_use_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_otel.py
@@ -1,7 +1,9 @@
+from collections.abc import Collection, Sequence
 from importlib.metadata import version
-from typing import Any, Collection, Sequence
+from typing import Any
 
 import pydantic
+from typing_extensions import override
 
 from lmnr import Laminar
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
@@ -31,11 +33,14 @@ class BrowserUseSpec(WrappedFunctionSpec, total=False):
     ignore_output: bool
 
 try:
-    from browser_use import AgentHistoryList
+    # we could pull in browser-use as a dev dep, but (1) it's heavy, (2) it's Python 3.11+
+    from browser_use import (  # pyright:ignore[reportMissingImports]
+        AgentHistoryList,  # pyright:ignore[reportUnknownVariableType]
+    )
 except ImportError as e:
     raise ImportError(
-        f"Attempted to import {__file__}, but it is designed "
-        "to patch Browser Use < 0.5.0, which is not installed. Use `pip install browser-use` "
+        f"Attempted to import {__file__}, but it is designed " +
+        "to patch Browser Use < 0.5.0, which is not installed. Use `pip install browser-use` " +
         "to install Browser Use or remove this import."
     ) from e
 
@@ -75,7 +80,7 @@ async def _wrap(
         if step_info and hasattr(step_info, "step_number"):
             span_name = f"agent.step.{step_info.step_number}"
 
-    with Laminar.start_as_current_span(span_name) as span:
+    with Laminar.start_as_current_span(str(span_name)) as span:
         result = await wrapped(*args, **kwargs)
         if not to_wrap.get("ignore_output"):
             to_serialize = result
@@ -140,9 +145,11 @@ WRAPPED_FUNCTIONS: list[BrowserUseSpec] = [
 class BrowserUseLegacyInstrumentor(BaseLaminarInstrumentor):
     _scope: LaminarInstrumentationScopeAttributes | None = None
 
+    @override
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
+    @override
     def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
         if self._scope is None:
             try:
@@ -158,7 +165,7 @@ class BrowserUseLegacyInstrumentor(BaseLaminarInstrumentor):
 
     def __init__(self):
         super().__init__()
-        self.instrumentor_config = LaminarInstrumentorConfig(
+        self.instrumentor_config: LaminarInstrumentorConfig = LaminarInstrumentorConfig(
             wrapped_functions=[
                 {**spec, "instrumentation_scope": self.instrumentation_scope()}
                 for spec in WRAPPED_FUNCTIONS

--- a/src/lmnr/sdk/browser/browser_use_otel.py
+++ b/src/lmnr/sdk/browser/browser_use_otel.py
@@ -1,6 +1,6 @@
-from collections.abc import Collection, Sequence
+from collections.abc import Callable, Collection, Coroutine, Sequence
 from importlib.metadata import version
-from typing import Any
+from typing import Any, TypeVar
 
 import pydantic
 from typing_extensions import override
@@ -46,15 +46,19 @@ except ImportError as e:
 
 _instruments = ("browser-use < 0.5.0",)
 
+#: `_wrap` returns exactly what `wrapped` returns, whatever that is per call
+#: site — bounding it lets pyright track that identity instead of widening to
+#: `Any`.
+T = TypeVar("T")
 
 
 async def _wrap(
     to_wrap: BrowserUseSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
-):
+    wrapped: Callable[..., Coroutine[Any, Any, T]],  # pyright: ignore[reportExplicitAny]
+    instance: Any,  # pyright: ignore[reportExplicitAny, reportAny]
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
+) -> T:
     span_name = to_wrap.get("span_name")
     attributes = {
         "lmnr.span.type": to_wrap.get("span_type"),
@@ -83,9 +87,13 @@ async def _wrap(
     with Laminar.start_as_current_span(str(span_name)) as span:
         result = await wrapped(*args, **kwargs)
         if not to_wrap.get("ignore_output"):
-            to_serialize = result
-            if isinstance(result, AgentHistoryList):
-                to_serialize = result.final_result()
+            # A fresh `Any`-typed alias, not `result` itself: `result` carries
+            # the bound `T` (so the function can return it unchanged below),
+            # but the isinstance narrowing here is only for serialization and
+            # must not leak back into `T`.
+            to_serialize: Any = result
+            if isinstance(to_serialize, AgentHistoryList):
+                to_serialize = to_serialize.final_result()
             serialized = (
                 to_serialize.model_dump_json()
                 if isinstance(to_serialize, pydantic.BaseModel)

--- a/src/lmnr/sdk/browser/bubus_otel.py
+++ b/src/lmnr/sdk/browser/bubus_otel.py
@@ -1,6 +1,6 @@
-from collections.abc import Collection, Sequence
+from collections.abc import Callable, Collection, Coroutine, Sequence
 from importlib.metadata import version
-from typing import Any
+from typing import Any, TypeVar
 
 from opentelemetry.trace import NonRecordingSpan, SpanContext, get_current_span
 from typing_extensions import override
@@ -18,20 +18,25 @@ from lmnr.opentelemetry_lib.tracing.context import get_current_context
 from lmnr.sdk.log import get_default_logger
 
 _instruments = ("bubus >= 1.3.0",)
-event_id_to_span_context: dict[Any, SpanContext] = {}
+event_id_to_span_context: dict[str, SpanContext] = {}
 logger = get_default_logger(__name__)
+
+#: Both wrappers below return exactly what `wrapped` returns, whatever that is
+#: per call site — bounding it lets pyright track that identity instead of
+#: widening to `Any`.
+T = TypeVar("T")
 
 
 def wrap_dispatch(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
-):
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., T],
+    _instance: Any,  # pyright: ignore[reportExplicitAny, reportAny]
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
+) -> T:
     event = args[0] if args and len(args) > 0 else kwargs.get("event", None)
     if event and hasattr(event, "event_id"):
-        event_id = event.event_id
+        event_id = str(event.event_id)
         if event_id:
             span = get_current_span(get_current_context())
             event_id_to_span_context[event_id] = span.get_span_context()
@@ -39,16 +44,16 @@ def wrap_dispatch(
 
 
 async def wrap_process_event(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
-):
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., Coroutine[Any, Any, T]],  # pyright: ignore[reportExplicitAny]
+    _instance: Any,  # pyright: ignore[reportExplicitAny, reportAny]
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
+) -> T:
     event = args[0] if args and len(args) > 0 else kwargs.get("event", None)
     span_context = None
     if event and hasattr(event, "event_id"):
-        event_id = event.event_id
+        event_id = str(event.event_id)
         if event_id:
             span_context = event_id_to_span_context.get(event_id)
     if not span_context:
@@ -115,7 +120,7 @@ class BubusInstrumentor(BaseLaminarInstrumentor):
         )
 
     @override
-    def _uninstrument(self, **kwargs: Any):
+    def _uninstrument(self, **kwargs: dict[str, Any]):  # pyright: ignore[reportExplicitAny]
         super()._uninstrument(**kwargs)
         # This map is the whole point of the instrumentation, so it must not
         # outlive it — a stale entry would re-parent a later event onto a span

--- a/src/lmnr/sdk/browser/bubus_otel.py
+++ b/src/lmnr/sdk/browser/bubus_otel.py
@@ -1,7 +1,9 @@
+from collections.abc import Collection, Sequence
 from importlib.metadata import version
-from typing import Any, Collection, Sequence
+from typing import Any
 
-from opentelemetry.trace import NonRecordingSpan, get_current_span
+from opentelemetry.trace import NonRecordingSpan, SpanContext, get_current_span
+from typing_extensions import override
 
 from lmnr import Laminar
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
@@ -16,7 +18,7 @@ from lmnr.opentelemetry_lib.tracing.context import get_current_context
 from lmnr.sdk.log import get_default_logger
 
 _instruments = ("bubus >= 1.3.0",)
-event_id_to_span_context = {}
+event_id_to_span_context: dict[Any, SpanContext] = {}
 logger = get_default_logger(__name__)
 
 
@@ -85,9 +87,11 @@ class BubusInstrumentor(BaseLaminarInstrumentor):
 
     _scope: LaminarInstrumentationScopeAttributes | None = None
 
+    @override
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
+    @override
     def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
         if self._scope is None:
             try:
@@ -103,14 +107,15 @@ class BubusInstrumentor(BaseLaminarInstrumentor):
 
     def __init__(self):
         super().__init__()
-        self.instrumentor_config = LaminarInstrumentorConfig(
+        self.instrumentor_config: LaminarInstrumentorConfig = LaminarInstrumentorConfig(
             wrapped_functions=[
                 {**spec, "instrumentation_scope": self.instrumentation_scope()}
                 for spec in WRAPPED_FUNCTIONS
             ]
         )
 
-    def _uninstrument(self, **kwargs):
+    @override
+    def _uninstrument(self, **kwargs: Any):
         super()._uninstrument(**kwargs)
         # This map is the whole point of the instrumentation, so it must not
         # outlive it — a stale entry would re-parent a later event onto a span

--- a/src/lmnr/sdk/browser/cdp_utils.py
+++ b/src/lmnr/sdk/browser/cdp_utils.py
@@ -1,22 +1,23 @@
 import asyncio
-import orjson
 import os
 import threading
 import time
-
+from collections.abc import Callable, Coroutine
+from typing import Any
 from weakref import WeakKeyDictionary
 
+import orjson
 from opentelemetry import trace
 
-from lmnr.sdk.decorators import observe
-from lmnr.sdk.browser.utils import retry_async
+from lmnr.opentelemetry_lib.tracing import TracerWrapper
+from lmnr.opentelemetry_lib.tracing.context import get_current_context
 from lmnr.sdk.browser.background_send_events import (
     get_background_loop,
     track_async_send,
 )
+from lmnr.sdk.browser.utils import retry_async
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
-from lmnr.opentelemetry_lib.tracing.context import get_current_context
-from lmnr.opentelemetry_lib.tracing import TracerWrapper
+from lmnr.sdk.decorators import observe
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.types import MaskInputOptions
 
@@ -62,7 +63,7 @@ with open(os.path.join(current_dir, "inject_script.js"), "r") as f:
     INJECT_SCRIPT_CONTENT = f.read()
 
 
-async def should_skip_page(cdp_session):
+async def should_skip_page(cdp_session: Any):
     """Checks if the page url is an error page or an empty page.
     This function returns True in case of any error in our code, because
     it is safer to not record events than to try to inject the recorder
@@ -158,16 +159,13 @@ def get_mask_input_setting() -> MaskInputOptions:
     """Get the mask_input setting from session recording configuration."""
     try:
         config = TracerWrapper.get_session_recording_options()
-        return config.get(
-            "mask_input_options",
-            MaskInputOptions(
-                textarea=False,
-                text=False,
-                number=False,
-                select=False,
-                email=False,
-                tel=False,
-            ),
+        return config.get("mask_input_options") or MaskInputOptions(
+            textarea=False,
+            text=False,
+            number=False,
+            select=False,
+            email=False,
+            tel=False,
         )
     except (AttributeError, Exception):
         # Fallback to default configuration if TracerWrapper is not initialized
@@ -182,7 +180,7 @@ def get_mask_input_setting() -> MaskInputOptions:
 
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
-async def get_isolated_context_id(cdp_session) -> int | None:
+async def get_isolated_context_id(cdp_session: Any) -> int | None:
     async with get_lock():
         tree = {}
         try:
@@ -233,7 +231,7 @@ async def get_isolated_context_id(cdp_session) -> int | None:
 
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
-async def inject_session_recorder(cdp_session) -> int | None:
+async def inject_session_recorder(cdp_session: Any) -> int | None:
     """Injects the session recorder base as well as the recorder itself.
     Returns the isolated context id if successful.
     """
@@ -319,7 +317,7 @@ async def inject_session_recorder(cdp_session) -> int | None:
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
 @observe(name="cdp_use.session", ignore_input=True, ignore_output=True)
 async def start_recording_events(
-    cdp_session,
+    cdp_session: Any,
     lmnr_session_id: str,
     client: AsyncLaminarClient,
 ):
@@ -334,9 +332,9 @@ async def start_recording_events(
     background_loop = get_background_loop()
 
     # Buffer for reassembling chunks
-    chunk_buffers = {}
+    chunk_buffers: dict[str, Any] = {}
 
-    async def send_events_from_browser(chunk: dict):
+    async def send_events_from_browser(chunk: dict[str, Any]):
         try:
             # Handle chunked data
             batch_id = chunk["batchId"]
@@ -393,7 +391,9 @@ async def start_recording_events(
     valid_context_ids: set[int] = set()
 
     # cdp_use.cdp.runtime.events.BindingCalledEvent
-    async def send_events_callback(event, cdp_session_id: str | None = None):
+    async def send_events_callback(
+        event: dict[str, Any], cdp_session_id: str | None = None
+    ):
         if event["name"] != "lmnrSendEvents":
             return
         if event["executionContextId"] not in valid_context_ids:
@@ -447,7 +447,7 @@ async def start_recording_events(
 
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
-async def enable_target_discovery(cdp_session):
+async def enable_target_discovery(cdp_session: Any):
     cdp_client = cdp_session.cdp_client
     await cdp_client.send.Target.setDiscoverTargets(
         {
@@ -459,13 +459,13 @@ async def enable_target_discovery(cdp_session):
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
 def register_on_target_created(
-    cdp_session, lmnr_session_id: str, client: AsyncLaminarClient
+    cdp_session: Any, _lmnr_session_id: str, _client: AsyncLaminarClient
 ):
     # cdp_use.cdp.target.events.TargetCreatedEvent
-    def on_target_created(event, cdp_session_id: str | None = None):
+    def on_target_created(event: dict[str, Any], cdp_session_id: str | None = None):
         target_info = event["targetInfo"]
         if target_info["type"] == "page":
-            asyncio.create_task(inject_session_recorder(cdp_session=cdp_session))
+            _ = asyncio.create_task(inject_session_recorder(cdp_session=cdp_session))
 
     try:
         cdp_session.cdp_client.register.Target.targetCreated(on_target_created)
@@ -473,7 +473,9 @@ def register_on_target_created(
         logger.debug(f"Failed to register on target created: {e}")
 
 
-def register_on_frame_navigated(cdp_session, on_navigated):
+def register_on_frame_navigated(
+    cdp_session: Any, on_navigated: Callable[[], Coroutine[Any, Any, None]]
+):
     """Re-inject recorder after page navigation.
 
     When the main frame navigates, the execution context is destroyed.
@@ -481,7 +483,7 @@ def register_on_frame_navigated(cdp_session, on_navigated):
     for the new context.
     """
 
-    def on_frame_navigated(event, cdp_session_id: str | None = None):
+    def on_frame_navigated(event: dict[str, Any], cdp_session_id: str | None = None):
         frame = event.get("frame", {})
         # Only handle main frame navigation (parentId is absent for main frame)
         if frame.get("parentId"):
@@ -499,7 +501,7 @@ def register_on_frame_navigated(cdp_session, on_navigated):
             for k in keys_to_remove:
                 del frame_to_isolated_context_id[k]
 
-        asyncio.create_task(on_navigated())
+        _ = asyncio.create_task(on_navigated())
 
     try:
         cdp_session.cdp_client.register.Page.frameNavigated(on_frame_navigated)
@@ -509,7 +511,7 @@ def register_on_frame_navigated(cdp_session, on_navigated):
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
 async def is_recorder_present(
-    cdp_session, isolated_context_id: int | None = None
+    cdp_session: Any, isolated_context_id: int | None = None
 ) -> bool:
     # This function returns True on any error, because it is safer to not record
     # events than to try to inject the recorder into a broken context.
@@ -542,7 +544,7 @@ async def is_recorder_present(
         return True
 
 
-async def take_full_snapshot(cdp_session):
+async def take_full_snapshot(cdp_session: Any):
     cdp_client = cdp_session.cdp_client
     isolated_context_id = await get_isolated_context_id(cdp_session)
     if isolated_context_id is None:

--- a/src/lmnr/sdk/browser/cdp_utils.py
+++ b/src/lmnr/sdk/browser/cdp_utils.py
@@ -3,7 +3,7 @@ import os
 import threading
 import time
 from collections.abc import Callable, Coroutine
-from typing import Any
+from typing import Any, cast
 from weakref import WeakKeyDictionary
 
 import orjson
@@ -15,6 +15,7 @@ from lmnr.sdk.browser.background_send_events import (
     get_background_loop,
     track_async_send,
 )
+from lmnr.sdk.browser.chunk_types import ChunkBuffer, ChunkMessage
 from lmnr.sdk.browser.utils import retry_async
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 from lmnr.sdk.decorators import observe
@@ -63,7 +64,7 @@ with open(os.path.join(current_dir, "inject_script.js"), "r") as f:
     INJECT_SCRIPT_CONTENT = f.read()
 
 
-async def should_skip_page(cdp_session: Any):
+async def should_skip_page(cdp_session: Any):  # pyright: ignore[reportExplicitAny, reportAny]
     """Checks if the page url is an error page or an empty page.
     This function returns True in case of any error in our code, because
     it is safer to not record events than to try to inject the recorder
@@ -84,7 +85,7 @@ async def should_skip_page(cdp_session: Any):
             timeout=CDP_OPERATION_TIMEOUT_SECONDS,
         )
 
-        url = result.get("result", {}).get("value", "")
+        url = str((result.get("result") or {}).get("value") or "")
 
         # Comprehensive list of browser error URLs
         error_url_patterns = [
@@ -180,7 +181,7 @@ def get_mask_input_setting() -> MaskInputOptions:
 
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
-async def get_isolated_context_id(cdp_session: Any) -> int | None:
+async def get_isolated_context_id(cdp_session: Any) -> int | None:  # pyright: ignore[reportExplicitAny, reportAny]
     async with get_lock():
         tree = {}
         try:
@@ -196,7 +197,7 @@ async def get_isolated_context_id(cdp_session: Any) -> int | None:
         except Exception as e:
             logger.debug(f"Failed to get frame tree: {e}")
             return None
-        frame = tree.get("frameTree", {}).get("frame", {})
+        frame: dict[str, Any] = (tree.get("frameTree") or {}).get("frame") or {}
         frame_id = frame.get("id")
         loader_id = frame.get("loaderId")
 
@@ -209,7 +210,7 @@ async def get_isolated_context_id(cdp_session: Any) -> int | None:
             return frame_to_isolated_context_id[key]
 
         try:
-            result = await asyncio.wait_for(
+            result: dict[str, int] = await asyncio.wait_for(
                 cdp_session.cdp_client.send.Page.createIsolatedWorld(
                     {
                         "frameId": frame_id,
@@ -231,7 +232,7 @@ async def get_isolated_context_id(cdp_session: Any) -> int | None:
 
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
-async def inject_session_recorder(cdp_session: Any) -> int | None:
+async def inject_session_recorder(cdp_session: Any) -> int | None:  # pyright: ignore[reportExplicitAny, reportAny]
     """Injects the session recorder base as well as the recorder itself.
     Returns the isolated context id if successful.
     """
@@ -317,7 +318,7 @@ async def inject_session_recorder(cdp_session: Any) -> int | None:
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
 @observe(name="cdp_use.session", ignore_input=True, ignore_output=True)
 async def start_recording_events(
-    cdp_session: Any,
+    cdp_session: Any,  # pyright: ignore[reportExplicitAny]
     lmnr_session_id: str,
     client: AsyncLaminarClient,
 ):
@@ -332,9 +333,9 @@ async def start_recording_events(
     background_loop = get_background_loop()
 
     # Buffer for reassembling chunks
-    chunk_buffers: dict[str, Any] = {}
+    chunk_buffers: dict[str, ChunkBuffer] = {}
 
-    async def send_events_from_browser(chunk: dict[str, Any]):
+    async def send_events_from_browser(chunk: ChunkMessage) -> None:
         try:
             # Handle chunked data
             batch_id = chunk["batchId"]
@@ -344,11 +345,11 @@ async def start_recording_events(
 
             # Initialize buffer for this batch if needed
             if batch_id not in chunk_buffers:
-                chunk_buffers[batch_id] = {
-                    "chunks": {},
-                    "total": total_chunks,
-                    "timestamp": time.time(),
-                }
+                chunk_buffers[batch_id] = ChunkBuffer(
+                    chunks={},
+                    total=total_chunks,
+                    timestamp=time.time(),
+                )
 
             # Store chunk
             chunk_buffers[batch_id]["chunks"][chunk_index] = data
@@ -360,13 +361,18 @@ async def start_recording_events(
                 for i in range(total_chunks):
                     full_data += chunk_buffers[batch_id]["chunks"][i]
 
-                # Parse the JSON
-                events = orjson.loads(full_data)
+                # Parse the JSON. The individual event shape is rrweb's, not
+                # ours, so `Any` here is a genuine external contract.
+                events = cast(list[dict[str, Any]], orjson.loads(full_data))  # pyright: ignore[reportExplicitAny]
 
                 # Send to server in background loop (independent of CDP's loop)
                 if events and len(events) > 0:
                     future = asyncio.run_coroutine_threadsafe(
-                        client._browser_events.send(lmnr_session_id, trace_id, events),
+                        # Internal client API, shared across the browser
+                        # instrumentation package.
+                        client._browser_events.send(  # pyright: ignore[reportPrivateUsage]
+                            lmnr_session_id, trace_id, events
+                        ),
                         background_loop,
                     )
                     track_async_send(future)
@@ -376,7 +382,7 @@ async def start_recording_events(
 
             # Clean up old incomplete buffers
             current_time = time.time()
-            to_delete = []
+            to_delete: list[str] = []
             for bid, buffer in chunk_buffers.items():
                 if current_time - buffer["timestamp"] > OLD_BUFFER_TIMEOUT:
                     to_delete.append(bid)
@@ -392,13 +398,16 @@ async def start_recording_events(
 
     # cdp_use.cdp.runtime.events.BindingCalledEvent
     async def send_events_callback(
-        event: dict[str, Any], cdp_session_id: str | None = None
+        event: dict[str, Any],  # pyright: ignore[reportExplicitAny]
+        _cdp_session_id: str | None = None,
     ):
         if event["name"] != "lmnrSendEvents":
             return
         if event["executionContextId"] not in valid_context_ids:
             return
-        asyncio.create_task(send_events_from_browser(orjson.loads(event["payload"])))
+        _send_task = asyncio.create_task(
+            send_events_from_browser(cast(ChunkMessage, orjson.loads(event["payload"])))
+        )
 
     async def setup_context(context_id: int) -> bool:
         """Register the binding for a specific context ID."""
@@ -425,7 +434,7 @@ async def start_recording_events(
         """Re-inject recorder and re-register binding after navigation."""
         new_context_id = await inject_session_recorder(cdp_session)
         if new_context_id is not None:
-            await setup_context(new_context_id)
+            _context_registered = await setup_context(new_context_id)
 
     # Register event handlers FIRST - they must be in place before any navigation
     try:
@@ -441,13 +450,13 @@ async def start_recording_events(
     # the frameNavigated handler will re-inject when a real page loads)
     isolated_context_id = await inject_session_recorder(cdp_session)
     if isolated_context_id is not None:
-        await setup_context(isolated_context_id)
+        _context_registered = await setup_context(isolated_context_id)
 
     return True
 
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
-async def enable_target_discovery(cdp_session: Any):
+async def enable_target_discovery(cdp_session: Any):  # pyright: ignore[reportExplicitAny]
     cdp_client = cdp_session.cdp_client
     await cdp_client.send.Target.setDiscoverTargets(
         {
@@ -459,13 +468,15 @@ async def enable_target_discovery(cdp_session: Any):
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
 def register_on_target_created(
-    cdp_session: Any, _lmnr_session_id: str, _client: AsyncLaminarClient
+    cdp_session: Any, _lmnr_session_id: str, _client: AsyncLaminarClient  # pyright: ignore[reportExplicitAny, reportAny]
 ):
-    # cdp_use.cdp.target.events.TargetCreatedEvent
-    def on_target_created(event: dict[str, Any], cdp_session_id: str | None = None):
+    # cdp_use.cdp.target.events.TargetCreatedEvent - coerced down to only what we use here
+    def on_target_created(event: dict[str, dict[str, str]], _cdp_session_id: str | None = None):
         target_info = event["targetInfo"]
         if target_info["type"] == "page":
-            _ = asyncio.create_task(inject_session_recorder(cdp_session=cdp_session))
+            _inject_task = asyncio.create_task(
+                inject_session_recorder(cdp_session=cdp_session)
+            )
 
     try:
         cdp_session.cdp_client.register.Target.targetCreated(on_target_created)
@@ -474,7 +485,7 @@ def register_on_target_created(
 
 
 def register_on_frame_navigated(
-    cdp_session: Any, on_navigated: Callable[[], Coroutine[Any, Any, None]]
+    cdp_session: Any, on_navigated: Callable[[], Coroutine[Any, Any, None]]  # pyright: ignore[reportExplicitAny, reportAny]
 ):
     """Re-inject recorder after page navigation.
 
@@ -483,7 +494,8 @@ def register_on_frame_navigated(
     for the new context.
     """
 
-    def on_frame_navigated(event: dict[str, Any], cdp_session_id: str | None = None):
+    # cdp_use.cdp.target.events.FrameNavigatedEvent - coerced down to only what we use here
+    def on_frame_navigated(event: dict[str, dict[str, str]], _cdp_session_id: str | None = None):
         frame = event.get("frame", {})
         # Only handle main frame navigation (parentId is absent for main frame)
         if frame.get("parentId"):
@@ -501,7 +513,7 @@ def register_on_frame_navigated(
             for k in keys_to_remove:
                 del frame_to_isolated_context_id[k]
 
-        _ = asyncio.create_task(on_navigated())
+        _navigate_task = asyncio.create_task(on_navigated())
 
     try:
         cdp_session.cdp_client.register.Page.frameNavigated(on_frame_navigated)
@@ -511,7 +523,7 @@ def register_on_frame_navigated(
 
 # browser_use.browser.session.CDPSession (browser-use >= 0.6.0)
 async def is_recorder_present(
-    cdp_session: Any, isolated_context_id: int | None = None
+    cdp_session: Any, isolated_context_id: int | None = None  # pyright: ignore[reportExplicitAny, reportAny]
 ) -> bool:
     # This function returns True on any error, because it is safer to not record
     # events than to try to inject the recorder into a broken context.
@@ -544,7 +556,7 @@ async def is_recorder_present(
         return True
 
 
-async def take_full_snapshot(cdp_session: Any):
+async def take_full_snapshot(cdp_session: Any) -> bool:  # pyright: ignore[reportExplicitAny, reportAny]
     cdp_client = cdp_session.cdp_client
     isolated_context_id = await get_isolated_context_id(cdp_session)
     if isolated_context_id is None:
@@ -556,7 +568,7 @@ async def take_full_snapshot(cdp_session: Any):
         return False
 
     try:
-        result = await asyncio.wait_for(
+        result: dict[str, dict[str, bool]] = await asyncio.wait_for(
             cdp_client.send.Runtime.evaluate(
                 {
                     "expression": """(() => {
@@ -577,12 +589,13 @@ async def take_full_snapshot(cdp_session: Any):
             ),
             timeout=CDP_OPERATION_TIMEOUT_SECONDS,
         )
+        if result and "result" in result and "value" in result["result"]:
+            return result["result"]["value"]
+        return False
     except asyncio.TimeoutError:
         logger.debug("Timeout error when taking full snapshot")
         return False
     except Exception as e:
         logger.debug(f"Error when taking full snapshot: {e}")
         return False
-    if result and "result" in result and "value" in result["result"]:
-        return result["result"]["value"]
     return False

--- a/src/lmnr/sdk/browser/chunk_types.py
+++ b/src/lmnr/sdk/browser/chunk_types.py
@@ -1,0 +1,33 @@
+"""Wire format for chunked rrweb event messages sent from the browser.
+
+This is a contract WE own on both ends: emitted by `inject_script.js`
+(`createChunks` / `sendEvent`) and parsed here (`pw_utils.py`, `cdp_utils.py`) —
+unlike the surrounding wrapt/CDP payloads, it is not a third-party shape, so it
+is fully typed rather than `dict[str, Any]`.
+"""
+
+from typing import TypedDict
+
+
+class ChunkMessage(TypedDict):
+    """One `lmnrSendEvents` payload chunk, as emitted by `inject_script.js`.
+
+    A batch of compressed rrweb events is JSON-stringified and, when too large
+    for a single CDP/`expose_function` call, split into chunks of this shape
+    by `createChunks`; a small batch is still sent as this shape with
+    `chunkIndex=0, totalChunks=1`.
+    """
+
+    batchId: str
+    chunkIndex: int
+    totalChunks: int
+    data: str
+    isFinal: bool
+
+
+class ChunkBuffer(TypedDict):
+    """Reassembly state for one in-flight `batchId`, held in `chunk_buffers`."""
+
+    chunks: dict[int, str]
+    total: int
+    timestamp: float

--- a/src/lmnr/sdk/browser/patchright_otel.py
+++ b/src/lmnr/sdk/browser/patchright_otel.py
@@ -1,5 +1,7 @@
+from collections.abc import Collection
 from importlib.metadata import version
-from typing import Any, Collection
+
+from typing_extensions import override
 
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
     BaseLaminarInstrumentor,
@@ -43,17 +45,19 @@ class PatchrightInstrumentor(BaseLaminarInstrumentor):
 
     def __init__(self, async_client: AsyncLaminarClient):
         super().__init__()
-        self.async_client = async_client
-        self.instrumentor_config = LaminarInstrumentorConfig(
+        self.async_client: AsyncLaminarClient = async_client
+        self.instrumentor_config: LaminarInstrumentorConfig = LaminarInstrumentorConfig(
             wrapped_functions=[
                 {**spec, "instrumentation_scope": self.instrumentation_scope()}
                 for spec in WRAPPED_FUNCTIONS
             ]
         )
 
+    @override
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
+    @override
     def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
         if self._scope is None:
             try:
@@ -67,6 +71,7 @@ class PatchrightInstrumentor(BaseLaminarInstrumentor):
             )
         return self._scope
 
-    def wrapper_kwargs(self) -> dict[str, Any]:
+    @override
+    def wrapper_kwargs(self) -> dict[str, AsyncLaminarClient]:
         # See PlaywrightInstrumentor: sync wrappers also get the async client.
         return {"client": self.async_client}

--- a/src/lmnr/sdk/browser/playwright_otel.py
+++ b/src/lmnr/sdk/browser/playwright_otel.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 import logging
 import uuid
 from collections.abc import Callable, Collection, Coroutine, Sequence
 from importlib.metadata import version
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from typing_extensions import override
 
@@ -23,41 +25,25 @@ from lmnr.sdk.browser.pw_utils import (
 )
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 
-try:
-    if is_package_installed("playwright"):
-        from playwright.async_api import Browser, BrowserContext, Page
-        from playwright.sync_api import (
-            Browser as SyncBrowser,
-        )
-        from playwright.sync_api import (
-            BrowserContext as SyncBrowserContext,
-        )
-        from playwright.sync_api import (
-            Page as SyncPage,
-        )
-    elif is_package_installed("patchright"):
-        from patchright.async_api import Browser, BrowserContext, Page
-        from patchright.sync_api import (
-            Browser as SyncBrowser,
-        )
-        from patchright.sync_api import (
-            BrowserContext as SyncBrowserContext,
-        )
-        from patchright.sync_api import (
-            Page as SyncPage,
-        )
-    else:
-        raise ImportError(
-            "Attempted to import lmnr.sdk.browser.playwright_otel, but neither " +
-            "playwright nor patchright is installed. Use `pip install playwright` " +
-            "or `pip install patchright` to install one of the supported browsers."
-        )
-except ImportError as e:
+if TYPE_CHECKING:
+    # `from __future__ import annotations` makes every annotation in this file a
+    # deferred string, so this import (unlike the patchright fallback below) is
+    # never evaluated at runtime — it exists purely so pyright can resolve the
+    # types below. playwright and patchright are drop-in forks of one another
+    # (same API shape), so typing against playwright's stubs is accurate
+    # regardless of which package the user actually has installed.
+    from playwright.async_api import Browser, BrowserContext, BrowserType, Page
+    from playwright.sync_api import Browser as SyncBrowser
+    from playwright.sync_api import BrowserContext as SyncBrowserContext
+    from playwright.sync_api import BrowserType as SyncBrowserType
+    from playwright.sync_api import Page as SyncPage
+
+if not (is_package_installed("playwright") or is_package_installed("patchright")):
     raise ImportError(
-        f"Attempted to import {__file__}, but it is designed " +
-        "to patch Playwright, which is not installed. Use `pip install playwright` " +
-        "or `pip install patchright` to install Playwright or remove this import."
-    ) from e
+        f"Attempted to import {__file__}, but it is designed "
+        + "to patch Playwright, which is not installed. Use `pip install playwright` "
+        + "or `pip install patchright` to install Playwright or remove this import."
+    )
 
 # all available versions at https://pypi.org/project/playwright/#history
 _instruments = ("playwright >= 1.9.0",)
@@ -65,15 +51,15 @@ logger = logging.getLogger(__name__)
 
 
 def _wrap_new_browser_sync(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., SyncBrowser],
+    _instance: SyncBrowserType,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
     client: AsyncLaminarClient,
-):
-    browser: SyncBrowser = wrapped(*args, **kwargs)
+) -> SyncBrowser:
+    browser = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
     def create_page_handler(
@@ -86,7 +72,7 @@ def _wrap_new_browser_sync(
 
     for context in browser.contexts:
         page_handler = create_page_handler(session_id, client)
-        _ = context.on("page", page_handler)
+        _page_listener = context.on("page", page_handler)
         for page in context.pages:
             start_recording_events_sync(page, session_id, client)
 
@@ -94,20 +80,20 @@ def _wrap_new_browser_sync(
 
 
 async def _wrap_new_browser_async(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., Coroutine[Any, Any, Browser]],  # pyright: ignore[reportExplicitAny]
+    _instance: BrowserType,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
     client: AsyncLaminarClient,
-):
-    browser: Browser = await wrapped(*args, **kwargs)
+) -> Browser:
+    browser = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
     def create_page_handler(
         session_id: str, client: AsyncLaminarClient
-    ) -> Callable[[Page], Coroutine[Any, Any, None]]:
+    ) -> Callable[[Page], Coroutine[Any, Any, None]]:  # pyright: ignore[reportExplicitAny]
         async def page_handler(page: Page) -> None:
             await start_recording_events_async(page, session_id, client)
 
@@ -115,22 +101,22 @@ async def _wrap_new_browser_async(
 
     for context in browser.contexts:
         page_handler = create_page_handler(session_id, client)
-        _ = context.on("page", page_handler)
+        _page_listener = context.on("page", page_handler)
         for page in context.pages:
             await start_recording_events_async(page, session_id, client)
     return browser
 
 
 def _wrap_new_context_sync(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., SyncBrowserContext],
+    _instance: SyncBrowser | SyncBrowserType,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
     client: AsyncLaminarClient,
-):
-    context: SyncBrowserContext = wrapped(*args, **kwargs)
+) -> SyncBrowserContext:
+    context = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
     def create_page_handler(
@@ -142,7 +128,7 @@ def _wrap_new_context_sync(
         return page_handler
 
     page_handler = create_page_handler(session_id, client)
-    _ = context.on("page", page_handler)
+    _page_listener = context.on("page", page_handler)
     for page in context.pages:
         start_recording_events_sync(page, session_id, client)
 
@@ -150,27 +136,27 @@ def _wrap_new_context_sync(
 
 
 async def _wrap_new_context_async(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., Coroutine[Any, Any, BrowserContext]],  # pyright: ignore[reportExplicitAny]
+    _instance: Browser | BrowserType,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
     client: AsyncLaminarClient,
-):
-    context: BrowserContext = await wrapped(*args, **kwargs)
+) -> BrowserContext:
+    context = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
     def create_page_handler(
         session_id: str, client: AsyncLaminarClient
-    ) -> Callable[[Page], Coroutine[Any, Any, None]]:
+    ) -> Callable[[Page], Coroutine[Any, Any, None]]:  # pyright: ignore[reportExplicitAny]
         async def page_handler(page: Page) -> None:
             await start_recording_events_async(page, session_id, client)
 
         return page_handler
 
     page_handler = create_page_handler(session_id, client)
-    _ = context.on("page", page_handler)
+    _page_listener = context.on("page", page_handler)
     for page in context.pages:
         await start_recording_events_async(page, session_id, client)
 
@@ -178,40 +164,40 @@ async def _wrap_new_context_async(
 
 
 def _wrap_bring_to_front_sync(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., None],
+    instance: SyncPage,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
-    client: AsyncLaminarClient,
-):
+    _client: AsyncLaminarClient,
+) -> None:
     wrapped(*args, **kwargs)
-    _ = take_full_snapshot(instance)
+    _snapshot_taken = take_full_snapshot(instance)
 
 
 async def _wrap_bring_to_front_async(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., Coroutine[Any, Any, None]],  # pyright: ignore[reportExplicitAny]
+    instance: Page,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
-    client: AsyncLaminarClient,
-):
+    _client: AsyncLaminarClient,
+) -> None:
     await wrapped(*args, **kwargs)
-    _ = await take_full_snapshot_async(instance)
+    _snapshot_taken = await take_full_snapshot_async(instance)
 
 
 def _wrap_browser_new_page_sync(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., SyncPage],
+    _instance: SyncBrowser,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
     client: AsyncLaminarClient,
-):
+) -> SyncPage:
     page = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
     start_recording_events_sync(page, session_id, client)
@@ -219,14 +205,14 @@ def _wrap_browser_new_page_sync(
 
 
 async def _wrap_browser_new_page_async(
-    to_wrap: WrappedFunctionSpec,
-    wrapped,
-    instance: Any,
-    args: Sequence[Any],
-    kwargs: dict[str, Any],
+    _to_wrap: WrappedFunctionSpec,
+    wrapped: Callable[..., Coroutine[Any, Any, Page]],  # pyright: ignore[reportExplicitAny]
+    _instance: Browser,
+    args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
+    kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
     client: AsyncLaminarClient,
-):
+) -> Page:
     page = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
     await start_recording_events_async(page, session_id, client)
@@ -373,7 +359,7 @@ class PlaywrightInstrumentor(BaseLaminarInstrumentor):
         return self._scope
 
     @override
-    def wrapper_kwargs(self) -> dict[str, Any]:
+    def wrapper_kwargs(self) -> dict[str, AsyncLaminarClient]:
         # Both sync and async wrappers get the ASYNC client on purpose: sends go
         # through a background asyncio loop either way.
         return {"client": self.async_client}

--- a/src/lmnr/sdk/browser/playwright_otel.py
+++ b/src/lmnr/sdk/browser/playwright_otel.py
@@ -1,15 +1,10 @@
 import logging
 import uuid
-
-from lmnr.opentelemetry_lib.utils.package_check import is_package_installed
-from lmnr.sdk.browser.pw_utils import (
-    start_recording_events_async,
-    start_recording_events_sync,
-    take_full_snapshot,
-    take_full_snapshot_async,
-)
+from collections.abc import Callable, Collection, Coroutine, Sequence
 from importlib.metadata import version
-from typing import Any, Collection, Sequence
+from typing import Any
+
+from typing_extensions import override
 
 from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.base_instrumentor import (
     BaseLaminarInstrumentor,
@@ -19,31 +14,48 @@ from lmnr.opentelemetry_lib.opentelemetry.instrumentation.shared.types import (
     LaminarInstrumentorConfig,
     WrappedFunctionSpec,
 )
+from lmnr.opentelemetry_lib.utils.package_check import is_package_installed
+from lmnr.sdk.browser.pw_utils import (
+    start_recording_events_async,
+    start_recording_events_sync,
+    take_full_snapshot,
+    take_full_snapshot_async,
+)
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 
 try:
     if is_package_installed("playwright"):
-        from playwright.async_api import Browser, BrowserContext
+        from playwright.async_api import Browser, BrowserContext, Page
         from playwright.sync_api import (
             Browser as SyncBrowser,
+        )
+        from playwright.sync_api import (
             BrowserContext as SyncBrowserContext,
         )
+        from playwright.sync_api import (
+            Page as SyncPage,
+        )
     elif is_package_installed("patchright"):
-        from patchright.async_api import Browser, BrowserContext
+        from patchright.async_api import Browser, BrowserContext, Page
         from patchright.sync_api import (
             Browser as SyncBrowser,
+        )
+        from patchright.sync_api import (
             BrowserContext as SyncBrowserContext,
+        )
+        from patchright.sync_api import (
+            Page as SyncPage,
         )
     else:
         raise ImportError(
-            "Attempted to import lmnr.sdk.browser.playwright_otel, but neither "
-            "playwright nor patchright is installed. Use `pip install playwright` "
+            "Attempted to import lmnr.sdk.browser.playwright_otel, but neither " +
+            "playwright nor patchright is installed. Use `pip install playwright` " +
             "or `pip install patchright` to install one of the supported browsers."
         )
 except ImportError as e:
     raise ImportError(
-        f"Attempted to import {__file__}, but it is designed "
-        "to patch Playwright, which is not installed. Use `pip install playwright` "
+        f"Attempted to import {__file__}, but it is designed " +
+        "to patch Playwright, which is not installed. Use `pip install playwright` " +
         "or `pip install patchright` to install Playwright or remove this import."
     ) from e
 
@@ -64,15 +76,17 @@ def _wrap_new_browser_sync(
     browser: SyncBrowser = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
-    def create_page_handler(session_id, client):
-        def page_handler(page):
+    def create_page_handler(
+        session_id: str, client: AsyncLaminarClient
+    ) -> Callable[[SyncPage], None]:
+        def page_handler(page: SyncPage) -> None:
             start_recording_events_sync(page, session_id, client)
 
         return page_handler
 
     for context in browser.contexts:
         page_handler = create_page_handler(session_id, client)
-        context.on("page", page_handler)
+        _ = context.on("page", page_handler)
         for page in context.pages:
             start_recording_events_sync(page, session_id, client)
 
@@ -91,15 +105,17 @@ async def _wrap_new_browser_async(
     browser: Browser = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
-    def create_page_handler(session_id, client):
-        async def page_handler(page):
+    def create_page_handler(
+        session_id: str, client: AsyncLaminarClient
+    ) -> Callable[[Page], Coroutine[Any, Any, None]]:
+        async def page_handler(page: Page) -> None:
             await start_recording_events_async(page, session_id, client)
 
         return page_handler
 
     for context in browser.contexts:
         page_handler = create_page_handler(session_id, client)
-        context.on("page", page_handler)
+        _ = context.on("page", page_handler)
         for page in context.pages:
             await start_recording_events_async(page, session_id, client)
     return browser
@@ -117,14 +133,16 @@ def _wrap_new_context_sync(
     context: SyncBrowserContext = wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
-    def create_page_handler(session_id, client):
-        def page_handler(page):
+    def create_page_handler(
+        session_id: str, client: AsyncLaminarClient
+    ) -> Callable[[SyncPage], None]:
+        def page_handler(page: SyncPage) -> None:
             start_recording_events_sync(page, session_id, client)
 
         return page_handler
 
     page_handler = create_page_handler(session_id, client)
-    context.on("page", page_handler)
+    _ = context.on("page", page_handler)
     for page in context.pages:
         start_recording_events_sync(page, session_id, client)
 
@@ -143,14 +161,16 @@ async def _wrap_new_context_async(
     context: BrowserContext = await wrapped(*args, **kwargs)
     session_id = str(uuid.uuid4().hex)
 
-    def create_page_handler(session_id, client):
-        async def page_handler(page):
+    def create_page_handler(
+        session_id: str, client: AsyncLaminarClient
+    ) -> Callable[[Page], Coroutine[Any, Any, None]]:
+        async def page_handler(page: Page) -> None:
             await start_recording_events_async(page, session_id, client)
 
         return page_handler
 
     page_handler = create_page_handler(session_id, client)
-    context.on("page", page_handler)
+    _ = context.on("page", page_handler)
     for page in context.pages:
         await start_recording_events_async(page, session_id, client)
 
@@ -167,7 +187,7 @@ def _wrap_bring_to_front_sync(
     client: AsyncLaminarClient,
 ):
     wrapped(*args, **kwargs)
-    take_full_snapshot(instance)
+    _ = take_full_snapshot(instance)
 
 
 async def _wrap_bring_to_front_async(
@@ -180,7 +200,7 @@ async def _wrap_bring_to_front_async(
     client: AsyncLaminarClient,
 ):
     await wrapped(*args, **kwargs)
-    await take_full_snapshot_async(instance)
+    _ = await take_full_snapshot_async(instance)
 
 
 def _wrap_browser_new_page_sync(
@@ -215,104 +235,108 @@ async def _wrap_browser_new_page_async(
 
 
 
+# Every wrapper below takes a keyword-only `client`, forwarded via
+# `wrapper_kwargs()` on `PlaywrightInstrumentor` (see
+# wrapper_helpers.add_spec_wrapper) — WrapperHandler can't express that extra
+# parameter, so the `reportArgumentType` ignores below are a known-safe mismatch.
 WRAPPED_FUNCTIONS: list[WrappedFunctionSpec] = [
     WrappedFunctionSpec(
         package_name="playwright.sync_api",
         object_name="BrowserType",
         method_name="launch",
         is_async=False,
-        wrapper_function=_wrap_new_browser_sync,
+        wrapper_function=_wrap_new_browser_sync,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.sync_api",
         object_name="BrowserType",
         method_name="connect",
         is_async=False,
-        wrapper_function=_wrap_new_browser_sync,
+        wrapper_function=_wrap_new_browser_sync,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.sync_api",
         object_name="BrowserType",
         method_name="connect_over_cdp",
         is_async=False,
-        wrapper_function=_wrap_new_browser_sync,
+        wrapper_function=_wrap_new_browser_sync,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.sync_api",
         object_name="Browser",
         method_name="new_context",
         is_async=False,
-        wrapper_function=_wrap_new_context_sync,
+        wrapper_function=_wrap_new_context_sync,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.sync_api",
         object_name="BrowserType",
         method_name="launch_persistent_context",
         is_async=False,
-        wrapper_function=_wrap_new_context_sync,
+        wrapper_function=_wrap_new_context_sync,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.sync_api",
         object_name="Page",
         method_name="bring_to_front",
         is_async=False,
-        wrapper_function=_wrap_bring_to_front_sync,
+        wrapper_function=_wrap_bring_to_front_sync,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.sync_api",
         object_name="Browser",
         method_name="new_page",
         is_async=False,
-        wrapper_function=_wrap_browser_new_page_sync,
+        wrapper_function=_wrap_browser_new_page_sync,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.async_api",
         object_name="BrowserType",
         method_name="launch",
         is_async=True,
-        wrapper_function=_wrap_new_browser_async,
+        wrapper_function=_wrap_new_browser_async,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.async_api",
         object_name="BrowserType",
         method_name="connect",
         is_async=True,
-        wrapper_function=_wrap_new_browser_async,
+        wrapper_function=_wrap_new_browser_async,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.async_api",
         object_name="BrowserType",
         method_name="connect_over_cdp",
         is_async=True,
-        wrapper_function=_wrap_new_browser_async,
+        wrapper_function=_wrap_new_browser_async,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.async_api",
         object_name="Browser",
         method_name="new_context",
         is_async=True,
-        wrapper_function=_wrap_new_context_async,
+        wrapper_function=_wrap_new_context_async,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.async_api",
         object_name="BrowserType",
         method_name="launch_persistent_context",
         is_async=True,
-        wrapper_function=_wrap_new_context_async,
+        wrapper_function=_wrap_new_context_async,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.async_api",
         object_name="Page",
         method_name="bring_to_front",
         is_async=True,
-        wrapper_function=_wrap_bring_to_front_async,
+        wrapper_function=_wrap_bring_to_front_async,  # pyright: ignore[reportArgumentType]
     ),
     WrappedFunctionSpec(
         package_name="playwright.async_api",
         object_name="Browser",
         method_name="new_page",
         is_async=True,
-        wrapper_function=_wrap_browser_new_page_async,
+        wrapper_function=_wrap_browser_new_page_async,  # pyright: ignore[reportArgumentType]
     ),
 ]
 
@@ -322,17 +346,19 @@ class PlaywrightInstrumentor(BaseLaminarInstrumentor):
 
     def __init__(self, async_client: AsyncLaminarClient):
         super().__init__()
-        self.async_client = async_client
-        self.instrumentor_config = LaminarInstrumentorConfig(
+        self.async_client: AsyncLaminarClient = async_client
+        self.instrumentor_config: LaminarInstrumentorConfig = LaminarInstrumentorConfig(
             wrapped_functions=[
                 {**spec, "instrumentation_scope": self.instrumentation_scope()}
                 for spec in WRAPPED_FUNCTIONS
             ]
         )
 
+    @override
     def instrumentation_dependencies(self) -> Collection[str]:
         return _instruments
 
+    @override
     def instrumentation_scope(self) -> LaminarInstrumentationScopeAttributes:
         if self._scope is None:
             try:
@@ -346,6 +372,7 @@ class PlaywrightInstrumentor(BaseLaminarInstrumentor):
             )
         return self._scope
 
+    @override
     def wrapper_kwargs(self) -> dict[str, Any]:
         # Both sync and async wrappers get the ASYNC client on purpose: sends go
         # through a background asyncio loop either way.

--- a/src/lmnr/sdk/browser/playwright_otel.py
+++ b/src/lmnr/sdk/browser/playwright_otel.py
@@ -170,7 +170,7 @@ def _wrap_bring_to_front_sync(
     args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
     kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
-    _client: AsyncLaminarClient,
+    client: AsyncLaminarClient,  #pyright: ignore[reportUnusedParameter] set for compatibility with common wrappers though unused
 ) -> None:
     wrapped(*args, **kwargs)
     _snapshot_taken = take_full_snapshot(instance)
@@ -183,7 +183,7 @@ async def _wrap_bring_to_front_async(
     args: Sequence[Any],  # pyright: ignore[reportExplicitAny]
     kwargs: dict[str, Any],  # pyright: ignore[reportExplicitAny]
     *,
-    _client: AsyncLaminarClient,
+    client: AsyncLaminarClient,  #pyright: ignore[reportUnusedParameter] set for compatibility with common wrappers though unused
 ) -> None:
     await wrapped(*args, **kwargs)
     _snapshot_taken = await take_full_snapshot_async(instance)

--- a/src/lmnr/sdk/browser/pw_utils.py
+++ b/src/lmnr/sdk/browser/pw_utils.py
@@ -1,7 +1,7 @@
 import asyncio
 import os
 import time
-from typing import cast
+from typing import Any, cast
 
 import orjson
 from opentelemetry import trace
@@ -45,7 +45,7 @@ OLD_BUFFER_TIMEOUT = 60
 
 
 def create_send_events_handler(
-    chunk_buffers: dict,
+    chunk_buffers: dict[str, Any],
     session_id: str,
     trace_id: str,
     client: AsyncLaminarClient,
@@ -69,7 +69,7 @@ def create_send_events_handler(
         An async function that handles incoming event chunks from the browser
     """
 
-    async def send_events_from_browser(chunk):
+    async def send_events_from_browser(chunk: dict[str, Any]):
         try:
             # Handle chunked data
             batch_id = chunk["batchId"]
@@ -137,16 +137,13 @@ def get_mask_input_setting() -> MaskInputOptions:
     """Get the mask_input setting from session recording configuration."""
     try:
         config = TracerWrapper.get_session_recording_options()
-        return config.get(
-            "mask_input_options",
-            MaskInputOptions(
-                textarea=False,
-                text=False,
-                number=False,
-                select=False,
-                email=False,
-                tel=False,
-            ),
+        return config.get("mask_input_options") or MaskInputOptions(
+            textarea=False,
+            text=False,
+            number=False,
+            select=False,
+            email=False,
+            tel=False,
         )
     except (AttributeError, Exception):
         # Fallback to default configuration if TracerWrapper is not initialized
@@ -256,18 +253,18 @@ def start_recording_events_sync(
     background_loop = get_background_loop()
 
     # Buffer for reassembling chunks
-    chunk_buffers = {}
+    chunk_buffers: dict[str, Any] = {}
 
     # Create the async event handler (shared implementation)
     send_events_from_browser = create_send_events_handler(
         chunk_buffers, session_id, trace_id, client, background_loop
     )
 
-    def submit_event(chunk):
+    def submit_event(chunk: dict[str, Any]):
         """Sync wrapper that submits async handler to background loop."""
         try:
             # Submit async handler to background loop
-            asyncio.run_coroutine_threadsafe(
+            _ = asyncio.run_coroutine_threadsafe(
                 send_events_from_browser(chunk),
                 background_loop,
             )
@@ -281,7 +278,7 @@ def start_recording_events_sync(
 
     inject_session_recorder_sync(page)
 
-    def on_load(p):
+    def on_load(p: SyncPage):
         try:
             if not p.is_closed():
                 inject_session_recorder_sync(p)
@@ -304,7 +301,7 @@ async def start_recording_events_async(
     background_loop = get_background_loop()
 
     # Buffer for reassembling chunks
-    chunk_buffers = {}
+    chunk_buffers: dict[str, Any] = {}
 
     # Create the async event handler (shared implementation)
     send_events_from_browser = create_send_events_handler(
@@ -318,7 +315,7 @@ async def start_recording_events_async(
 
     await inject_session_recorder_async(page)
 
-    async def on_load(p):
+    async def on_load(p: Page):
         try:
             # Check if page is closed before attempting to inject
             if not p.is_closed():

--- a/src/lmnr/sdk/browser/pw_utils.py
+++ b/src/lmnr/sdk/browser/pw_utils.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import asyncio
 import os
 import time
-from typing import Any, cast
+from collections.abc import Callable, Coroutine
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 import orjson
 from opentelemetry import trace
@@ -13,44 +16,61 @@ from lmnr.sdk.browser.background_send_events import (
     get_background_loop,
     track_async_send,
 )
+from lmnr.sdk.browser.chunk_types import ChunkBuffer, ChunkMessage
 from lmnr.sdk.browser.utils import retry_async, retry_sync
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 from lmnr.sdk.decorators import observe
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.types import MaskInputOptions
 
-try:
-    if is_package_installed("playwright"):
-        from playwright.async_api import Page
-        from playwright.sync_api import Page as SyncPage
-    elif is_package_installed("patchright"):
-        from patchright.async_api import Page
-        from patchright.sync_api import Page as SyncPage
-    else:
-        raise ImportError(
-            "Attempted to import lmnr.sdk.browser.pw_utils, but neither " +
-            "playwright nor patchright is installed. Use `pip install playwright` " +
-            "or `pip install patchright` to install one of the supported browsers."
-        )
-except ImportError as e:
+if TYPE_CHECKING:
+    from playwright.async_api import Page
+    from playwright.sync_api import Page as SyncPage
+
+if not (is_package_installed("playwright") or is_package_installed("patchright")):
     raise ImportError(
-        "Attempted to import lmnr.sdk.browser.pw_utils, but neither " +
-        "playwright nor patchright is installed. Use `pip install playwright` " +
-        "or `pip install patchright` to install one of the supported browsers."
-    ) from e
+        "Attempted to import lmnr.sdk.browser.pw_utils, but neither "
+        + "playwright nor patchright is installed. Use `pip install playwright` "
+        + "or `pip install patchright` to install one of the supported browsers."
+    )
 
 logger = get_default_logger(__name__)
 
 OLD_BUFFER_TIMEOUT = 60
 
 
+class _ExposesSyncEvents(Protocol):
+    """The slice of playwright's sync `Page`/`BrowserContext` API used to wire
+    up `lmnrSendEvents`, re-declared with a precise callback type.
+
+    Playwright's own stub declares `expose_function`'s `callback` as a bare
+    `typing.Callable` — no parameter/return types — which pyright renders as
+    `(...) -> Unknown` and flags on every call, regardless of what we pass.
+    Casting to this Protocol at the call site swaps in a signature we own.
+    """
+
+    def expose_function(
+        self, name: str, callback: Callable[[ChunkMessage], None]
+    ) -> None: ...
+
+
+class _ExposesAsyncEvents(Protocol):
+    """Async counterpart of `_ExposesSyncEvents`, see there for why this exists."""
+
+    async def expose_function(
+        self,
+        name: str,
+        callback: Callable[[ChunkMessage], Coroutine[Any, Any, None]],  # pyright: ignore[reportExplicitAny]
+    ) -> None: ...
+
+
 def create_send_events_handler(
-    chunk_buffers: dict[str, Any],
+    chunk_buffers: dict[str, ChunkBuffer],
     session_id: str,
     trace_id: str,
     client: AsyncLaminarClient,
     background_loop: asyncio.AbstractEventLoop,
-):
+) -> Callable[[ChunkMessage], Coroutine[Any, Any, None]]:  # pyright: ignore[reportExplicitAny]
     """
     Create an async event handler for sending browser events.
 
@@ -69,7 +89,7 @@ def create_send_events_handler(
         An async function that handles incoming event chunks from the browser
     """
 
-    async def send_events_from_browser(chunk: dict[str, Any]):
+    async def send_events_from_browser(chunk: ChunkMessage) -> None:
         try:
             # Handle chunked data
             batch_id = chunk["batchId"]
@@ -79,11 +99,11 @@ def create_send_events_handler(
 
             # Initialize buffer for this batch if needed
             if batch_id not in chunk_buffers:
-                chunk_buffers[batch_id] = {
-                    "chunks": {},
-                    "total": total_chunks,
-                    "timestamp": time.time(),
-                }
+                chunk_buffers[batch_id] = ChunkBuffer(
+                    chunks={},
+                    total=total_chunks,
+                    timestamp=time.time(),
+                )
 
             # Store chunk
             chunk_buffers[batch_id]["chunks"][chunk_index] = data
@@ -95,13 +115,18 @@ def create_send_events_handler(
                 for i in range(total_chunks):
                     full_data += chunk_buffers[batch_id]["chunks"][i]
 
-                # Parse the JSON
-                events = orjson.loads(full_data)
+                # Parse the JSON. The individual event shape is rrweb's, not
+                # ours, so `Any` here is a genuine external contract.
+                events = cast(list[dict[str, Any]], orjson.loads(full_data))  # pyright: ignore[reportExplicitAny]
 
                 # Send to server in background loop (independent of Playwright's loop)
                 if events and len(events) > 0:
                     future = asyncio.run_coroutine_threadsafe(
-                        client._browser_events.send(session_id, trace_id, events),
+                        # Internal client API, shared across the browser
+                        # instrumentation package.
+                        client._browser_events.send(  # pyright: ignore[reportPrivateUsage]
+                            session_id, trace_id, events
+                        ),
                         background_loop,
                     )
                     track_async_send(future)
@@ -111,7 +136,7 @@ def create_send_events_handler(
 
             # Clean up old incomplete buffers
             current_time = time.time()
-            to_delete = []
+            to_delete: list[str] = []
             for bid, buffer in chunk_buffers.items():
                 if current_time - buffer["timestamp"] > OLD_BUFFER_TIMEOUT:
                     to_delete.append(bid)
@@ -253,18 +278,18 @@ def start_recording_events_sync(
     background_loop = get_background_loop()
 
     # Buffer for reassembling chunks
-    chunk_buffers: dict[str, Any] = {}
+    chunk_buffers: dict[str, ChunkBuffer] = {}
 
     # Create the async event handler (shared implementation)
     send_events_from_browser = create_send_events_handler(
         chunk_buffers, session_id, trace_id, client, background_loop
     )
 
-    def submit_event(chunk: dict[str, Any]):
+    def submit_event(chunk: ChunkMessage) -> None:
         """Sync wrapper that submits async handler to background loop."""
         try:
             # Submit async handler to background loop
-            _ = asyncio.run_coroutine_threadsafe(
+            _future = asyncio.run_coroutine_threadsafe(
                 send_events_from_browser(chunk),
                 background_loop,
             )
@@ -272,13 +297,13 @@ def start_recording_events_sync(
             logger.debug(f"Error submitting event: {e}")
 
     try:
-        page.expose_function("lmnrSendEvents", submit_event)
+        cast(_ExposesSyncEvents, page).expose_function("lmnrSendEvents", submit_event)
     except Exception as e:
         logger.debug(f"Could not expose function: {e}")
 
     inject_session_recorder_sync(page)
 
-    def on_load(p: SyncPage):
+    def on_load(p: SyncPage) -> None:
         try:
             if not p.is_closed():
                 inject_session_recorder_sync(p)
@@ -301,7 +326,7 @@ async def start_recording_events_async(
     background_loop = get_background_loop()
 
     # Buffer for reassembling chunks
-    chunk_buffers: dict[str, Any] = {}
+    chunk_buffers: dict[str, ChunkBuffer] = {}
 
     # Create the async event handler (shared implementation)
     send_events_from_browser = create_send_events_handler(
@@ -309,13 +334,15 @@ async def start_recording_events_async(
     )
 
     try:
-        await page.expose_function("lmnrSendEvents", send_events_from_browser)
+        await cast(_ExposesAsyncEvents, page).expose_function(
+            "lmnrSendEvents", send_events_from_browser
+        )
     except Exception as e:
         logger.debug(f"Could not expose function: {e}")
 
     await inject_session_recorder_async(page)
 
-    async def on_load(p: Page):
+    async def on_load(p: Page) -> None:
         try:
             # Check if page is closed before attempting to inject
             if not p.is_closed():

--- a/src/lmnr/sdk/utils.py
+++ b/src/lmnr/sdk/utils.py
@@ -215,11 +215,11 @@ def serialize(obj: Any) -> JsonValue:  # pyright: ignore[reportExplicitAny, repo
 def get_input_from_func_args(
     func: Callable[..., Any],  # pyright: ignore[reportExplicitAny]
     is_method: bool = False,
-    func_args: list[Any] | None = None,  # pyright: ignore[reportExplicitAny]
+    func_args: Sequence[Any] | None = None,  # pyright: ignore[reportExplicitAny]
     func_kwargs: dict[str, Any] | None = None,  # pyright: ignore[reportExplicitAny]
     ignore_inputs: list[str] | None = None,
 ) -> dict[str, Any]:  # pyright: ignore[reportExplicitAny]
-    normalized_args = func_args if func_args is not None else []
+    normalized_args = list(func_args if func_args is not None else [])
     normalized_kwargs = func_kwargs if func_kwargs is not None else {}
     # Remove implicitly passed "self" or "cls" argument for
     # instance or class methods


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly annotations and import structure; limited runtime changes in browser recording and background loop startup paths.
> 
> **Overview**
> This PR tightens **static typing (pyright)** across browser OpenTelemetry instrumentors and session-recording helpers, with a few small runtime hardening tweaks.
> 
> It adds **`ChunkMessage` / `ChunkBuffer` TypedDicts** in `chunk_types.py` and wires them through CDP and Playwright chunk reassembly and `lmnrSendEvents` handlers. Wrapper functions now use **`TypeVar` return types**, `@override`, and targeted **`pyright: ignore`** comments where the shared instrumentor API cannot express extra kwargs like `client`.
> 
> **Playwright/patchright** imports move behind **`TYPE_CHECKING`** (and optional install checks), with **Protocols** for `expose_function` callbacks. **`background_send_events`** types pending work as `Future[None]` and **raises if the background loop never materializes** after the ready wait.
> 
> Minor behavior-adjacent fixes include **`mask_input_options` via `or` defaults**, **`take_full_snapshot`** return handling in CDP utils, and **`get_input_from_func_args`** accepting **`Sequence`** args.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 404c68d94e5b5f264d4f4e45866a02502e3c6a80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->