### PR TITLE
migrate scheduled actions to ARM

### DIFF
--- a/.github/workflows/build-package.yml
+++ b/.github/workflows/build-package.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python

--- a/.github/workflows/ensure-version-match.yml
+++ b/.github/workflows/ensure-version-match.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   ensure-version-match:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     environment:
       name: pypi
       url: https://pypi.org/p/lmnr/

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]

--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
ARM runners are 16 % cheaper on github, and this repo is 2nd by spending (because of scheduled tests), so switch to arm for slight cost savings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only runner label changes with no application or release logic modifications; main risk is rare ARM-specific test or wheel-build differences.
> 
> **Overview**
> Switches GitHub Actions jobs from **`ubuntu-latest`** to **`ubuntu-24.04-arm`** across five workflows: PR **build**, **version match**, **run-tests**, **scheduled-tests**, and release **PyPI publish**. Workflow triggers, matrices, and steps are unchanged—only the runner image moves to ARM for lower Actions cost (especially on frequent scheduled tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e74915d8212441e50b9197bd3a26cfb13722c7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->