### PR TITLE
Chore/pyright fixes debugger evals

### DIFF
--- a/src/lmnr/__init__.py
+++ b/src/lmnr/__init__.py
@@ -9,7 +9,6 @@ from .sdk.client.synchronous.sync_client import LaminarClient
 from .sdk.datasets import EvaluationDataset, LaminarDataset
 from .sdk.decorators import observe
 from .sdk.evaluations import evaluate
-from .sdk.evaluations.models import HumanEvaluator
 from .sdk.laminar import Laminar
 from .sdk.types import (
     LaminarSpanContext,
@@ -21,7 +20,6 @@ __all__ = [
     "AsyncLaminarClient",
     "Attributes",
     "EvaluationDataset",
-    "HumanEvaluator",
     "Instruments",
     "Laminar",
     "LaminarClient",

--- a/src/lmnr/opentelemetry_lib/tracing/attributes.py
+++ b/src/lmnr/opentelemetry_lib/tracing/attributes.py
@@ -1,11 +1,12 @@
 from enum import Enum
+
 from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
-    GEN_AI_SYSTEM,
     GEN_AI_REQUEST_MODEL,
+    GEN_AI_RESPONSE_ID,
     GEN_AI_RESPONSE_MODEL,
+    GEN_AI_SYSTEM,
     GEN_AI_USAGE_INPUT_TOKENS,
     GEN_AI_USAGE_OUTPUT_TOKENS,
-    GEN_AI_RESPONSE_ID,
 )
 
 SPAN_INPUT = "lmnr.span.input"
@@ -18,7 +19,6 @@ PARENT_SPAN_IDS_PATH = "lmnr.span.parent_ids_path"
 SPAN_INSTRUMENTATION_SOURCE = "lmnr.span.instrumentation_source"
 SPAN_SDK_VERSION = "lmnr.span.sdk_version"
 SPAN_LANGUAGE_VERSION = "lmnr.span.language_version"
-HUMAN_EVALUATOR_OPTIONS = "lmnr.span.human_evaluator_options"
 
 ASSOCIATION_PROPERTIES = "lmnr.association.properties"
 SESSION_ID = "session_id"

--- a/src/lmnr/sdk/client/asynchronous/resources/rollout_sessions.py
+++ b/src/lmnr/sdk/client/asynchronous/resources/rollout_sessions.py
@@ -1,15 +1,35 @@
 """Debug (rollout) session registration resource for the asynchronous client."""
 
 import uuid
-from typing import cast
+from typing import Any, cast
 
 from lmnr.sdk.client.asynchronous.resources.base import BaseAsyncResource
-from lmnr.sdk.debug.outcome import CacheOutcome, parse_cache_outcome
+from lmnr.sdk.debug.outcome import CacheOutcome
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.types import SessionBlock, SessionBlockContent, SessionBlockType
 
 logger = get_default_logger(__name__)
 
+def _parse_cache_outcome(data: object) -> CacheOutcome:
+    """Map app-server's `{outcome: hit|miss|live, response?}` body to CacheOutcome.
+
+    Anything unrecognized degrades to `live` (safe).
+    """
+    outcome = data.get("outcome") if isinstance(data, dict) else None  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    if outcome == "hit":
+        # A HIT must carry a response envelope to be servable; the provider
+        # wrappers call cached_response_to_*(cached), which does cached.get().
+        # A response-less HIT (omitted/null `response`) is malformed — degrade
+        # to `live` so the call runs live (no latch) instead of raising.
+        data_dict = cast(dict[str, Any], data)  # pyright: ignore[reportExplicitAny]
+        response = data_dict.get("response")
+        if response is None:
+            logger.debug("Cache HIT without response body; running call live")
+            return CacheOutcome(kind="live")
+        return CacheOutcome(kind="hit", cached=response) # pyright: ignore[reportAny])
+    if outcome == "miss":
+        return CacheOutcome(kind="miss")
+    return CacheOutcome(kind="live")
 
 class AsyncRolloutSessions(BaseAsyncResource):
     """Register / delete debug sessions on the backend.
@@ -122,8 +142,8 @@ class AsyncRolloutSessions(BaseAsyncResource):
     async def cache(
         self,
         session_id: uuid.UUID | str,
-        replay_trace_id: uuid.UUID | str,
-        cache_until: str,
+        replay_trace_id: uuid.UUID | str | None,
+        cache_until: str | None,
         input_hash: str,
     ) -> CacheOutcome:
         """Async variant of `RolloutSessions.cache` (shared spec §7).
@@ -136,7 +156,7 @@ class AsyncRolloutSessions(BaseAsyncResource):
                 f"{self._base_url}/v1/rollouts/{session_id}/cache",
                 headers=self._headers(),
                 json={
-                    "replayTraceId": str(replay_trace_id),
+                    "replayTraceId": str(replay_trace_id) if replay_trace_id is not None else None,
                     "cacheUntil": cache_until,
                     "inputHash": input_hash,
                 },
@@ -151,4 +171,4 @@ class AsyncRolloutSessions(BaseAsyncResource):
         except Exception as exc:
             logger.debug("Cache lookup failed (%s); running this call live", exc)
             return CacheOutcome(kind="live")
-        return parse_cache_outcome(data)
+        return _parse_cache_outcome(data)

--- a/src/lmnr/sdk/client/synchronous/resources/rollout_sessions.py
+++ b/src/lmnr/sdk/client/synchronous/resources/rollout_sessions.py
@@ -1,15 +1,35 @@
 """Debug (rollout) session registration resource for the synchronous client."""
 
 import uuid
-from typing import cast
+from typing import Any, cast
 
 from lmnr.sdk.client.synchronous.resources.base import BaseResource
-from lmnr.sdk.debug.outcome import CacheOutcome, parse_cache_outcome
+from lmnr.sdk.debug.outcome import CacheOutcome
 from lmnr.sdk.log import get_default_logger
 from lmnr.sdk.types import SessionBlock, SessionBlockContent, SessionBlockType
 
 logger = get_default_logger(__name__)
 
+def _parse_cache_outcome(data: object) -> CacheOutcome:
+    """Map app-server's `{outcome: hit|miss|live, response?}` body to CacheOutcome.
+
+    Anything unrecognized degrades to `live` (safe).
+    """
+    outcome = data.get("outcome") if isinstance(data, dict) else None  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
+    if outcome == "hit":
+        # A HIT must carry a response envelope to be servable; the provider
+        # wrappers call cached_response_to_*(cached), which does cached.get().
+        # A response-less HIT (omitted/null `response`) is malformed — degrade
+        # to `live` so the call runs live (no latch) instead of raising.
+        data_dict = cast(dict[str, Any], data)  # pyright: ignore[reportExplicitAny]
+        response = data_dict.get("response")
+        if response is None:
+            logger.debug("Cache HIT without response body; running call live")
+            return CacheOutcome(kind="live")
+        return CacheOutcome(kind="hit", cached=response) # pyright: ignore[reportAny])
+    if outcome == "miss":
+        return CacheOutcome(kind="miss")
+    return CacheOutcome(kind="live")
 
 class RolloutSessions(BaseResource):
     """Register / delete debug sessions on the backend.
@@ -133,8 +153,8 @@ class RolloutSessions(BaseResource):
     def cache(
         self,
         session_id: uuid.UUID | str,
-        replay_trace_id: uuid.UUID | str,
-        cache_until: str,
+        replay_trace_id: uuid.UUID | str | None,
+        cache_until: str | None,
         input_hash: str,
     ) -> CacheOutcome:
         """Look up one LLM call's input hash in the server-side replay cache.
@@ -152,7 +172,7 @@ class RolloutSessions(BaseResource):
                 f"{self._base_url}/v1/rollouts/{session_id}/cache",
                 headers=self._headers(),
                 json={
-                    "replayTraceId": str(replay_trace_id),
+                    "replayTraceId": str(replay_trace_id) if replay_trace_id is not None else None,
                     "cacheUntil": cache_until,
                     "inputHash": input_hash,
                 },
@@ -167,4 +187,4 @@ class RolloutSessions(BaseResource):
         except Exception as exc:
             logger.debug("Cache lookup failed (%s); running this call live", exc)
             return CacheOutcome(kind="live")
-        return parse_cache_outcome(data)
+        return _parse_cache_outcome(data)

--- a/src/lmnr/sdk/debug/__init__.py
+++ b/src/lmnr/sdk/debug/__init__.py
@@ -16,10 +16,15 @@ use `runtime.client` / `runtime.async_client` to call the cache endpoint. When
 debug mode is off, `get_runtime()` returns None and everything is inert.
 """
 
+from __future__ import annotations
+
 import datetime
 import threading
-from typing import Any
+from typing import TYPE_CHECKING
 
+if TYPE_CHECKING:
+    from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
+    from lmnr.sdk.client.synchronous.sync_client import LaminarClient
 from lmnr.sdk.debug.config import (
     DebugConfig,
     build_debug_config,
@@ -44,21 +49,21 @@ class DebugRuntime:
     def __init__(
         self,
         config: DebugConfig,
-        client: Any,
-        async_client: Any,
+        client: LaminarClient,
+        async_client: AsyncLaminarClient,
         debugger_url: str | None,
     ):
-        self._config = config
-        self._client = client
-        self._async_client = async_client
-        self._debugger_url = debugger_url
+        self._config: DebugConfig = config
+        self._client: LaminarClient = client
+        self._async_client: AsyncLaminarClient = async_client
+        self._debugger_url: str | None = debugger_url
         self._trace_id: str | None = None
         self._project_id: str | None = None
-        self._emitted = False
-        self._lock = threading.Lock()
+        self._emitted: bool = False
+        self._lock: threading.Lock = threading.Lock()
         # Captured at construction (SDK init) so the pointer's `started_at`
         # reflects when the run began, not when the pointer is emitted (shutdown).
-        self._started_at = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        self._started_at: str = datetime.datetime.now(datetime.timezone.utc).isoformat()
 
     @property
     def session_id(self) -> str:
@@ -93,12 +98,12 @@ class DebugRuntime:
         return self._config.local_origin and self._config.session_minted
 
     @property
-    def client(self) -> Any:
+    def client(self) -> LaminarClient:
         """The retained synchronous `LaminarClient` for cache lookups."""
         return self._client
 
     @property
-    def async_client(self) -> Any:
+    def async_client(self) -> AsyncLaminarClient:
         """The retained asynchronous `AsyncLaminarClient` for cache lookups."""
         return self._async_client
 
@@ -245,8 +250,8 @@ def reset_debug_runtime() -> None:
 
 
 def init_debug_runtime(
-    client: Any,
-    async_client: Any,
+    client: LaminarClient,
+    async_client: AsyncLaminarClient,
     debugger_url: str | None = None,
 ) -> DebugRuntime | None:
     """Build the debug runtime once. Idempotent; safe to call from initialize().
@@ -280,8 +285,8 @@ def init_debug_runtime(
 
 def init_debug_runtime_from_context(
     debug: DebugContext | None,
-    client: Any,
-    async_client: Any,
+    client: LaminarClient,
+    async_client: AsyncLaminarClient,
     debugger_url: str | None = None,
 ) -> tuple[DebugRuntime | None, bool]:
     """Arm OR refresh the debug runtime from a propagated `DebugContext`.

--- a/src/lmnr/sdk/debug/config.py
+++ b/src/lmnr/sdk/debug/config.py
@@ -11,12 +11,12 @@ import re
 import uuid
 from dataclasses import dataclass
 
-from lmnr.sdk.types import DebugContext
 from lmnr.sdk.debug.debug_session_file import (
     read_debug_session_file,
     resolve_debug_session_dir,
 )
 from lmnr.sdk.log import get_default_logger
+from lmnr.sdk.types import DebugContext
 
 logger = get_default_logger(__name__)
 

--- a/src/lmnr/sdk/debug/debug_session_file.py
+++ b/src/lmnr/sdk/debug/debug_session_file.py
@@ -21,7 +21,7 @@ session has no trace yet).
 import datetime
 import json
 import os
-from typing import Any
+from typing import Any, cast
 
 # Directory the debug-session file lives in, relative to the working dir.
 DEBUG_SESSION_DIR = ".lmnr"
@@ -49,9 +49,10 @@ def read_debug_session_file(directory: str | None = None) -> dict[str, Any] | No
     try:
         path = os.path.join(directory, DEBUG_SESSION_DIR, DEBUG_SESSION_FILE)
         with open(path, "r", encoding="utf-8") as f:
-            r = json.load(f)
+            r = json.load(f)  # pyright: ignore[reportAny]
         if not isinstance(r, dict):
             return None
+        r = cast(dict[str, str], r)
         session_id = _str(r.get("session_id"))
         if not session_id:
             return None

--- a/src/lmnr/sdk/debug/debug_session_file.py
+++ b/src/lmnr/sdk/debug/debug_session_file.py
@@ -21,7 +21,7 @@ session has no trace yet).
 import datetime
 import json
 import os
-from typing import Any, cast
+from typing import Any, TypedDict, cast
 
 # Directory the debug-session file lives in, relative to the working dir.
 DEBUG_SESSION_DIR = ".lmnr"
@@ -29,7 +29,23 @@ DEBUG_SESSION_DIR = ".lmnr"
 DEBUG_SESSION_FILE = "debug-session.json"
 
 
-def _str(value: Any) -> str | None:
+class DebugSessionFile(TypedDict):
+    """The persisted `.lmnr/debug-session.json` record shape.
+
+    Field order matches the on-disk/console JSON and the TS `DebugSessionFile`
+    contract: `session_id` is first and primary (the field read at startup);
+    `trace_id` is `None` for a freshly-minted session that has no trace yet.
+    """
+
+    session_id: str
+    trace_id: str | None
+    replay_trace_id: str | None
+    cache_until: str | None
+    debugger_url: str | None
+    started_at: str
+
+
+def _str(value: Any) -> str | None:  # pyright: ignore[reportExplicitAny, reportAny]
     """Coerce an unknown field to a non-empty string, else None.
 
     The file is best-effort local state that an agent may hand-edit, so every
@@ -38,7 +54,7 @@ def _str(value: Any) -> str | None:
     return value if isinstance(value, str) and len(value) > 0 else None
 
 
-def read_debug_session_file(directory: str | None = None) -> dict[str, Any] | None:
+def read_debug_session_file(directory: str | None = None) -> DebugSessionFile | None:
     """Read `${dir ?? cwd}/.lmnr/debug-session.json`.
 
     Best-effort: returns None on a missing / unreadable / malformed file, or one
@@ -103,7 +119,7 @@ def resolve_debug_session_dir(start_dir: str | None = None) -> str:
 
 
 def write_debug_session_file(
-    file: dict[str, Any], directory: str | None = None
+    file: DebugSessionFile, directory: str | None = None
 ) -> bool:
     """Write the debug-session file (mkdir -p first). Best-effort.
 
@@ -117,7 +133,7 @@ def write_debug_session_file(
         with open(
             os.path.join(target_dir, DEBUG_SESSION_FILE), "w", encoding="utf-8"
         ) as f:
-            f.write(json.dumps(file, separators=(",", ":")))
+            _bytes_written = f.write(json.dumps(file, separators=(",", ":")))
         return True
     except Exception:
         return False

--- a/src/lmnr/sdk/debug/hash.py
+++ b/src/lmnr/sdk/debug/hash.py
@@ -26,12 +26,12 @@ lockstep.
 """
 
 import json
-from typing import Any
+from typing import Any, cast
 
 from blake3 import blake3
 
 
-def _canonical_json(value: Any) -> str:
+def _canonical_json(value: Any) -> str:  # pyright: ignore[reportExplicitAny, reportAny]
     """Reproduce app-server's `canonical_json` (input_dedup.rs).
 
     Objects → keys sorted lexicographically (recursive); arrays → order
@@ -39,21 +39,21 @@ def _canonical_json(value: Any) -> str:
     strings/numbers/bools/null). No whitespace, `","` / `":"` separators.
     """
     if isinstance(value, dict):
-        items = sorted(value.items(), key=lambda kv: kv[0])
+        items = sorted(value.items(), key=lambda kv: kv[0])  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType, reportUnknownVariableType]
         return (
             "{"
             + ",".join(
                 json.dumps(k, ensure_ascii=False) + ":" + _canonical_json(v)
-                for k, v in items
+                for k, v in items  # pyright: ignore[reportUnknownVariableType]
             )
             + "}"
         )
     if isinstance(value, list):
-        return "[" + ",".join(_canonical_json(v) for v in value) + "]"
+        return "[" + ",".join(_canonical_json(v) for v in value) + "]"  # pyright: ignore[reportUnknownVariableType]
     return json.dumps(value, ensure_ascii=False)
 
 
-def _extract_system_remaining(messages: Any) -> list[Any] | None:
+def _extract_system_remaining(messages: Any) -> list[Any] | None:  # pyright: ignore[reportExplicitAny, reportAny]
     """Return the message array without its system message, or None.
 
     Mirrors `extract_system_message` (prompt_hash.rs): find the first
@@ -68,22 +68,22 @@ def _extract_system_remaining(messages: Any) -> list[Any] | None:
     sys_idx = next(
         (
             i
-            for i, m in enumerate(messages)
-            if isinstance(m, dict) and m.get("role") == "system"
+            for i, m in enumerate(messages) # pyright: ignore[reportUnknownArgumentType, reportUnknownVariableType]
+            if isinstance(m, dict) and cast(dict[str, str], m).get("role") == "system"
         ),
         None,
     )
     if sys_idx is None:
         return None
 
-    sys_text = _system_text(messages[sys_idx])
+    sys_text = _system_text(messages[sys_idx]) # pyright: ignore[reportUnknownArgumentType]
     if not sys_text:
         return None
 
-    return [m for i, m in enumerate(messages) if i != sys_idx]
+    return [m for i, m in enumerate(messages) if i != sys_idx] # pyright: ignore[reportUnknownArgumentType, reportUnknownVariableType]
 
 
-def _system_text(sys_msg: dict[str, Any]) -> str:
+def _system_text(sys_msg: dict[str, Any]) -> str:  # pyright: ignore[reportExplicitAny]
     """Extract the system prompt text (priority order matches prompt_hash.rs)."""
     content = sys_msg.get("content")
     # "content": "plain string" (OpenAI format)
@@ -94,15 +94,16 @@ def _system_text(sys_msg: dict[str, Any]) -> str:
         joined = " ".join(
             block["text"]
             for block in content
-            if isinstance(block, dict) and isinstance(block.get("text"), str)
+            if isinstance(block, dict) and isinstance(cast(dict[str, str], block).get("text"), str)  # pyright: ignore[reportUnknownArgumentType]
         )
         if joined:
             return joined
     # "parts" shapes — first part only (Gemini {"text"}, OTel {"content"}).
     parts = sys_msg.get("parts")
     if isinstance(parts, list) and parts:
-        first = parts[0]
+        first = parts[0]  # pyright: ignore[reportUnknownVariableType]
         if isinstance(first, dict):
+            first = cast(dict[str, str], first)
             text = first.get("text")
             if not isinstance(text, str):
                 text = first.get("content")
@@ -111,7 +112,7 @@ def _system_text(sys_msg: dict[str, Any]) -> str:
     return ""
 
 
-def debug_input_hash(messages: Any) -> str:
+def debug_input_hash(messages: Any) -> str:  # pyright: ignore[reportExplicitAny, reportAny]
     """Hex blake3 of the canonical, system-excluded input messages (shared §5)."""
     remaining = _extract_system_remaining(messages)
     target = remaining if remaining is not None else messages

--- a/src/lmnr/sdk/debug/outcome.py
+++ b/src/lmnr/sdk/debug/outcome.py
@@ -12,7 +12,7 @@ provider wrappers branch on:
 """
 
 from dataclasses import dataclass
-from typing import Any, Literal, cast
+from typing import Any, Literal
 
 from lmnr.sdk.log import get_default_logger
 
@@ -23,25 +23,3 @@ logger = get_default_logger(__name__)
 class CacheOutcome:
     kind: Literal["hit", "miss", "live"]
     cached: dict[str, Any] | None = None  # pyright: ignore[reportExplicitAny]
-
-
-def parse_cache_outcome(data: object) -> CacheOutcome:
-    """Map app-server's `{outcome: hit|miss|live, response?}` body to CacheOutcome.
-
-    Shared by the sync and async resources. Anything unrecognized degrades to `live` (safe).
-    """
-    outcome = data.get("outcome") if isinstance(data, dict) else None  # pyright: ignore[reportUnknownMemberType, reportUnknownVariableType]
-    if outcome == "hit":
-        # A HIT must carry a response envelope to be servable; the provider
-        # wrappers call cached_response_to_*(cached), which does cached.get().
-        # A response-less HIT (omitted/null `response`) is malformed — degrade
-        # to `live` so the call runs live (no latch) instead of raising.
-        data_dict = cast(dict[str, Any], data)  # pyright: ignore[reportExplicitAny]
-        response = data_dict.get("response")
-        if response is None:
-            logger.debug("Cache HIT without response body; running call live")
-            return CacheOutcome(kind="live")
-        return CacheOutcome(kind="hit", cached=response) # pyright: ignore[reportAny])
-    if outcome == "miss":
-        return CacheOutcome(kind="miss")
-    return CacheOutcome(kind="live")

--- a/src/lmnr/sdk/debug/pointer.py
+++ b/src/lmnr/sdk/debug/pointer.py
@@ -15,9 +15,9 @@ Part of the cross-language parity surface — keep line-comparable with the TS
 
 import datetime
 import json
-from typing import Any
 
 from lmnr.sdk.debug.debug_session_file import (
+    DebugSessionFile,
     read_debug_session_file,
     resolve_debug_session_dir,
     write_debug_session_file,
@@ -34,7 +34,7 @@ def build_debug_session_file(
     cache_until: str | None,
     debugger_url: str | None,
     started_at: str | None = None,
-) -> dict[str, Any]:
+) -> DebugSessionFile:
     """Build the persisted debug-session record. Key order matches the TS SDK.
 
     `started_at` is the run's start time, captured by `DebugRuntime` at SDK init
@@ -54,7 +54,7 @@ def build_debug_session_file(
 
 
 def emit_pointer(
-    file: dict[str, Any],
+    file: DebugSessionFile,
     directory: str | None = None,
     file_session_id_at_init: str | None = None,
 ) -> None:

--- a/src/lmnr/sdk/debug/pointer.py
+++ b/src/lmnr/sdk/debug/pointer.py
@@ -22,6 +22,9 @@ from lmnr.sdk.debug.debug_session_file import (
     resolve_debug_session_dir,
     write_debug_session_file,
 )
+from lmnr.sdk.log import get_default_logger
+
+logger = get_default_logger(__name__)
 
 # Console marker the orchestrating tooling greps for. Must match the TS SDK.
 CONSOLE_PREFIX = "LMNR_DEBUG_RUN "
@@ -82,4 +85,5 @@ def emit_pointer(
         file_session_id_at_init,
     ):
         return
-    write_debug_session_file(file, directory)
+    if not write_debug_session_file(file, directory):
+        logger.debug("Failed to write debug session_file")

--- a/src/lmnr/sdk/debug/replay.py
+++ b/src/lmnr/sdk/debug/replay.py
@@ -14,7 +14,7 @@ and consumed by the wrappers.
 import json
 from typing import Any
 
-from opentelemetry.trace import Span
+from opentelemetry.sdk.trace import Span
 
 from lmnr.sdk.debug import get_runtime
 from lmnr.sdk.debug.hash import debug_input_hash
@@ -45,7 +45,7 @@ def replay_enabled() -> bool:
     return runtime is not None and runtime.replay_configured
 
 
-def input_messages_from_span(span: Span | None) -> list[Any] | None:
+def input_messages_from_span(span: Span | None) -> list[Any] | None:  # pyright: ignore[reportExplicitAny]
     """Read and parse the `gen_ai.input.messages` JSON off a live span.
 
     Every provider sets this attribute (via `json_dumps`) before the rollout
@@ -57,14 +57,14 @@ def input_messages_from_span(span: Span | None) -> list[Any] | None:
     if span is None:
         return None
     try:
-        raw = span.attributes.get(GEN_AI_INPUT_MESSAGES_ATTRIBUTE)
+        raw = (span.attributes or {}).get(GEN_AI_INPUT_MESSAGES_ATTRIBUTE)
         if not raw:
             return None
         messages = json.loads(raw) if isinstance(raw, str) else raw
         if isinstance(messages, list):
-            return messages
-    except Exception:
-        pass
+            return messages  # pyright: ignore[reportUnknownVariableType]
+    except Exception as e:
+       logger.debug(f"Failed to get input mesages from span {e}")
     return None
 
 
@@ -143,5 +143,5 @@ def mark_span_cached(span: Span | None) -> None:
                     "lmnr.span.original_type": "LLM",
                 }
             )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug(f"Failed to mark span as cached {e}")

--- a/src/lmnr/sdk/evaluations/__init__.py
+++ b/src/lmnr/sdk/evaluations/__init__.py
@@ -1,8 +1,6 @@
 import asyncio
-import uuid
+from types import CoroutineType
 from typing import Any
-
-from typing_extensions import TypedDict
 
 from lmnr.opentelemetry_lib.tracing.instruments import Instruments
 from lmnr.sdk.datasets import EvaluationDataset
@@ -14,18 +12,17 @@ from lmnr.sdk.evaluations.models import (
     EvaluationRunResult,
     EvaluatorFunction,
     ExecutorFunction,
-    HumanEvaluator,
 )
 from lmnr.sdk.types import Datapoint
 
 
 def evaluate(
-    data: EvaluationDataset | list[Datapoint | dict],
+    data: EvaluationDataset | list[Datapoint | dict[Any, Any]],  # pyright:ignore[reportExplicitAny]
     executor: ExecutorFunction,
-    evaluators: dict[str, EvaluatorFunction | HumanEvaluator],
+    evaluators: dict[str, EvaluatorFunction],
     name: str | None = None,
     group_name: str | None = None,
-    metadata: dict[str, Any] | None = None,
+    metadata: dict[str, Any] | None = None,  # pyright:ignore[reportExplicitAny]
     concurrency_limit: int = DEFAULT_BATCH_SIZE,
     project_api_key: str | None = None,
     base_url: str | None = None,
@@ -41,7 +38,7 @@ def evaluate(
     ) = None,
     max_export_batch_size: int | None = MAX_EXPORT_BATCH_SIZE,
     trace_export_timeout_seconds: int | None = None,
-) -> EvaluationRunResult | None:
+) -> EvaluationRunResult | CoroutineType[Any, Any, EvaluationRunResult] | None:  # pyright: ignore[reportExplicitAny]
     """
     If added to the file which is called through `lmnr eval` command, then
     registers the evaluation; otherwise, runs the evaluation.
@@ -131,7 +128,7 @@ def evaluate(
     if PREPARE_ONLY.get():
         existing_evaluations = EVALUATION_INSTANCES.get([])
         new_evaluations = (existing_evaluations or []) + [evaluation]
-        EVALUATION_INSTANCES.set(new_evaluations)
+        _set_token = EVALUATION_INSTANCES.set(new_evaluations)
         return None
     else:
         try:

--- a/src/lmnr/sdk/evaluations/evaluation.py
+++ b/src/lmnr/sdk/evaluations/evaluation.py
@@ -1,9 +1,13 @@
 import asyncio
 import re
 import uuid
-from typing import Any
+from asyncio.tasks import Task
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from logging import Logger
+from typing import Any, cast
 
-from lmnr.opentelemetry_lib.tracing.attributes import HUMAN_EVALUATOR_OPTIONS, SPAN_TYPE
+from lmnr.opentelemetry_lib.tracing.attributes import SPAN_TYPE
 from lmnr.opentelemetry_lib.tracing.context import (
     attach_context,
     detach_context,
@@ -12,7 +16,7 @@ from lmnr.opentelemetry_lib.tracing.context import (
 from lmnr.opentelemetry_lib.tracing.instruments import Instruments
 from lmnr.sdk.client.asynchronous.async_client import AsyncLaminarClient
 from lmnr.sdk.client.synchronous.sync_client import LaminarClient
-from lmnr.sdk.datasets import EvaluationDataset
+from lmnr.sdk.datasets import EvaluationDataset, LaminarDataset
 from lmnr.sdk.evaluations.models import (
     DEFAULT_BATCH_SIZE,
     MAX_EXPORT_BATCH_SIZE,
@@ -20,7 +24,7 @@ from lmnr.sdk.evaluations.models import (
     EvaluationResultDatapoint,
     EvaluationRunResult,
     EvaluatorFunction,
-    HumanEvaluator,
+    EvaluatorFunctionReturnType,
     PartialEvaluationDatapoint,
 )
 from lmnr.sdk.evaluations.reporter import EvaluationReporter
@@ -34,7 +38,7 @@ from lmnr.sdk.types import (
     SpanType,
     TraceType,
 )
-from lmnr.sdk.utils import from_env, is_async, json_dumps
+from lmnr.sdk.utils import from_env, is_async
 
 # Evaluation-metadata key that links an eval run to its debug session. Kept as
 # `rollout.session_id` (matching the trace-metadata key the debugger stamps) so
@@ -42,8 +46,8 @@ from lmnr.sdk.utils import from_env, is_async, json_dumps
 SESSION_METADATA_KEY = "rollout.session_id"
 
 def _with_debugger_session_metadata(
-    metadata: dict[str, Any] | None,
-) -> dict[str, Any] | None:
+    metadata: dict[str, Any] | None,  # pyright: ignore[reportExplicitAny]
+) -> dict[str, Any] | None:  # pyright: ignore[reportExplicitAny]
     """Stamp the debug session id into eval metadata when running under debug.
 
     When this eval runs under a debug session, auto-stamp the session id into
@@ -71,12 +75,12 @@ def _with_debugger_session_metadata(
 class Evaluation:
     def __init__(
         self,
-        data: EvaluationDataset | list[Datapoint | dict],
-        executor: Any,
-        evaluators: dict[str, EvaluatorFunction | HumanEvaluator],
+        data: EvaluationDataset | list[Datapoint | dict[Any, Any]],  # pyright: ignore[reportExplicitAny]
+        executor: Callable[..., Any],  # pyright: ignore[reportExplicitAny]
+        evaluators: dict[str, EvaluatorFunction],
         name: str | None = None,
         group_name: str | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: dict[str, Any] | None = None,  # pyright: ignore[reportExplicitAny]
         concurrency_limit: int = DEFAULT_BATCH_SIZE,
         project_api_key: str | None = None,
         base_url: str | None = None,
@@ -171,9 +175,9 @@ class Evaluation:
 
         base_url = base_url or from_env("LMNR_BASE_URL") or "https://api.lmnr.ai"
 
-        self.reporter = EvaluationReporter(base_url, frontend_port)
+        self.reporter: EvaluationReporter = EvaluationReporter(base_url, frontend_port)
         if isinstance(data, list):
-            self.data = [
+            self.data: list[Datapoint] | EvaluationDataset = [
                 (Datapoint.model_validate(point) if isinstance(point, dict) else point)
                 for point in data
             ]
@@ -185,29 +189,29 @@ class Evaluation:
             raise ValueError("No data provided. Skipping evaluation")
         # The underlying remote source (through any depth of subsampling
         # chaining), resolved in _run. None for in-memory data.
-        self._source_dataset = None
-        self.executor = executor
-        self.evaluators = evaluators
-        self.group_name = group_name
-        self.name = name
-        self.metadata = metadata
-        self.concurrency_limit = concurrency_limit
-        self.batch_size = concurrency_limit
-        self._logger = get_default_logger(self.__class__.__name__)
-        self.upload_tasks = []
-        self.base_http_url = f"{base_http_url or base_url}:{http_port or 443}"
+        self._source_dataset: LaminarDataset | None = None
+        self.executor: Callable[..., Any] = executor  # pyright: ignore[reportExplicitAny]
+        self.evaluators: dict[str, EvaluatorFunction] = evaluators
+        self.group_name: str | None = group_name
+        self.name: str | None = name
+        self.metadata: dict[str, Any] | None = metadata  # pyright: ignore[reportExplicitAny]
+        self.concurrency_limit: int = concurrency_limit
+        self.batch_size: int = concurrency_limit
+        self._logger: Logger = get_default_logger(self.__class__.__name__)
+        self.upload_tasks: list[Task[None]] = []
+        self.base_http_url: str = f"{base_http_url or base_url}:{http_port or 443}"
 
         api_key = project_api_key or from_env("LMNR_PROJECT_API_KEY")
         if not api_key and not L.is_initialized():
             raise ValueError(
-                "Please pass the project API key to `evaluate`"
-                " or set the LMNR_PROJECT_API_KEY environment variable"
+                "Please pass the project API key to `evaluate`" +
+                " or set the LMNR_PROJECT_API_KEY environment variable" +
                 " in your environment or .env file"
             )
-        self.project_api_key = api_key
+        self.project_api_key: str | None = api_key
 
         if L.is_initialized():
-            self.client = AsyncLaminarClient(
+            self.client: AsyncLaminarClient = AsyncLaminarClient(
                 base_url=L.get_base_http_url(),
                 project_api_key=L.get_project_api_key(),
             )
@@ -249,7 +253,7 @@ class Evaluation:
                 if not source.id:
                     try:
                         datasets = await self.client.datasets.get_dataset_by_name(
-                            source.name
+                            source.name or ""
                         )
                         if len(datasets) == 0:
                             self._logger.warning(f"Dataset {source.name} not found")
@@ -281,7 +285,7 @@ class Evaluation:
                 self._logger.debug(
                     f"Waiting for {len(self.upload_tasks)} upload tasks to complete"
                 )
-                await asyncio.gather(*self.upload_tasks)
+                _gathered_results = await asyncio.gather(*self.upload_tasks)
                 self._logger.debug("All upload tasks completed")
         except Exception as e:
             await self._shutdown()
@@ -303,7 +307,7 @@ class Evaluation:
         # can be run sequentially in the same process. `shutdown()` would
         # close the OTLP exporter and we wouldn't be able to export traces in
         # the next evaluation.
-        L.flush()
+        _flush_success = L.flush()
         await self.client.close()
         source = self._source_dataset
         if source is not None and getattr(source, "client", None):
@@ -314,10 +318,10 @@ class Evaluation:
     ) -> list[EvaluationResultDatapoint]:
 
         semaphore = asyncio.Semaphore(self.concurrency_limit)
-        tasks = []
+        tasks: list[Task[tuple[int, EvaluationResultDatapoint]]] = []
         data_iter = self.data if isinstance(self.data, list) else range(len(self.data))
 
-        async def evaluate_task(datapoint, index):
+        async def evaluate_task(datapoint: Datapoint, index: int):
             try:
                 result = await self._evaluate_datapoint(eval_id, datapoint, index)
                 self.reporter.update(1)
@@ -327,8 +331,8 @@ class Evaluation:
 
         # Create tasks only after acquiring semaphore
         for idx, item in enumerate(data_iter):
-            await semaphore.acquire()
-            datapoint = item if isinstance(self.data, list) else self.data[item]
+            _ = await semaphore.acquire()
+            datapoint = cast(Datapoint, item if isinstance(self.data, list) else self.data[cast(int, item)])
             task = asyncio.create_task(evaluate_task(datapoint, idx))
             tasks.append(task)
 
@@ -352,10 +356,10 @@ class Evaluation:
 
         try:
             with L.start_as_current_span("evaluation") as evaluation_span:
-                L._set_trace_type(trace_type=TraceType.EVALUATION)
+                L._set_trace_type(trace_type=TraceType.EVALUATION)  # pyright: ignore[reportPrivateUsage]
                 evaluation_span.set_attribute(SPAN_TYPE, SpanType.EVALUATION.value)
                 with L.start_as_current_span(
-                    "executor", input={"data": datapoint.data}
+                    "executor", input={"data": datapoint.data}  # pyright: ignore[reportAny]
                 ) as executor_span:
                     executor_span_id = uuid.UUID(
                         int=executor_span.get_span_context().span_id
@@ -366,19 +370,19 @@ class Evaluation:
 
                     partial_datapoint = PartialEvaluationDatapoint(
                         id=evaluation_id,
-                        data=datapoint.data,
+                        data=datapoint.data,  # pyright: ignore[reportAny]
                         target=datapoint.target,
                         index=index,
                         trace_id=trace_id,
                         executor_span_id=executor_span_id,
                         metadata=datapoint.metadata,
                     )
-                    if self._source_dataset is not None:
+                    if self._source_dataset is not None and self._source_dataset.id is not None:
                         partial_datapoint.dataset_link = (
                             EvaluationDatapointDatasetLink(
                                 dataset_id=self._source_dataset.id,
-                                datapoint_id=datapoint.id,
-                                created_at=datapoint.created_at,
+                                datapoint_id=datapoint.id or uuid.UUID(int=0),
+                                created_at=datapoint.created_at or datetime.now(timezone.utc),
                             )
                         )
                     # First, create datapoint with trace_id so that we can show the dp in the UI
@@ -389,72 +393,52 @@ class Evaluation:
                     # Run synchronous executors in a thread pool to avoid blocking
                     if not is_async(self.executor):
                         loop = asyncio.get_event_loop()
-                        output = await loop.run_in_executor(
-                            None, self.executor, datapoint.data
+                        output = await loop.run_in_executor(    # pyright: ignore[reportAny]
+                            None, self.executor, datapoint.data   # pyright: ignore[reportAny]
                         )
                     else:
-                        output = await self.executor(datapoint.data)
+                        output = await self.executor(datapoint.data)  # pyright: ignore[reportAny]
 
                     L.set_span_output(output)
                 target = datapoint.target
 
                 # Iterate over evaluators
-                scores: dict[str, Numeric] = {}
+                scores: dict[str, Numeric | None] = {}
                 for evaluator_name, evaluator in self.evaluators.items():
                     # Check if evaluator is a HumanEvaluator instance
-                    if isinstance(evaluator, dict):  # HumanEvaluator is a TypedDict
-                        # Create an empty span for human evaluators
-                        with L.start_as_current_span(
-                            evaluator_name,
-                            input={"output": output, "target": target},
-                        ) as human_evaluator_span:
-                            human_evaluator_span.set_attribute(
-                                SPAN_TYPE, SpanType.HUMAN_EVALUATOR.value
-                            )
-                            if evaluator.get("options"):
-                                human_evaluator_span.set_attribute(
-                                    HUMAN_EVALUATOR_OPTIONS,
-                                    json_dumps(evaluator.get("options")),
-                                )
-                            # Human evaluators don't execute automatically, just create the span
-                            L.set_span_output(None)
-
-                        # We don't want to save the score for human evaluators
-                        scores[evaluator_name] = None
-                    else:
-                        # Regular evaluator function
-                        with L.start_as_current_span(
-                            evaluator_name,
-                            input={"output": output, "target": target},
-                        ) as evaluator_span:
-                            evaluator_span.set_attribute(
-                                SPAN_TYPE, SpanType.EVALUATOR.value
-                            )
-                            if is_async(evaluator):
-                                value = await evaluator(output, target)
-                            else:
-                                loop = asyncio.get_event_loop()
-                                value = await loop.run_in_executor(
-                                    None, evaluator, output, target
-                                )
-                            L.set_span_output(value)
-
-                        # If evaluator returns a single number, use evaluator name as key
-                        if isinstance(value, NumericTypes):
-                            scores[evaluator_name] = value
+                    # Regular evaluator function
+                    with L.start_as_current_span(
+                        evaluator_name,
+                        input={"output": output, "target": target},
+                    ) as evaluator_span:
+                        evaluator_span.set_attribute(
+                            SPAN_TYPE, SpanType.EVALUATOR.value
+                        )
+                        if is_async(evaluator):
+                            value = await cast(Awaitable[EvaluatorFunctionReturnType], evaluator(output, target))
                         else:
-                            scores.update(value)
+                            loop = asyncio.get_event_loop()
+                            value = cast(EvaluatorFunctionReturnType, await loop.run_in_executor(
+                                None, evaluator, output, target
+                            ))
+                        L.set_span_output(value)
+
+                    # If evaluator returns a single number, use evaluator name as key
+                    if isinstance(value, NumericTypes):
+                        scores[evaluator_name] = value
+                    else:
+                        scores.update(value)
 
                 trace_id = uuid.UUID(int=evaluation_span.get_span_context().trace_id)
         finally:
             try:
                 detach_context(eval_id_token)
-            except Exception:
-                pass
+            except Exception as e:
+                self._logger.debug(f"Failed to detach evaluation trace context {e}")
 
         eval_datapoint = EvaluationResultDatapoint(
             id=evaluation_id,
-            data=datapoint.data,
+            data=datapoint.data,  # pyright: ignore[reportAny]
             target=target,
             executor_output=output,
             scores=scores,
@@ -463,11 +447,11 @@ class Evaluation:
             index=index,
             metadata=datapoint.metadata,
         )
-        if self._source_dataset is not None:
+        if self._source_dataset is not None and self._source_dataset.id is not None:
             eval_datapoint.dataset_link = EvaluationDatapointDatasetLink(
                 dataset_id=self._source_dataset.id,
-                datapoint_id=datapoint.id,
-                created_at=datapoint.created_at,
+                datapoint_id=datapoint.id or uuid.UUID(int=0),
+                created_at=datapoint.created_at or datetime.now(timezone.utc),
             )
 
         # Create background upload task without awaiting it

--- a/src/lmnr/sdk/evaluations/models.py
+++ b/src/lmnr/sdk/evaluations/models.py
@@ -46,15 +46,6 @@ EvaluatorFunction = Callable[
 ]
 
 
-class HumanEvaluatorOptionsEntry(TypedDict):
-    label: str
-    value: float
-
-
-class HumanEvaluator(TypedDict, total=False):
-    options: list[HumanEvaluatorOptionsEntry]
-
-
 class InitEvaluationResponse(TypedDict):
     id: uuid.UUID
     createdAt: datetime.datetime
@@ -92,7 +83,7 @@ def _dataset_link_to_dict(link: EvaluationDatapointDatasetLink) -> dict[str, str
 
 class PartialEvaluationDatapoint(BaseModel):
     id: uuid.UUID
-    data: EvaluationDatapointData
+    data: EvaluationDatapointData  # pyright: ignore[reportExplicitAny]
     target: EvaluationDatapointTarget
     index: int
     trace_id: uuid.UUID
@@ -102,7 +93,7 @@ class PartialEvaluationDatapoint(BaseModel):
 
     # uuid is not serializable by default, so we need to convert it to a string
     def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
-        serialized_data = serialize(self.data)
+        serialized_data = serialize(self.data)  # pyright: ignore[reportAny]
         serialized_target = serialize(self.target)
         str_data = json_dumps(serialized_data)
         str_target = json_dumps(serialized_target)
@@ -123,7 +114,7 @@ class PartialEvaluationDatapoint(BaseModel):
                 "traceId": str(self.trace_id),
                 "executorSpanId": str(self.executor_span_id),
                 "metadata": (
-                    serialize(self.metadata) if self.metadata is not None else {}
+                    serialize(self.metadata) if self.metadata is not None else {}  # pyright: ignore[reportAny]
                 ),
                 "datasetLink": (
                     _dataset_link_to_dict(self.dataset_link)
@@ -138,9 +129,9 @@ class PartialEvaluationDatapoint(BaseModel):
 class EvaluationResultDatapoint(BaseModel):
     id: uuid.UUID
     index: int
-    data: EvaluationDatapointData
+    data: EvaluationDatapointData  # pyright: ignore[reportExplicitAny]
     target: EvaluationDatapointTarget
-    executor_output: ExecutorFunctionReturnType
+    executor_output: ExecutorFunctionReturnType  # pyright: ignore[reportExplicitAny]
     scores: dict[str, Numeric | None]
     trace_id: uuid.UUID
     executor_span_id: uuid.UUID
@@ -150,9 +141,9 @@ class EvaluationResultDatapoint(BaseModel):
     # uuid is not serializable by default, so we need to convert it to a string
     def to_dict(self, max_data_length: int = DEFAULT_DATAPOINT_MAX_DATA_LENGTH):
         try:
-            serialized_data = serialize(self.data)
+            serialized_data = serialize(self.data)  # pyright: ignore[reportAny]
             serialized_target = serialize(self.target)
-            serialized_executor_output = serialize(self.executor_output)
+            serialized_executor_output = serialize(self.executor_output)  # pyright: ignore[reportAny]
             str_data = json.dumps(serialized_data)
             str_target = json.dumps(serialized_target)
             str_executor_output = json.dumps(serialized_executor_output)
@@ -180,7 +171,7 @@ class EvaluationResultDatapoint(BaseModel):
                 "executorSpanId": str(self.executor_span_id),
                 "index": self.index,
                 "metadata": (
-                    serialize(self.metadata) if self.metadata is not None else {}
+                    serialize(self.metadata) if self.metadata is not None else {}  # pyright: ignore[reportAny]
                 ),
                 "datasetLink": (
                     _dataset_link_to_dict(self.dataset_link)

--- a/src/lmnr/sdk/evaluations/reporter.py
+++ b/src/lmnr/sdk/evaluations/reporter.py
@@ -1,3 +1,4 @@
+from typing import NoReturn
 from uuid import UUID
 
 from tqdm import tqdm
@@ -7,9 +8,10 @@ from lmnr.sdk.types import Numeric
 
 
 class EvaluationReporter:
-    def __init__(self, base_url, frontend_port: int | None = None):
-        self.base_url = base_url
-        self.frontend_port = frontend_port
+    def __init__(self, base_url: str, frontend_port: int | None = None):
+        self.base_url: str = base_url
+        self.frontend_port: int | None = frontend_port
+        self.cli_progress: tqdm[NoReturn] | None = None
 
     def start(self, length: int):
         self.cli_progress = tqdm(
@@ -19,16 +21,18 @@ class EvaluationReporter:
         )
 
     def update(self, batch_length: int):
-        self.cli_progress.update(batch_length)
+        assert self.cli_progress is not None
+        _display_method_triggered = self.cli_progress.update(batch_length)
 
     def stop_with_error(self, error: Exception):
-        if hasattr(self, "cli_progress"):
+        if self.cli_progress is not None:
             self.cli_progress.close()
         raise error
 
     def stop(
         self, average_scores: dict[str, Numeric], project_id: UUID, evaluation_id: UUID
     ):
+        assert self.cli_progress is not None
         self.cli_progress.close()
         print("Average scores:")
         for name, score in average_scores.items():

--- a/src/lmnr/sdk/evaluations/utils.py
+++ b/src/lmnr/sdk/evaluations/utils.py
@@ -38,14 +38,14 @@ def get_evaluation_url(
 
 
 def get_average_scores(results: list[EvaluationResultDatapoint]) -> dict[str, Numeric]:
-    per_score_values = {}
+    per_score_values: dict[str, list[Numeric | None]] = {}
     for result in results:
         for key, value in result.scores.items():
             if key not in per_score_values:
                 per_score_values[key] = []
             per_score_values[key].append(value)
 
-    average_scores = {}
+    average_scores: dict[str, Numeric] = {}
     for key, values in per_score_values.items():
         scores = [v for v in values if v is not None]
 


### PR DESCRIPTION
Also, delete deprecated human-evals code

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removing `HumanEvaluator` is a breaking public API change for anyone still using human-eval spans. Debugger cache and replay paths are behavior-sensitive but changes are mostly typing and safer degradation/logging.
> 
> **Overview**
> **Removes deprecated human-in-the-loop evaluation** from the public API and runtime: `HumanEvaluator` is no longer exported or accepted by `evaluate`, related span attributes (`HUMAN_EVALUATOR_OPTIONS`) and the special “empty span” evaluator path are gone, and evaluators are typed as callable functions only.
> 
> **Tightens static typing and pyright compliance** across debug/replay and evaluations—`DebugSessionFile` as a `TypedDict`, `DebugRuntime` clients typed as `LaminarClient` / `AsyncLaminarClient`, richer annotations on `Evaluation` / `evaluate` return types, and targeted casts or `pyright: ignore` where JSON/dynamic data is unavoidable.
> 
> **Adjusts rollout cache client behavior**: `parse_cache_outcome` moves into private `_parse_cache_outcome` on sync/async `RolloutSessions`; `cache()` now allows `replay_trace_id` and `cache_until` to be `None` and serializes a null `replayTraceId` when absent. Replay helpers use SDK `Span`, guard missing `span.attributes`, and log debug messages instead of swallowing errors silently; failed debug-session file writes are logged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51de67fc575fecdbe8bf771a63a2ed31c937161f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->